### PR TITLE
fix(frontend): remove duplicate exported AggregatedSession type alias

### DIFF
--- a/frontend/src/app/api/agent/sessions/all/route.ts
+++ b/frontend/src/app/api/agent/sessions/all/route.ts
@@ -11,7 +11,7 @@ export const dynamic = "force-dynamic";
 // Aggregated session index across every registered project. The agent
 // sidebar/dashboard loads this once and then filters/searches client-side so
 // search-as-you-type stays snappy without per-keystroke fetches.
-export type AggregatedSession = SessionSummary & {
+type AggregatedSession = SessionSummary & {
   projectId: string;
   projectName: string;
   projectPath: string;


### PR DESCRIPTION
Fixes #158

Removes the `export` keyword from the route-local `AggregatedSession` type alias in `frontend/src/app/api/agent/sessions/all/route.ts`. The canonical client contract remains exported from `frontend/src/features/agent/session-contracts.ts`.

## Verification
- `npm run check:contracts` ✅
- `npm --prefix frontend run typecheck` ✅
- `npm --prefix frontend run lint` ✅

## Notes
- No runtime behavior change.
- No response JSON shape change.
- No route behavior change.
- Does not touch PR #151/#152/#155/#157.