### PR TITLE
fix(controller): reject request-controlled runtime job commands

### DIFF
--- a/controller/src/modules/engines/routes.ts
+++ b/controller/src/modules/engines/routes.ts
@@ -1,7 +1,7 @@
 import type { RouteRegistrar } from "../../http/route-registrar";
 import { delay } from "../../core/async";
 import { HttpStatus, badRequest, notFound, serviceUnavailable } from "../../core/errors";
-import { optionalEnum, optionalStringArray, parseJsonObjectBody } from "../../core/validation";
+import { optionalEnum, parseJsonObjectBody } from "../../core/validation";
 import { observeControllerFunction } from "../../core/function-observability";
 import { parseRecipe } from "../models/recipes/recipe-serializer";
 import { Event } from "../system/event-manager";
@@ -49,21 +49,19 @@ const parseRuntimeJobBody = async (ctx: {
   backend?: (typeof RUNTIME_JOB_BACKENDS)[number];
   targetId?: string;
   type?: (typeof RUNTIME_JOB_TYPES)[number];
-  command?: string;
-  args?: string[];
   version?: string;
   preferBundled?: boolean;
 }> => {
   const record = await parseJsonObjectBody(ctx);
   const backend = optionalEnum(record, "backend", RUNTIME_JOB_BACKENDS);
   const type = optionalEnum(record, "type", RUNTIME_JOB_TYPES, "job type");
-  const args = optionalStringArray(record, "args");
+  if ("command" in record || "args" in record) {
+    throw badRequest("Request-controlled command or args are not allowed for runtime jobs");
+  }
   return {
     ...(backend ? { backend } : {}),
     ...(typeof record["targetId"] === "string" ? { targetId: record["targetId"] } : {}),
     ...(type ? { type } : {}),
-    ...(typeof record["command"] === "string" ? { command: record["command"] } : {}),
-    ...(args ? { args } : {}),
     ...(typeof record["version"] === "string" ? { version: record["version"] } : {}),
     ...(typeof record["prefer_bundled"] === "boolean"
       ? { preferBundled: record["prefer_bundled"] }
@@ -336,8 +334,6 @@ export const registerEngineRoutes: RouteRegistrar = (app, context) => {
       backend: body.backend,
       type: body.type ?? "update",
       ...(body.targetId ? { targetId: body.targetId } : {}),
-      ...(body.command ? { command: body.command } : {}),
-      ...(body.args ? { args: body.args } : {}),
       ...(body.version ? { version: body.version } : {}),
       ...(body.preferBundled !== undefined ? { preferBundled: body.preferBundled } : {}),
       runningProcess: current,
@@ -420,8 +416,6 @@ export const registerEngineRoutes: RouteRegistrar = (app, context) => {
       backend: "vllm",
       type: "update",
       ...(body.targetId ? { targetId: body.targetId } : {}),
-      ...(body.command ? { command: body.command } : {}),
-      ...(body.args ? { args: body.args } : {}),
       ...(body.version ? { version: body.version.trim() } : {}),
       ...(body.preferBundled !== undefined ? { preferBundled: body.preferBundled } : {}),
       runningProcess: current,
@@ -430,41 +424,37 @@ export const registerEngineRoutes: RouteRegistrar = (app, context) => {
   });
 
   app.post("/runtime/sglang/upgrade", async (ctx) => {
-    const body = await parseRuntimeJobBody(ctx);
+    await parseRuntimeJobBody(ctx);
     const job = createEngineJob(context.config, {
       backend: "sglang",
       type: "update",
-      ...(body.args ? { args: body.args } : {}),
     });
     return ctx.json({ job_id: job.id, job });
   });
 
   app.post("/runtime/llamacpp/upgrade", async (ctx) => {
-    const body = await parseRuntimeJobBody(ctx);
+    await parseRuntimeJobBody(ctx);
     const job = createEngineJob(context.config, {
       backend: "llamacpp",
       type: "update",
-      ...(body.args ? { args: body.args } : {}),
     });
     return ctx.json({ job_id: job.id, job });
   });
 
   app.post("/runtime/cuda/upgrade", async (ctx) => {
-    const body = await parseRuntimeJobBody(ctx);
+    await parseRuntimeJobBody(ctx);
     const job = createEngineJob(context.config, {
       backend: "cuda",
       type: "update",
-      ...(body.args ? { args: body.args } : {}),
     });
     return ctx.json({ job_id: job.id, job });
   });
 
   app.post("/runtime/rocm/upgrade", async (ctx) => {
-    const body = await parseRuntimeJobBody(ctx);
+    await parseRuntimeJobBody(ctx);
     const job = createEngineJob(context.config, {
       backend: "rocm",
       type: "update",
-      ...(body.args ? { args: body.args } : {}),
     });
     return ctx.json({ job_id: job.id, job });
   });

--- a/controller/src/modules/engines/runtimes/engine-jobs.ts
+++ b/controller/src/modules/engines/runtimes/engine-jobs.ts
@@ -27,8 +27,6 @@ type CreateEngineJobOptions = {
   backend: RuntimeJobBackend;
   type: EngineJob["type"];
   targetId?: string;
-  command?: string;
-  args?: string[];
   version?: string;
   preferBundled?: boolean;
   runningProcess?: ProcessInfo | null;
@@ -75,7 +73,6 @@ const createJobRecord = (options: CreateEngineJobOptions): EngineJob => ({
   status: "queued",
   progress: 0,
   message: `${options.type} queued for ${options.backend}`,
-  ...(options.command ? { command: options.command } : {}),
   startedAt: nowIso(),
 });
 
@@ -96,7 +93,6 @@ const updateRunningJob = (id: string, updates: Partial<EngineJob>): void => {
 };
 
 const describeDefaultCommand = (options: CreateEngineJobOptions): string => {
-  if (options.command) return [options.command, ...(options.args ?? [])].join(" ").trim();
   if (options.type === "install" && isManagedPythonBackend(options.backend)) {
     return `python -m venv $DATA_DIR/runtime/venvs/${managedVenvName(options.backend)} && pip install ${managedPackageSpec(options.backend, options.version)}`;
   }
@@ -267,8 +263,6 @@ const runJob = async (
     }
 
     const upgradeOptions: RuntimeUpgradeOptions = {
-      ...(options.command ? { command: options.command } : {}),
-      ...(options.args ? { args: options.args } : {}),
       ...(options.version ? { version: options.version } : {}),
       ...(options.backend === "sglang" && target?.pythonPath
         ? { pythonPath: target.pythonPath }

--- a/controller/src/modules/engines/runtimes/runtime-upgrade.ts
+++ b/controller/src/modules/engines/runtimes/runtime-upgrade.ts
@@ -17,29 +17,12 @@ import { RUNTIME_UPGRADE_TIMEOUT_MS } from "../configs";
 export type { RuntimeUpgradeResult } from "../../../../../shared/contracts/system";
 
 export interface RuntimeUpgradeOptions {
-  command?: string;
-  args?: string[];
   version?: string;
   pythonPath?: string | null;
 }
 
-const resolveCommand = (command: string | undefined, envKey: string): string | null => {
-  // A request-supplied command is arbitrary-binary execution as the controller
-  // user. Ignore it unless the operator has explicitly opted in; the
-  // operator-configured env command (and the built-in pip/uv path) still work.
-  const allowRequestCommand =
-    process.env["VLLM_STUDIO_ALLOW_RUNTIME_UPGRADE_COMMAND"] === "true";
-  if (allowRequestCommand && command?.trim()) return command.trim();
-  return getUpgradeCommandFromEnvironment(envKey);
-};
-
-const parseCommandInput = (args: unknown): string[] | null => {
-  if (!Array.isArray(args)) return null;
-  const parsed = args
-    .map((item) => (typeof item === "string" ? item.trim() : ""))
-    .filter((item) => item.length > 0);
-  return parsed.length > 0 ? parsed : null;
-};
+const resolveCommand = (envKey: string): string | null =>
+  getUpgradeCommandFromEnvironment(envKey);
 
 const upgradeTimeoutMessage = (): string =>
   `Upgrade command timed out after ${Math.round(RUNTIME_UPGRADE_TIMEOUT_MS / 60_000)} minutes`;
@@ -71,10 +54,9 @@ export const upgradeSglangRuntime = async (
   config: Config,
   options: RuntimeUpgradeOptions = {}
 ): Promise<RuntimeUpgradeResult> => {
-  const command = resolveCommand(options.command, SGLANG_UPGRADE_ENV);
-  const parsedArguments = parseCommandInput(options.args);
+  const command = resolveCommand(SGLANG_UPGRADE_ENV);
   const python = getSglangRuntimePython(config, options);
-  if (command) return runCommandUpgrade(command, parsedArguments ?? []);
+  if (command) return runCommandUpgrade(command, []);
   const uv = resolveBinary("uv");
   const args = uv
     ? ["pip", "install", "--python", python, "--upgrade", "sglang"]
@@ -106,9 +88,9 @@ export const upgradeSglangRuntime = async (
 
 export const upgradeLlamacppRuntime = async (
   config: Config,
-  options: RuntimeUpgradeOptions
+  _options: RuntimeUpgradeOptions
 ): Promise<RuntimeUpgradeResult> => {
-  const command = resolveCommand(options.command, LLAMACPP_UPGRADE_ENV);
+  const command = resolveCommand(LLAMACPP_UPGRADE_ENV);
   if (!command)
     return {
       success: false,
@@ -117,18 +99,17 @@ export const upgradeLlamacppRuntime = async (
       error: "No llama.cpp upgrade command configured. Set VLLM_STUDIO_LLAMACPP_UPGRADE_CMD.",
       used_command: null,
     };
-  const parsedArguments = parseCommandInput(options.args);
-  const result = await runCommandUpgrade(command, parsedArguments ?? []);
+  const result = await runCommandUpgrade(command, []);
   const runtime = getLlamacppRuntimeInfo(config);
   return { ...result, success: result.success && runtime.installed, version: runtime.version };
 };
 
 export const runPlatformUpgrade = async (
   platform: "cuda" | "rocm",
-  options: RuntimeUpgradeOptions
+  _options: RuntimeUpgradeOptions
 ): Promise<RuntimeUpgradeResult> => {
   const envKey = platform === "cuda" ? CUDA_UPGRADE_ENV : ROCM_UPGRADE_ENV;
-  const command = resolveCommand(options.command, envKey);
+  const command = resolveCommand(envKey);
   if (!command)
     return {
       success: false,
@@ -137,8 +118,7 @@ export const runPlatformUpgrade = async (
       error: `No ${platform.toUpperCase()} upgrade command configured. Set ${envKey}.`,
       used_command: null,
     };
-  const parsedArguments = parseCommandInput(options.args);
-  const result = await runCommandUpgrade(command, parsedArguments ?? []);
+  const result = await runCommandUpgrade(command, []);
   if (!result.success) return result;
   if (platform === "cuda") {
     const info = getCudaInfo();

--- a/controller/src/modules/engines/runtimes/vllm-runtime.ts
+++ b/controller/src/modules/engines/runtimes/vllm-runtime.ts
@@ -9,14 +9,6 @@ import {
 } from "./upgrade-config";
 import { VLLM_RUNTIME_COMMAND_TIMEOUT_MS, VLLM_UPGRADE_TIMEOUT_MS } from "../configs";
 
-const parseCommandInput = (args: unknown): string[] | null => {
-  if (!Array.isArray(args)) return null;
-  const parsed = args
-    .map((item) => (typeof item === "string" ? item.trim() : ""))
-    .filter((item) => item.length > 0);
-  return parsed.length > 0 ? parsed : null;
-};
-
 const resolveVllmUpgradeTarget = (version?: string): string => {
   const configured =
     version && version.trim().length > 0 ? version.trim() : getVllmUpgradeVersion();
@@ -201,8 +193,6 @@ export const getVllmConfigHelp = async (): Promise<{
 
 type VllmUpgradeOptions = {
   preferBundled?: boolean;
-  command?: string;
-  args?: string[];
   version?: string;
   pythonPath?: string | null;
 };
@@ -228,10 +218,7 @@ export const upgradeVllmRuntime = async (
       used_command: null,
     };
 
-  const preferredCommand =
-    options.command?.trim() ?? getUpgradeCommandFromEnvironment(VLLM_UPGRADE_ENV);
-  const command = preferredCommand;
-  const parsedArguments = parseCommandInput(options.args);
+  const command = getUpgradeCommandFromEnvironment(VLLM_UPGRADE_ENV);
   const preferBundled = options.preferBundled !== false;
   if (!command) {
     const version = resolveVllmUpgradeTarget(options.version);
@@ -270,11 +257,10 @@ export const upgradeVllmRuntime = async (
       used_command: usedCommand,
     };
   }
-  const customArguments = parsedArguments ?? [];
-  const result = await runCommandAsync(command, customArguments, {
+  const result = await runCommandAsync(command, [], {
     timeoutMs: VLLM_UPGRADE_TIMEOUT_MS,
   });
-  const usedCommand = [command, ...customArguments].join(" ");
+  const usedCommand = command;
   if (result.status !== 0)
     return {
       success: false,

--- a/tests/controller/integration/runtime-job-command-boundary.test.ts
+++ b/tests/controller/integration/runtime-job-command-boundary.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { createTestApp, registerControllerTestLifecycle } from "./fixtures";
+
+registerControllerTestLifecycle();
+
+describe("runtime job command boundary", () => {
+  describe("POST /runtime/jobs", () => {
+    test("rejects a request-controlled command field with 400", async () => {
+      const app = await createTestApp();
+      const response = await app.request("/runtime/jobs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ backend: "llamacpp", type: "update", command: "whoami" }),
+      });
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        detail: "Request-controlled command or args are not allowed for runtime jobs",
+      });
+    });
+
+    test("rejects a request-controlled args field with 400", async () => {
+      const app = await createTestApp();
+      const response = await app.request("/runtime/jobs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ backend: "llamacpp", type: "update", args: ["-c", "whoami"] }),
+      });
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        detail: "Request-controlled command or args are not allowed for runtime jobs",
+      });
+    });
+  });
+
+  const upgradeRoutes = [
+    "/runtime/vllm/upgrade",
+    "/runtime/sglang/upgrade",
+    "/runtime/llamacpp/upgrade",
+    "/runtime/cuda/upgrade",
+    "/runtime/rocm/upgrade",
+  ] as const;
+
+  for (const path of upgradeRoutes) {
+    describe(`POST ${path}`, () => {
+      test("rejects a request-controlled command field with 400", async () => {
+        const app = await createTestApp();
+        const response = await app.request(path, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ command: "whoami" }),
+        });
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({
+          detail: "Request-controlled command or args are not allowed for runtime jobs",
+        });
+      });
+
+      test("rejects a request-controlled args field with 400", async () => {
+        const app = await createTestApp();
+        const response = await app.request(path, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ args: ["-c", "whoami"] }),
+        });
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({
+          detail: "Request-controlled command or args are not allowed for runtime jobs",
+        });
+      });
+    });
+  }
+});

--- a/tests/controller/integration/runtime-recipe-contracts.test.ts
+++ b/tests/controller/integration/runtime-recipe-contracts.test.ts
@@ -652,7 +652,7 @@ describe("controller route contracts", () => {
     const invalidArgsBody = await invalidArgsResponse.json();
     expect(invalidArgsResponse.status).toBe(400);
     expect(invalidArgsBody).toEqual({
-      detail: "args must be an array of strings",
+      detail: "Request-controlled command or args are not allowed for runtime jobs",
     });
 
     for (const route of [
@@ -668,7 +668,9 @@ describe("controller route contracts", () => {
       });
       const body = await response.json();
       expect(response.status).toBe(400);
-      expect(body).toEqual({ detail: "args must be an array of strings" });
+      expect(body).toEqual({
+        detail: "Request-controlled command or args are not allowed for runtime jobs",
+      });
     }
 
     const vllmConfigResponse = await app.request("/runtime/vllm/config");

--- a/tests/controller/integration/runtime-upgrade-env-command.test.ts
+++ b/tests/controller/integration/runtime-upgrade-env-command.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { createConfig } from "../../../controller/src/config/env";
+import { upgradeVllmRuntime } from "../../../controller/src/modules/engines/runtimes/vllm-runtime";
+import {
+  runPlatformUpgrade,
+  upgradeLlamacppRuntime,
+  upgradeSglangRuntime,
+} from "../../../controller/src/modules/engines/runtimes/runtime-upgrade";
+import { registerControllerTestLifecycle, tempDir } from "./fixtures";
+
+registerControllerTestLifecycle();
+
+const UPGRADE_ENV_KEYS = [
+  "VLLM_STUDIO_VLLM_UPGRADE_CMD",
+  "VLLM_STUDIO_SGLANG_UPGRADE_CMD",
+  "VLLM_STUDIO_LLAMACPP_UPGRADE_CMD",
+  "VLLM_STUDIO_CUDA_UPGRADE_CMD",
+  "VLLM_STUDIO_ROCM_UPGRADE_CMD",
+] as const;
+
+describe("runtime upgrade env-command path", () => {
+  let envSnapshot: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    envSnapshot = Object.fromEntries(
+      UPGRADE_ENV_KEYS.map((key) => [key, process.env[key]])
+    );
+    for (const key of UPGRADE_ENV_KEYS) {
+      process.env[key] = "true";
+    }
+    // The test lifecycle skips system python; allow it so vllm-runtime can find a python binary.
+    delete process.env.VLLM_STUDIO_RUNTIME_SKIP_SYSTEM;
+  });
+
+  afterEach(() => {
+    for (const key of UPGRADE_ENV_KEYS) {
+      const value = envSnapshot[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  test("upgradeVllmRuntime uses the operator-configured command", async () => {
+    const result = await upgradeVllmRuntime({});
+    expect(result.used_command).toBe("true");
+  });
+
+  test("upgradeSglangRuntime uses the operator-configured command", async () => {
+    const config = createConfig();
+    const result = await upgradeSglangRuntime(config, {});
+    expect(result.used_command).toBe("true");
+  });
+
+  test("upgradeLlamacppRuntime uses the operator-configured command", async () => {
+    const config = createConfig();
+    const result = await upgradeLlamacppRuntime(config, {});
+    expect(result.used_command).toBe("true");
+  });
+
+  test("runPlatformUpgrade uses the operator-configured command for CUDA", async () => {
+    const result = await runPlatformUpgrade("cuda", {});
+    expect(result.used_command).toBe("true");
+  });
+
+  test("runPlatformUpgrade uses the operator-configured command for ROCm", async () => {
+    const result = await runPlatformUpgrade("rocm", {});
+    expect(result.used_command).toBe("true");
+  });
+});


### PR DESCRIPTION
WP-005 hardening: runtime job APIs no longer accept caller-controlled executable or argv fields.

Changes:
- POST /runtime/jobs rejects payloads containing command or args with 400.
- All runtime upgrade wrapper routes reject payloads containing command or args with 400.
- Removed request-controlled command/args plumbing from engine-jobs, runtime-upgrade, and vllm-runtime.
- Operator-configured env/default upgrade paths remain functional.
- Recipe launch-command behavior is unchanged.

Verification:
- cd controller && bun run typecheck: passed
- cd controller && bun run lint: passed
- Focused controller tests passed
- Broader controller integration has one known unrelated observability fixture failure (host power readout non-zero)