### PR TITLE
fix(controller): per-recipe crash-loop budget

### DIFF
--- a/controller/src/modules/engines/configs.ts
+++ b/controller/src/modules/engines/configs.ts
@@ -1,5 +1,8 @@
 export const LIFECYCLE_READY_TIMEOUT_MS = 300_000;
 
+export const CRASH_LOOP_MAX_FAILURES = 3;
+export const CRASH_LOOP_WINDOW_MS = 60_000;
+
 export const DOWNLOAD_DEFAULT_IGNORE_FILENAMES = [".gitattributes", ".gitignore"];
 export const DOWNLOAD_PROGRESS_THROTTLE_MS = 750;
 

--- a/controller/src/modules/engines/engine-coordinator.ts
+++ b/controller/src/modules/engines/engine-coordinator.ts
@@ -3,8 +3,8 @@ import { Event, type EventManager } from "../system/event-manager"; import { CON
 import { pidExists } from "./process/process-utilities"; import { isRecipeRunning } from "../models/recipes/recipe-matching";
 import type { ProcessInfo, Recipe } from "../models/types"; import type { Config } from "../../config/env";
 import type { Logger } from "../../core/logger"; import type { ProcessManager } from "./process/process-manager";
-import type { RecipeStore } from "../models/recipes/recipe-store"; import { LIFECYCLE_READY_TIMEOUT_MS } from "./configs";
-import type { EngineService, DownloadRequest, HfModel, SetActiveRecipeResult, SetActiveRecipeOptions } from "./engine-service"; import type { ModelDownload } from "../shared/recipe-types";
+import type { RecipeStore } from "../models/recipes/recipe-store"; import { LIFECYCLE_READY_TIMEOUT_MS, CRASH_LOOP_MAX_FAILURES, CRASH_LOOP_WINDOW_MS } from "./configs";
+import type { EngineService, CrashLoopInfo, DownloadRequest, HfModel, SetActiveRecipeResult, SetActiveRecipeOptions, EnsureActiveResult } from "./engine-service"; import type { ModelDownload } from "../shared/recipe-types";
  import type { DownloadManager } from "./downloads/download-manager";
 import { fetchHuggingFaceModelInfo } from "./downloads/huggingface-api";
 interface CoordinatorDeps { config: Config;
@@ -16,6 +16,7 @@ export class EngineCoordinator implements EngineService {
   private readonly switchLock = new AsyncLock();
   private activeLifecycleAbort: AbortController | null = null; private activeLaunchPid: number | null = null;
   private lifecycleIntentSerial = 0; private autoActivationBlocked = false;
+  private readonly launchFailures = new Map<string, CrashLoopEntry>();
  constructor(private readonly deps: CoordinatorDeps) {}
 
   async setActiveRecipe(recipe: Recipe | null, options: SetActiveRecipeOptions = {}): Promise<SetActiveRecipeResult> { const intentSerial = ++this.lifecycleIntentSerial;
@@ -59,10 +60,15 @@ export class EngineCoordinator implements EngineService {
  const postEvictAbort = await abortIfNeeded(recipe);
       if (postEvictAbort) return postEvictAbort;
       if (!recipe) { return { ok: true }; }
+      if (this.isQuarantined(recipe.id)) {
+        const info = this.getFailureEntry(recipe.id);
+        return { ok: false, error: `Recipe ${recipe.id} is temporarily quarantined due to repeated launch failures`, quarantineInfo: info ? this.toCrashLoopInfo(info) : undefined };
+      }
  await this.deps.eventManager.publishLaunchProgress(recipe.id, "launching", `Starting ${recipe.name}...`, 0.25);
       const launch = await this.deps.processManager.launchModel(recipe); spawnedPid = launch.pid;
       this.activeLaunchPid = launch.pid; if (!launch.success) {
-        await this.deps.eventManager.publishLaunchProgress(recipe.id, "error", launch.message, 0); return { ok: false, error: launch.message };
+        const info = this.recordLaunchFailure(recipe.id);
+        await this.deps.eventManager.publishLaunchProgress(recipe.id, "error", launch.message, 0); return { ok: false, error: launch.message, quarantineInfo: info };
       }
       const postLaunchAbort = await abortIfNeeded(recipe); if (postLaunchAbort) return postLaunchAbort;
  await this.deps.eventManager.publishLaunchProgress(recipe.id, "waiting", "Loading model... (0s)", 0.5);
@@ -74,11 +80,13 @@ export class EngineCoordinator implements EngineService {
  if (isAborted()) {
         return publishCancelled(recipe); }
  if (ready.ready) {
+        this.recordLaunchSuccess(recipe.id);
         await this.deps.eventManager.publishLaunchProgress(recipe.id, "ready", "Model is ready!", 1);
         return { ok: true }; }
  if (launch.pid) {
         await this.deps.processManager.killProcess(launch.pid, true); }
-      await this.deps.eventManager.publishLaunchProgress(recipe.id, "error", ready.message, 0); return { ok: false, error: ready.message };
+      const failureInfo = this.recordLaunchFailure(recipe.id);
+      await this.deps.eventManager.publishLaunchProgress(recipe.id, "error", ready.message, 0); return { ok: false, error: ready.message, quarantineInfo: failureInfo };
     } finally { if (this.activeLifecycleAbort === lifecycleAbort) {
         this.activeLifecycleAbort = null; }
       if (this.activeLaunchPid === spawnedPid) { this.activeLaunchPid = null;
@@ -128,7 +136,7 @@ export class EngineCoordinator implements EngineService {
         recipe_id: recipe.id, aborted_runs: totalAborted,
       }); }
   }
-  async ensureActive(recipe: Recipe, options: { force_evict?: boolean; publish_events?: boolean } = {}): Promise<{ switched: boolean; error: string | null }> {
+  async ensureActive(recipe: Recipe, options: { force_evict?: boolean; publish_events?: boolean } = {}): Promise<EnsureActiveResult> {
     const existing = await this.deps.processManager.findInferenceProcess(this.deps.config.inference_port); if (existing && isRecipeRunning(recipe, existing)) {
       return { switched: false, error: null }; }
     if (this.autoActivationBlocked) { return {
@@ -144,6 +152,10 @@ export class EngineCoordinator implements EngineService {
       } if (this.autoActivationBlocked) {
         return { switched: false,
           error: "Model auto-loading is disabled because the model was manually stopped. Start a model from vLLM Studio before sending local inference requests.", };
+      }
+      if (this.isQuarantined(recipe.id)) {
+        const info = this.getFailureEntry(recipe.id);
+        return { switched: false, error: `Recipe ${recipe.id} is temporarily quarantined due to repeated launch failures`, quarantineInfo: info ? this.toCrashLoopInfo(info) : undefined };
       }
       const publishEvents = options.publish_events !== false; const observedProcess = latest ?? existing;
       const fromRecipe = observedProcess ? this.findRecipeForProcess(observedProcess) : null; const fromModel = fromRecipe ? (fromRecipe.served_model_name ?? fromRecipe.id) : observedProcess ? observedProcess.model_path : null;
@@ -161,13 +173,14 @@ export class EngineCoordinator implements EngineService {
         return { switched: true, error: "Model switch cancelled" }; }
       const launch = await this.deps.processManager.launchModel(recipe); launchPid = launch.pid;
       this.activeLaunchPid = launch.pid; if (!launch.success) {
+        const info = this.recordLaunchFailure(recipe.id);
         const message = `Failed to launch model ${recipe.id}: ${launch.message}`; if (publishEvents) {
           await this.deps.eventManager.publish( new Event(CONTROLLER_EVENTS.MODEL_SWITCH, {
               status: "error", to_recipe_id: recipe.id,
               to_model: recipe.served_model_name ?? recipe.id, to_backend: recipe.backend,
               reason: message, })
           ); }
-        return { switched: true, error: message }; }
+        return { switched: true, error: message, quarantineInfo: info }; }
  const logFilePath = primaryLogPathFor(this.deps.config.data_dir, recipe.id);
       const ready = await this.waitForReady({ recipe,
         pid: launch.pid, logFilePath,
@@ -176,6 +189,7 @@ export class EngineCoordinator implements EngineService {
         if (launch.pid) { await this.deps.processManager.killProcess(launch.pid, true);
         } return { switched: true, error: "Model switch cancelled" };
       } if (ready.ready) {
+        this.recordLaunchSuccess(recipe.id);
         if (publishEvents) { await this.deps.eventManager.publish(
             new Event(CONTROLLER_EVENTS.MODEL_SWITCH, { status: "ready",
               to_recipe_id: recipe.id, to_model: recipe.served_model_name ?? recipe.id,
@@ -185,13 +199,15 @@ export class EngineCoordinator implements EngineService {
         return { switched: true, error: null };
       }
       if (launch.pid) { await this.deps.processManager.killProcess(launch.pid, true);
-      } if (publishEvents) {
+      }
+      const failureInfo = this.recordLaunchFailure(recipe.id);
+      if (publishEvents) {
         await this.deps.eventManager.publish( new Event(CONTROLLER_EVENTS.MODEL_SWITCH, {
             status: "error", to_recipe_id: recipe.id,
             to_model: recipe.served_model_name ?? recipe.id, to_backend: recipe.backend,
             reason: ready.message, })
         ); }
-      return { switched: true, error: ready.message }; } finally {
+      return { switched: true, error: ready.message, quarantineInfo: failureInfo }; } finally {
       if (this.activeLifecycleAbort === lifecycleAbort) { this.activeLifecycleAbort = null;
       } if (this.activeLaunchPid === launchPid) {
         this.activeLaunchPid = null; }
@@ -223,6 +239,67 @@ export class EngineCoordinator implements EngineService {
         name: info.modelId ?? query, },
     ]; }
 
+  resetLaunchFailures(recipeId: string): void {
+    this.launchFailures.delete(recipeId);
+  }
+
+  isQuarantined(recipeId: string): boolean {
+    return this.getFailureEntry(recipeId)?.quarantined ?? false;
+  }
+
+  getQuarantinedRecipes(): { recipe_id: string; info: CrashLoopInfo }[] {
+    const result: { recipe_id: string; info: CrashLoopInfo }[] = [];
+    for (const [recipeId, entry] of this.launchFailures) {
+      if (entry.quarantined) {
+        result.push({ recipe_id: recipeId, info: this.toCrashLoopInfo(entry) });
+      }
+    }
+    return result;
+  }
+
+  private recordLaunchFailure(recipeId: string): CrashLoopInfo {
+    const now = Date.now();
+    let entry = this.launchFailures.get(recipeId);
+    if (!entry || now - entry.windowStart > CRASH_LOOP_WINDOW_MS) {
+      entry = { consecutiveFailures: 0, windowStart: now, quarantined: false };
+      this.launchFailures.set(recipeId, entry);
+    }
+    entry.consecutiveFailures += 1;
+    if (entry.consecutiveFailures >= CRASH_LOOP_MAX_FAILURES) {
+      entry.quarantined = true;
+    }
+    return this.toCrashLoopInfo(entry);
+  }
+
+  private recordLaunchSuccess(recipeId: string): void {
+    this.launchFailures.delete(recipeId);
+  }
+
+  private getFailureEntry(recipeId: string): CrashLoopEntry | undefined {
+    const entry = this.launchFailures.get(recipeId);
+    if (!entry) return undefined;
+    if (Date.now() - entry.windowStart > CRASH_LOOP_WINDOW_MS) {
+      this.launchFailures.delete(recipeId);
+      return undefined;
+    }
+    return entry;
+  }
+
+  private toCrashLoopInfo(entry: CrashLoopEntry): CrashLoopInfo {
+    return {
+      consecutiveFailures: entry.consecutiveFailures,
+      windowStart: entry.windowStart,
+      quarantined: entry.quarantined,
+    };
+  }
+
 }
+
+interface CrashLoopEntry {
+  consecutiveFailures: number;
+  windowStart: number;
+  quarantined: boolean;
+}
+
  export const createEngineCoordinator = (deps: CoordinatorDeps): EngineCoordinator => {
   return new EngineCoordinator(deps); };

--- a/controller/src/modules/engines/engine-service.ts
+++ b/controller/src/modules/engines/engine-service.ts
@@ -22,6 +22,7 @@ export interface HfModel {
 export interface EnsureActiveResult {
   switched: boolean;
   error: string | null;
+  quarantineInfo?: CrashLoopInfo | undefined;
 }
 
 export interface EnsureActiveOptions {
@@ -29,7 +30,9 @@ export interface EnsureActiveOptions {
   publish_events?: boolean;
 }
 
-export type SetActiveRecipeResult = { ok: true } | { ok: false; error: string };
+export type SetActiveRecipeResult =
+  | { ok: true }
+  | { ok: false; error: string; quarantineInfo?: CrashLoopInfo | undefined };
 
 /** Options for setting the active recipe. */
 export interface SetActiveRecipeOptions {
@@ -40,6 +43,12 @@ export interface SetActiveRecipeOptions {
  * The single public contract for the engines module.
  * All consumers (HTTP routes, other modules, tests) use this interface.
  */
+export interface CrashLoopInfo {
+  consecutiveFailures: number;
+  windowStart: number;
+  quarantined: boolean;
+}
+
 export interface EngineService {
   setActiveRecipe(
     recipe: Recipe | null,
@@ -48,6 +57,10 @@ export interface EngineService {
   ensureActive(recipe: Recipe, options?: EnsureActiveOptions): Promise<EnsureActiveResult>;
 
   getCurrentProcess(): Promise<ProcessInfo | null>;
+
+  resetLaunchFailures(recipeId: string): void;
+  isQuarantined(recipeId: string): boolean;
+  getQuarantinedRecipes(): { recipe_id: string; info: CrashLoopInfo }[];
 
   startDownload(request: DownloadRequest): Promise<ModelDownload>;
   pauseDownload(downloadId: string): ModelDownload;

--- a/controller/src/modules/engines/routes.ts
+++ b/controller/src/modules/engines/routes.ts
@@ -105,6 +105,7 @@ export const registerEngineRoutes: RouteRegistrar = (app, context) => {
     try {
       const recipe = parseRecipe(body);
       context.stores.recipeStore.save(recipe);
+      context.engineService.resetLaunchFailures(recipe.id);
       await context.eventManager.publish(new Event(CONTROLLER_EVENTS.RECIPE_CREATED, { recipe }));
       return ctx.json({ success: true, id: recipe.id });
     } catch (error) {
@@ -118,6 +119,7 @@ export const registerEngineRoutes: RouteRegistrar = (app, context) => {
     try {
       const recipe = parseRecipe({ ...body, id: recipeId });
       context.stores.recipeStore.save(recipe);
+      context.engineService.resetLaunchFailures(recipe.id);
       await context.eventManager.publish(new Event(CONTROLLER_EVENTS.RECIPE_UPDATED, { recipe }));
       return ctx.json({ success: true, id: recipe.id });
     } catch (error) {
@@ -129,6 +131,7 @@ export const registerEngineRoutes: RouteRegistrar = (app, context) => {
     const recipeId = ctx.req.param("recipeId");
     const deleted = context.stores.recipeStore.delete(recipeId);
     if (!deleted) throw notFound("Recipe not found");
+    context.engineService.resetLaunchFailures(recipeId);
     await context.eventManager.publish(
       new Event(CONTROLLER_EVENTS.RECIPE_DELETED, { recipe_id: recipeId })
     );

--- a/tests/controller/integration/engine-coordinator-crash-loop.test.ts
+++ b/tests/controller/integration/engine-coordinator-crash-loop.test.ts
@@ -1,0 +1,383 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { spawn, type ChildProcess } from "node:child_process";
+import { join } from "node:path";
+import type { Config } from "../../../controller/src/config/env";
+import type { Logger } from "../../../controller/src/core/logger";
+import { CRASH_LOOP_MAX_FAILURES } from "../../../controller/src/modules/engines/configs";
+import { createEngineCoordinator } from "../../../controller/src/modules/engines/engine-coordinator";
+import type { DownloadManager } from "../../../controller/src/modules/engines/downloads/download-manager";
+import type { ProcessManager } from "../../../controller/src/modules/engines/process/process-manager";
+import type { Recipe, LaunchResult } from "../../../controller/src/modules/models/types";
+import type { RecipeStore } from "../../../controller/src/modules/models/recipes/recipe-store";
+import { EventManager } from "../../../controller/src/modules/system/event-manager";
+import { registerControllerTestLifecycle, tempDir } from "./fixtures";
+
+registerControllerTestLifecycle();
+
+const noopLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+function makeRecipe(id: string): Recipe {
+  return {
+    id: id as Recipe["id"],
+    name: id,
+    model_path: join(tempDir, "models", id),
+    backend: "vllm",
+    env_vars: null,
+    tensor_parallel_size: 1,
+    pipeline_parallel_size: 1,
+    max_model_len: 4096,
+    gpu_memory_utilization: 0.9,
+    kv_cache_dtype: "auto",
+    max_num_seqs: 256,
+    trust_remote_code: false,
+    tool_call_parser: null,
+    reasoning_parser: null,
+    enable_auto_tool_choice: false,
+    quantization: null,
+    dtype: null,
+    host: "127.0.0.1",
+    port: 8000,
+    served_model_name: null,
+    python_path: null,
+    extra_args: {},
+    max_thinking_tokens: null,
+    thinking_mode: "none",
+  } as Recipe;
+}
+
+function makeConfig(inferencePort: number): Config {
+  return {
+    host: "127.0.0.1",
+    port: 18080,
+    inference_host: "127.0.0.1",
+    inference_port: inferencePort,
+    data_dir: tempDir,
+    db_path: join(tempDir, "controller.db"),
+    models_dir: join(tempDir, "models"),
+    strict_openai_models: false,
+    providers: [],
+  };
+}
+
+function makeRecipeStore(recipes: Recipe[]): RecipeStore {
+  return {
+    list: () => recipes,
+    get: (id: string) => recipes.find((recipe) => recipe.id === id) ?? null,
+    save: (recipe: Recipe) => {
+      const index = recipes.findIndex((existing) => existing.id === recipe.id);
+      if (index >= 0) recipes[index] = recipe;
+      else recipes.push(recipe);
+    },
+    delete: () => true,
+    importFromJson: () => 0,
+  } as unknown as RecipeStore;
+}
+
+function makeDownloadManager(): DownloadManager {
+  return {
+    start: async () => { throw new Error("not implemented"); },
+    pause: () => { throw new Error("not implemented"); },
+    resume: () => { throw new Error("not implemented"); },
+    cancel: () => { throw new Error("not implemented"); },
+    list: () => [],
+    get: () => null,
+  } as unknown as DownloadManager;
+}
+
+interface CoordinatorFixture {
+  coordinator: ReturnType<typeof createEngineCoordinator>;
+  processManager: ProcessManager;
+  launchCallCount: () => number;
+}
+
+function createCoordinator({
+  launchResult,
+  recipes,
+  inferencePort,
+}: {
+  launchResult: LaunchResult;
+  recipes: Recipe[];
+  inferencePort: number;
+}): CoordinatorFixture {
+  let calls = 0;
+  const processManager: ProcessManager = {
+    findInferenceProcess: async () => null,
+    evictModel: async () => null,
+    killProcess: async () => true,
+    launchModel: async () => {
+      calls += 1;
+      return launchResult;
+    },
+  };
+
+  const coordinator = createEngineCoordinator({
+    config: makeConfig(inferencePort),
+    logger: noopLogger,
+    eventManager: new EventManager(),
+    processManager,
+    recipeStore: makeRecipeStore(recipes),
+    downloadManager: makeDownloadManager(),
+  });
+
+  return { coordinator, processManager, launchCallCount: () => calls };
+}
+
+describe("EngineCoordinator crash-loop budget", () => {
+  test("records launch failures and quarantines after the budget is exhausted", async () => {
+    const recipe = makeRecipe("failing-recipe");
+    const launchResult: LaunchResult = {
+      success: false,
+      pid: null,
+      message: "mock launch failure",
+      log_file: null,
+    };
+    const { coordinator, launchCallCount } = createCoordinator({
+      launchResult,
+      recipes: [recipe],
+      inferencePort: 65534,
+    });
+
+    for (let index = 1; index < CRASH_LOOP_MAX_FAILURES; index += 1) {
+      const result = await coordinator.setActiveRecipe(recipe);
+      expect(result.ok).toBe(false);
+      expect(coordinator.isQuarantined(recipe.id)).toBe(false);
+      expect(launchCallCount()).toBe(index);
+    }
+
+    const finalResult = await coordinator.setActiveRecipe(recipe);
+    expect(finalResult.ok).toBe(false);
+    expect(coordinator.isQuarantined(recipe.id)).toBe(true);
+    expect(launchCallCount()).toBe(CRASH_LOOP_MAX_FAILURES);
+    expect(finalResult.quarantineInfo?.quarantined).toBe(true);
+  });
+
+  test("blocks further launches while the recipe is quarantined", async () => {
+    const recipe = makeRecipe("blocked-recipe");
+    const launchResult: LaunchResult = {
+      success: false,
+      pid: null,
+      message: "mock launch failure",
+      log_file: null,
+    };
+    const { coordinator, launchCallCount } = createCoordinator({
+      launchResult,
+      recipes: [recipe],
+      inferencePort: 65534,
+    });
+
+    for (let index = 0; index < CRASH_LOOP_MAX_FAILURES; index += 1) {
+      await coordinator.setActiveRecipe(recipe);
+    }
+    expect(coordinator.isQuarantined(recipe.id)).toBe(true);
+
+    const blocked = await coordinator.setActiveRecipe(recipe);
+    expect(blocked.ok).toBe(false);
+    expect(blocked.error).toContain("quarantined");
+    expect(launchCallCount()).toBe(CRASH_LOOP_MAX_FAILURES);
+  });
+
+  test("resetLaunchFailures clears the budget", async () => {
+    const recipe = makeRecipe("reset-recipe");
+    const launchResult: LaunchResult = {
+      success: false,
+      pid: null,
+      message: "mock launch failure",
+      log_file: null,
+    };
+    const { coordinator, launchCallCount } = createCoordinator({
+      launchResult,
+      recipes: [recipe],
+      inferencePort: 65534,
+    });
+
+    for (let index = 0; index < CRASH_LOOP_MAX_FAILURES - 1; index += 1) {
+      await coordinator.setActiveRecipe(recipe);
+    }
+    coordinator.resetLaunchFailures(recipe.id);
+
+    for (let index = 0; index < CRASH_LOOP_MAX_FAILURES - 1; index += 1) {
+      await coordinator.setActiveRecipe(recipe);
+    }
+    expect(coordinator.isQuarantined(recipe.id)).toBe(false);
+
+    await coordinator.setActiveRecipe(recipe);
+    expect(coordinator.isQuarantined(recipe.id)).toBe(true);
+    expect(launchCallCount()).toBe(CRASH_LOOP_MAX_FAILURES * 2 - 1);
+  });
+
+  describe("with a live health endpoint", () => {
+    let server: ReturnType<typeof Bun.serve>;
+    let aliveChild: ChildProcess;
+
+    beforeEach(() => {
+      server = Bun.serve({
+        port: 0,
+        fetch: (request) => {
+          if (new URL(request.url).pathname === "/health") {
+            return new Response("OK", { status: 200 });
+          }
+          return new Response("Not Found", { status: 404 });
+        },
+      });
+      aliveChild = spawn("sleep", ["60"]);
+    });
+
+    afterEach(() => {
+      aliveChild.kill();
+      server.stop();
+    });
+
+    test("a successful launch resets the failure budget", async () => {
+      const recipe = makeRecipe("success-recipe");
+      const failingResult: LaunchResult = {
+        success: false,
+        pid: null,
+        message: "mock launch failure",
+        log_file: null,
+      };
+      const successResult: LaunchResult = {
+        success: true,
+        pid: aliveChild.pid ?? null,
+        message: "launched",
+        log_file: null,
+      };
+
+      let nextResult = failingResult;
+      const { coordinator } = createCoordinator({
+        launchResult: {
+          get success() { return nextResult.success; },
+          get pid() { return nextResult.pid; },
+          get message() { return nextResult.message; },
+          get log_file() { return nextResult.log_file; },
+        } as LaunchResult,
+        recipes: [recipe],
+        inferencePort: server.port,
+      });
+
+      for (let index = 0; index < CRASH_LOOP_MAX_FAILURES - 1; index += 1) {
+        await coordinator.setActiveRecipe(recipe);
+      }
+      expect(coordinator.isQuarantined(recipe.id)).toBe(false);
+
+      nextResult = successResult;
+      const success = await coordinator.setActiveRecipe(recipe);
+      expect(success.ok).toBe(true);
+      expect(coordinator.isQuarantined(recipe.id)).toBe(false);
+
+      nextResult = failingResult;
+      for (let index = 0; index < CRASH_LOOP_MAX_FAILURES - 1; index += 1) {
+        await coordinator.setActiveRecipe(recipe);
+      }
+      expect(coordinator.isQuarantined(recipe.id)).toBe(false);
+
+      await coordinator.setActiveRecipe(recipe);
+      expect(coordinator.isQuarantined(recipe.id)).toBe(true);
+    });
+  });
+
+  test("records wait-for-ready failures and quarantines the recipe", async () => {
+    const recipe = makeRecipe("crash-recipe");
+    const quickExit = spawn("node", ["-e", "process.exit(1)"]);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    try {
+      const launchResult: LaunchResult = {
+        success: true,
+        pid: quickExit.pid ?? null,
+        message: "launched",
+        log_file: null,
+      };
+      const { coordinator } = createCoordinator({
+        launchResult,
+        recipes: [recipe],
+        inferencePort: 65534,
+      });
+
+      for (let index = 1; index <= CRASH_LOOP_MAX_FAILURES; index += 1) {
+        const result = await coordinator.setActiveRecipe(recipe);
+        expect(result.ok).toBe(false);
+      }
+      expect(coordinator.isQuarantined(recipe.id)).toBe(true);
+    } finally {
+      quickExit.kill();
+    }
+  });
+
+  test("evicting a model is still allowed when the recipe is quarantined", async () => {
+    const recipe = makeRecipe("evict-recipe");
+    const launchResult: LaunchResult = {
+      success: false,
+      pid: null,
+      message: "mock launch failure",
+      log_file: null,
+    };
+    const { coordinator } = createCoordinator({
+      launchResult,
+      recipes: [recipe],
+      inferencePort: 65534,
+    });
+
+    for (let index = 0; index < CRASH_LOOP_MAX_FAILURES; index += 1) {
+      await coordinator.setActiveRecipe(recipe);
+    }
+    expect(coordinator.isQuarantined(recipe.id)).toBe(true);
+
+    const evictResult = await coordinator.setActiveRecipe(null);
+    expect(evictResult.ok).toBe(true);
+  });
+
+  test("ensureActive respects the quarantine and does not launch", async () => {
+    const recipe = makeRecipe("ensure-blocked-recipe");
+    const launchResult: LaunchResult = {
+      success: false,
+      pid: null,
+      message: "mock launch failure",
+      log_file: null,
+    };
+    const { coordinator, launchCallCount } = createCoordinator({
+      launchResult,
+      recipes: [recipe],
+      inferencePort: 65534,
+    });
+
+    for (let index = 0; index < CRASH_LOOP_MAX_FAILURES; index += 1) {
+      await coordinator.setActiveRecipe(recipe);
+    }
+    expect(coordinator.isQuarantined(recipe.id)).toBe(true);
+
+    const result = await coordinator.ensureActive(recipe, { publish_events: false });
+    expect(result.error).toContain("quarantined");
+    expect(result.quarantineInfo?.quarantined).toBe(true);
+    expect(launchCallCount()).toBe(CRASH_LOOP_MAX_FAILURES);
+  });
+
+  test("getQuarantinedRecipes returns only quarantined recipes", async () => {
+    const recipeA = makeRecipe("recipe-a");
+    const recipeB = makeRecipe("recipe-b");
+    const launchResult: LaunchResult = {
+      success: false,
+      pid: null,
+      message: "mock launch failure",
+      log_file: null,
+    };
+    const { coordinator } = createCoordinator({
+      launchResult,
+      recipes: [recipeA, recipeB],
+      inferencePort: 65534,
+    });
+
+    for (let index = 0; index < CRASH_LOOP_MAX_FAILURES; index += 1) {
+      await coordinator.setActiveRecipe(recipeA);
+    }
+
+    const quarantined = coordinator.getQuarantinedRecipes();
+    expect(quarantined).toHaveLength(1);
+    expect(quarantined[0].recipe_id).toBe(recipeA.id);
+    expect(quarantined[0].info.quarantined).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #153

Implements a per-recipe crash-loop budget so a repeatedly failing launch cannot spin indefinitely.

- Tracks consecutive launch failures per recipe in EngineCoordinator.
- Quarantines a recipe after 3 failures within 60 seconds.
- Resets the budget on a successful launch or when a recipe is created/updated/deleted.
- Blocks setActiveRecipe and ensureActive launches while quarantined.
- Allows evict/cancel regardless of quarantine state.

Verification:
- cd controller && bun run typecheck: passed
- cd controller && bun run lint: passed
- New integration tests: cd controller && bun test ../tests/controller/integration/engine-coordinator-crash-loop.test.ts: passed