### PR TITLE
feat(controller): redact secrets in log API responses

### DIFF
--- a/controller/src/core/log-redaction.ts
+++ b/controller/src/core/log-redaction.ts
@@ -1,0 +1,84 @@
+/**
+ * Conservative log-line redaction for API/SSE responses.
+ *
+ * Preserves raw log files on disk; only use this when serializing lines to
+ * HTTP/SSE clients. The regexes are intentionally anchored to known secret
+ * markers so ordinary error messages, file paths, ports, and throughput metrics
+ * are not eaten.
+ */
+
+const REDACTED = "[redacted]";
+
+/**
+ * Token-like value that stops at common separators/punctuation so surrounding
+ * log context (semicolons, commas, quotes) is preserved.
+ */
+const TOKEN = String.raw`[^\s;,"']+`;
+
+/**
+ * Redact common secret-bearing patterns from a single log line.
+ *
+ * Covered:
+ * - Authorization: Bearer <token>
+ * - X-Api-Key: <token>
+ * - Env assignments: HF_TOKEN=..., OPENAI_API_KEY=..., *_API_KEY=..., *_TOKEN=...
+ * - JSON-ish pairs: "api_key": "...", 'token': '...'
+ * - CLI flags: --api-key <value>, --hf-token <value>, --token <value>, etc.
+ * - URL query params: ?api_key=...&token=...
+ */
+export function redactLogLine(line: string): string {
+  let redacted = line;
+
+  // Authorization / Bearer headers.
+  redacted = redacted.replace(
+    new RegExp(String.raw`(Authorization:\s*Bearer\s+)` + TOKEN, "gi"),
+    `$1${REDACTED}`
+  );
+
+  // X-Api-Key style headers.
+  redacted = redacted.replace(
+    new RegExp(String.raw`((?:^|[\r\n])[Xx]-[Aa]pi-[Kk]ey:\s+)` + TOKEN, "g"),
+    `$1${REDACTED}`
+  );
+
+  // Env-style assignments: KEY=VALUE or export KEY=VALUE.
+  // Covers explicit keys plus generic *_API_KEY / *_TOKEN patterns.
+  redacted = redacted.replace(
+    new RegExp(
+      String.raw`((?:^|[\s;{"'|&]|export\s+)(?:HF_TOKEN|HUGGING_FACE_HUB_TOKEN|OPENAI_API_KEY|ANTHROPIC_API_KEY|[A-Za-z_][A-Za-z0-9_]*_API_KEY|[A-Za-z_][A-Za-z0-9_]*_TOKEN)\s*=\s*)(?:"[^"]*"|'[^']*'|` + TOKEN + ")",
+      "g"
+    ),
+    `$1${REDACTED}`
+  );
+
+  // JSON-ish key/value pairs: "api_key": "...", 'token': '...'.
+  // Preserves the quote style of the value.
+  redacted = redacted.replace(
+    /(["']?(?:api_key|api-key|apikey|auth_token|access_token|token|secret|password|hf_token|openai_api_key|anthropic_api_key)["']?\s*:\s*)(["'])[^"']*\2/gi,
+    `$1$2${REDACTED}$2`
+  );
+
+  // CLI long flags: --api-key <value>, --hf-token <value>, etc.
+  redacted = redacted.replace(
+    new RegExp(String.raw`(\s)(--(?:api-key|apikey|api_token|auth-token|access-token|hf-token|token|secret|password))\s+` + TOKEN, "gi"),
+    `$1$2 ${REDACTED}`
+  );
+
+  // URL query parameters: api_key=..., token=..., etc.
+  redacted = redacted.replace(
+    /([?&])(api_key|api-key|apikey|token|access_token|auth_token|key|secret|hf_token|openai_api_key|anthropic_api_key)=([^&\s]*)/gi,
+    `$1$2=${REDACTED}`
+  );
+
+  return redacted;
+}
+
+/**
+ * Redact a multi-line log string, preserving line endings.
+ */
+export function redactLogContent(content: string): string {
+  return content
+    .split(/(\r?\n)/)
+    .map((part, index) => (index % 2 === 0 ? redactLogLine(part) : part))
+    .join("");
+}

--- a/controller/src/modules/system/logs-routes.ts
+++ b/controller/src/modules/system/logs-routes.ts
@@ -19,6 +19,7 @@ import {
   sanitizeLogSessionId,
   tailFileLines,
 } from "../../core/log-files";
+import { redactLogLine } from "../../core/log-redaction";
 
 export const registerLogsRoutes: RouteRegistrar = (app, context) => {
   let lastCleanupAt = 0;
@@ -160,14 +161,16 @@ export const registerLogsRoutes: RouteRegistrar = (app, context) => {
     const limit = Math.min(Math.max(Number(ctx.req.query("limit") ?? 2000), 1), 20000);
     const dockerContainer = getDockerContainerForSession(sessionId);
     if (dockerContainer) {
-      const dockerLines = readDockerLogLines(dockerContainer, limit);
+      const dockerLines = readDockerLogLines(dockerContainer, limit).map(redactLogLine);
       if (dockerLines.length > 0) {
         return ctx.json({ id: sessionId, logs: dockerLines, content: dockerLines.join("\n") });
       }
     }
     const path = resolveExistingLogPath(context.config.data_dir, sessionId);
     if (!path) throw notFound("Log not found");
-    const lines = tailFileLines(path, limit).map((line) => line.replace(/\n$/, ""));
+    const lines = tailFileLines(path, limit)
+      .map((line) => line.replace(/\n$/, ""))
+      .map(redactLogLine);
     return ctx.json({ id: sessionId, logs: lines, content: lines.join("\n") });
   });
 
@@ -221,7 +224,10 @@ export const registerLogsRoutes: RouteRegistrar = (app, context) => {
         if (dockerContainer) {
           for await (const line of streamDockerLogLines(dockerContainer, replayLimit, signal)) {
             if (signal.aborted) return;
-            yield new Event(CONTROLLER_EVENTS.LOG, { session_id: sessionId, line }).toSse();
+            yield new Event(CONTROLLER_EVENTS.LOG, {
+              session_id: sessionId,
+              line: redactLogLine(line),
+            }).toSse();
           }
           return;
         }
@@ -230,11 +236,21 @@ export const registerLogsRoutes: RouteRegistrar = (app, context) => {
           for (const line of lines) {
             if (!line) continue;
             if (signal.aborted) return;
-            yield new Event(CONTROLLER_EVENTS.LOG, { session_id: sessionId, line }).toSse();
+            yield new Event(CONTROLLER_EVENTS.LOG, {
+              session_id: sessionId,
+              line: redactLogLine(line),
+            }).toSse();
           }
         }
         for await (const event of context.eventManager.subscribe(`logs:${sessionId}`, signal)) {
-          yield event.toSse();
+          if (event.type === CONTROLLER_EVENTS.LOG && typeof event.data["line"] === "string") {
+            yield new Event(CONTROLLER_EVENTS.LOG, {
+              ...event.data,
+              line: redactLogLine(event.data["line"] as string),
+            }).toSse();
+          } else {
+            yield event.toSse();
+          }
         }
       })()
     );

--- a/tests/controller/integration/log-redaction.test.ts
+++ b/tests/controller/integration/log-redaction.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  redactLogLine,
+  redactLogContent,
+} from "../../../controller/src/core/log-redaction";
+import { primaryLogPathFor } from "../../../controller/src/core/log-files";
+
+const ENV_KEYS = [
+  "VLLM_STUDIO_DATA_DIR",
+  "VLLM_STUDIO_DB_PATH",
+  "VLLM_STUDIO_MODELS_DIR",
+  "VLLM_STUDIO_HOST",
+  "VLLM_STUDIO_PORT",
+  "VLLM_STUDIO_INFERENCE_PORT",
+  "VLLM_STUDIO_MOCK_INFERENCE",
+  "VLLM_STUDIO_MOCK_MODEL_ID",
+  "VLLM_STUDIO_API_KEY",
+  "PI_CODING_AGENT_DIR",
+] as const;
+
+let envSnapshot: Record<string, string | undefined>;
+let tempDir: string;
+
+beforeEach(() => {
+  envSnapshot = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+  tempDir = mkdtempSync(join(tmpdir(), "vllm-studio-log-redaction-"));
+  Object.assign(process.env, {
+    VLLM_STUDIO_DATA_DIR: tempDir,
+    VLLM_STUDIO_DB_PATH: join(tempDir, "controller.db"),
+    VLLM_STUDIO_MODELS_DIR: join(tempDir, "models"),
+    VLLM_STUDIO_HOST: "127.0.0.1",
+    VLLM_STUDIO_PORT: "18080",
+    VLLM_STUDIO_INFERENCE_PORT: "65534",
+    VLLM_STUDIO_MOCK_INFERENCE: "true",
+    VLLM_STUDIO_MOCK_MODEL_ID: "mock-model",
+    PI_CODING_AGENT_DIR: join(tempDir, "pi-agent"),
+  });
+  delete process.env.VLLM_STUDIO_API_KEY;
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = envSnapshot[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("redactLogLine", () => {
+  test("redacts Authorization Bearer tokens", () => {
+    expect(redactLogLine("Authorization: Bearer sk-abc123xyz")).toBe(
+      "Authorization: Bearer [redacted]",
+    );
+    expect(redactLogLine("authorization: bearer eyJhbGciOiJIUzI1NiJ9")).toBe(
+      "authorization: bearer [redacted]",
+    );
+  });
+
+  test("redacts X-Api-Key headers", () => {
+    expect(redactLogLine("X-Api-Key: sk-test-key")).toBe("X-Api-Key: [redacted]");
+    expect(redactLogLine("x-api-key: hf_secret_value")).toBe("x-api-key: [redacted]");
+  });
+
+  test("redacts HF token env assignments", () => {
+    expect(redactLogLine("HF_TOKEN=hf_abcdef123456")).toBe("HF_TOKEN=[redacted]");
+    expect(redactLogLine("HUGGING_FACE_HUB_TOKEN=hf_secret")).toBe(
+      "HUGGING_FACE_HUB_TOKEN=[redacted]",
+    );
+    expect(redactLogLine('export HF_TOKEN="hf_quoted_token"')).toBe(
+      'export HF_TOKEN=[redacted]',
+    );
+  });
+
+  test("redacts OpenAI / Anthropic API key env assignments", () => {
+    expect(redactLogLine("OPENAI_API_KEY=sk-openai-secret")).toBe(
+      "OPENAI_API_KEY=[redacted]",
+    );
+    expect(redactLogLine("ANTHROPIC_API_KEY=sk-ant-secret")).toBe(
+      "ANTHROPIC_API_KEY=[redacted]",
+    );
+  });
+
+  test("redacts generic *_API_KEY and *_TOKEN env assignments", () => {
+    expect(redactLogLine("MY_SERVICE_API_KEY=abc123")).toBe(
+      "MY_SERVICE_API_KEY=[redacted]",
+    );
+    expect(redactLogLine("SESSION_TOKEN=xyz789")).toBe("SESSION_TOKEN=[redacted]");
+  });
+
+  test("redacts JSON-ish secret pairs", () => {
+    expect(redactLogLine('{ "api_key": "sk-json-key" }')).toBe(
+      '{ "api_key": "[redacted]" }',
+    );
+    expect(redactLogLine("{ 'token': 'secret-token' }")).toBe(
+      "{ 'token': '[redacted]' }",
+    );
+    expect(redactLogLine('{"openai_api_key":"sk-123"}')).toBe(
+      '{"openai_api_key":"[redacted]"}',
+    );
+  });
+
+  test("redacts CLI flag secrets", () => {
+    expect(redactLogLine("vllm serve --api-key sk-api-key-value")).toBe(
+      "vllm serve --api-key [redacted]",
+    );
+    expect(redactLogLine("python -m vllm --hf-token hf_secret")).toBe(
+      "python -m vllm --hf-token [redacted]",
+    );
+    expect(redactLogLine("cmd --token secret")).toBe("cmd --token [redacted]");
+  });
+
+  test("redacts URL query parameter secrets", () => {
+    expect(redactLogLine("https://api.example.com/v1?api_key=sk-123&model=gpt4")).toBe(
+      "https://api.example.com/v1?api_key=[redacted]&model=gpt4",
+    );
+    expect(redactLogLine("http://host/path?token=secret&other=value")).toBe(
+      "http://host/path?token=[redacted]&other=value",
+    );
+  });
+
+  test("preserves ordinary log context", () => {
+    const errorLine =
+      "RuntimeError: CUDA out of memory. Tried to allocate 3.45 GiB. GPU 0 has 5.00 GiB total";
+    expect(redactLogLine(errorLine)).toBe(errorLine);
+  });
+
+  test("preserves throughput metrics", () => {
+    const metric = "llama-server: tokens per second = 42.5";
+    expect(redactLogLine(metric)).toBe(metric);
+  });
+
+  test("preserves file paths without secret markers", () => {
+    const path = "Loading model from /home/user/models/Llama-3.1-8B-Instruct-Q4_K_M.gguf";
+    expect(redactLogLine(path)).toBe(path);
+  });
+
+  test("redacts secrets in a multi-token line while keeping context", () => {
+    const line =
+      "request failed Authorization: Bearer sk-leaked; retry with OPENAI_API_KEY=sk-other";
+    expect(redactLogLine(line)).toBe(
+      "request failed Authorization: Bearer [redacted]; retry with OPENAI_API_KEY=[redacted]",
+    );
+  });
+});
+
+describe("redactLogContent", () => {
+  test("redacts secrets across multiple lines", () => {
+    const content = "line1\nAuthorization: Bearer sk-abc\nline3\nHF_TOKEN=hf_123\n";
+    expect(redactLogContent(content)).toBe(
+      "line1\nAuthorization: Bearer [redacted]\nline3\nHF_TOKEN=[redacted]\n",
+    );
+  });
+});
+
+describe("GET /logs/:sessionId redaction", () => {
+  test("returns redacted log lines without rewriting the file", async () => {
+    const recipeId = "test-recipe";
+    const logPath = primaryLogPathFor(tempDir, recipeId);
+    writeFileSync(
+      logPath,
+      [
+        "Starting model load",
+        "Authorization: Bearer sk-live-token",
+        "OPENAI_API_KEY=sk-openai-key",
+        "CUDA out of memory",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const [{ createAppContext }, { createApp }] = await Promise.all([
+      import("../../../controller/src/app-context"),
+      import("../../../controller/src/http/app"),
+    ]);
+    const context = createAppContext();
+    const app = createApp(context);
+
+    const response = await app.request(`/logs/${recipeId}`);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.logs).toEqual([
+      "Starting model load",
+      "Authorization: Bearer [redacted]",
+      "OPENAI_API_KEY=[redacted]",
+      "CUDA out of memory",
+    ]);
+    expect(body.content).toBe(body.logs.join("\n"));
+
+    // Raw file on disk is unchanged.
+    const raw = await Bun.file(logPath).text();
+    expect(raw).toContain("sk-live-token");
+    expect(raw).toContain("sk-openai-key");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `controller/src/core/log-redaction.ts` with conservative patterns for bearer tokens, API keys, HF/OpenAI/Anthropic env tokens, generic `*_API_KEY`/`*_TOKEN`, JSON-ish secret pairs, CLI flag secrets, and URL query secrets.
- Applies redaction only at `GET /logs/:sessionId` and `GET /logs/:sessionId/stream` response boundaries.
- Preserves raw log files on disk; no UI, logger-format, or metrics-parsing changes.
- Complements #85 by redacting log content as it crosses API/SSE response boundaries rather than changing controller log-file writes.

## Verification
- `bun test tests/controller/integration/log-redaction.test.ts` — 14 pass, 0 fail
- `npm --prefix controller run typecheck`
- `npm --prefix controller run lint`

## Known upstream check
- `npm run check:contracts` currently fails on current `main` with duplicate `AggregatedSession` exports in `frontend/src/app/api/agent/sessions/all/route.ts` and `frontend/src/features/agent/session-contracts.ts`; this PR does not touch those files.

## Notes / Non-goals
- No UI redesign or WP-001 error-card/deep-link work.
- No mutation of raw disk logs or controller logger format.
- No change to llama.cpp/vLLM metrics parsing.
