### PR TITLE
Add JSDoc documentation to getConfigsViewSnapshot function

### DIFF
--- a/frontend/src/ui/configs/configs-view-snapshot.ts
+++ b/frontend/src/ui/configs/configs-view-snapshot.ts
@@ -1,1 +1,5 @@
+/**
+ * 获取配置视图快照的当前版本号。
+ * @returns 当前快照版本号，始终为0。
+ */
 export const getConfigsViewSnapshot = (): number => 0;


### PR DESCRIPTION
## 问题背景
公共函数 `getConfigsViewSnapshot` 缺少文档字符串，这降低了代码的可读性和维护性，对其他开发者理解函数用途造成困难。

## 修改内容
为函数 `getConfigsViewSnapshot` 添加了 JSDoc 文档字符串，明确说明了其功能：获取配置视图快照的当前版本号，并返回始终为0的值。这符合仓库的 TypeScript 代码风格，增强了代码的自文档化。

## 验证方式
- 通过代码审查确认文档准确反映了函数行为，且没有改变任何功能。
- 确保函数输出和 API 保持不变，维持向后兼容性。
- 如果项目集成文档生成工具（如 Typedoc），验证文档正确生成。