### PR TITLE
feat(proxy): normalize tool request order for stable prefix-cache bytes

### DIFF
--- a/controller/src/modules/proxy/content-normalizer.test.ts
+++ b/controller/src/modules/proxy/content-normalizer.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+
+import { normalizeToolRequest } from "./content-normalizer";
+
+type Tool = {
+  type: "function";
+  function: Record<string, unknown>;
+};
+
+describe("normalizeToolRequest", () => {
+  const makeShuffledTools = (): Tool[] => [
+    {
+      type: "function",
+      function: {
+        parameters: { type: "object", properties: {} },
+        name: "charlie",
+        description: "Charlie tool",
+      },
+    },
+    {
+      type: "function",
+      function: {
+        description: "Alpha tool",
+        name: "alpha",
+        parameters: { type: "object", properties: {} },
+      },
+    },
+    {
+      type: "function",
+      function: {
+        name: "bravo",
+        description: "Bravo tool",
+        parameters: { type: "object", properties: {} },
+      },
+    },
+  ];
+
+  const makeCanonicalTools = (): Tool[] => [
+    {
+      type: "function",
+      function: {
+        name: "alpha",
+        description: "Alpha tool",
+        parameters: { type: "object", properties: {} },
+      },
+    },
+    {
+      type: "function",
+      function: {
+        name: "bravo",
+        description: "Bravo tool",
+        parameters: { type: "object", properties: {} },
+      },
+    },
+    {
+      type: "function",
+      function: {
+        name: "charlie",
+        description: "Charlie tool",
+        parameters: { type: "object", properties: {} },
+      },
+    },
+  ];
+
+  test("sorts tools by function.name", () => {
+    const result = normalizeToolRequest({ tools: makeShuffledTools() });
+    const resultTools = result["tools"] as Array<Record<string, unknown>>;
+    expect(
+      resultTools.map((tool) => (tool["function"] as Record<string, unknown>)["name"]),
+    ).toEqual(["alpha", "bravo", "charlie"]);
+  });
+
+  test("converts and sorts legacy functions", () => {
+    const functions = [
+      { name: "charlie", description: "Charlie fn", parameters: {} },
+      { name: "alpha", description: "Alpha fn", parameters: {} },
+      { name: "bravo", description: "Bravo fn", parameters: {} },
+    ];
+    const result = normalizeToolRequest({ functions });
+    expect(result["functions"]).toBeUndefined();
+    const resultTools = result["tools"] as Array<Record<string, unknown>>;
+    expect(
+      resultTools.map((tool) => (tool["function"] as Record<string, unknown>)["name"]),
+    ).toEqual(["alpha", "bravo", "charlie"]);
+    expect(resultTools[0]).toEqual({
+      type: "function",
+      function: expect.objectContaining({ name: "alpha" }),
+    });
+  });
+
+  test("produces stable JSON for shuffled vs original tool order", () => {
+    const shuffled = normalizeToolRequest({ tools: makeShuffledTools() });
+    const canonical = normalizeToolRequest({ tools: makeCanonicalTools() });
+    expect(JSON.stringify(shuffled)).toEqual(JSON.stringify(canonical));
+  });
+
+  test("canonicalizes function object key order", () => {
+    const tool = {
+      type: "function",
+      function: {
+        parameters: { type: "object" },
+        extra: "value",
+        name: "single",
+        description: "A tool",
+        another: 1,
+      },
+    };
+    const result = normalizeToolRequest({ tools: [tool] });
+    const resultTools = result["tools"] as Array<Record<string, unknown>>;
+    const firstTool = resultTools[0];
+    if (firstTool === undefined) {
+      throw new Error("expected at least one tool");
+    }
+    const functionObject = firstTool["function"] as Record<string, unknown>;
+    expect(Object.keys(functionObject)).toEqual([
+      "name",
+      "description",
+      "parameters",
+      "another",
+      "extra",
+    ]);
+  });
+});

--- a/controller/src/modules/proxy/content-normalizer.ts
+++ b/controller/src/modules/proxy/content-normalizer.ts
@@ -3,15 +3,96 @@ export const normalizeToolRequest = (payload: Record<string, unknown>): Record<s
     payload["tools"] = (payload["functions"] as Array<Record<string, unknown>>).map(
       (functionDefinition) => ({
         type: "function",
-        function: functionDefinition,
+        function: canonicalizeFunction(functionDefinition),
       })
     );
     delete payload["functions"];
   }
+
+  const tools = payload["tools"];
+  if (Array.isArray(tools)) {
+    payload["tools"] = tools
+      .map((tool) => {
+        if (!tool || typeof tool !== "object" || Array.isArray(tool)) {
+          return tool;
+        }
+        const toolRecord = tool as Record<string, unknown>;
+        const functionDefinition = toolRecord["function"];
+        if (
+          functionDefinition &&
+          typeof functionDefinition === "object" &&
+          !Array.isArray(functionDefinition)
+        ) {
+          return {
+            ...toolRecord,
+            function: canonicalizeFunction(functionDefinition as Record<string, unknown>),
+          };
+        }
+        return tool;
+      })
+      .sort((left, right) => {
+        const leftName = getFunctionName(left);
+        const rightName = getFunctionName(right);
+        if (leftName === null && rightName === null) {
+          return 0;
+        }
+        if (leftName === null) {
+          return 1;
+        }
+        if (rightName === null) {
+          return -1;
+        }
+        return leftName.localeCompare(rightName);
+      });
+  }
+
   if (payload["tool_choice"] === "auto") {
     delete payload["tool_choice"];
   }
   return payload;
+};
+
+const canonicalizeFunction = (
+  functionDefinition: Record<string, unknown>
+): Record<string, unknown> => {
+  const rest: Record<string, unknown> = {};
+  for (const key of Object.keys(functionDefinition)) {
+    if (key !== "name" && key !== "description" && key !== "parameters") {
+      rest[key] = functionDefinition[key];
+    }
+  }
+
+  const canonical: Record<string, unknown> = {};
+  if ("name" in functionDefinition) {
+    canonical["name"] = functionDefinition["name"];
+  }
+  if ("description" in functionDefinition) {
+    canonical["description"] = functionDefinition["description"];
+  }
+  if ("parameters" in functionDefinition) {
+    canonical["parameters"] = functionDefinition["parameters"];
+  }
+  for (const key of Object.keys(rest).sort()) {
+    canonical[key] = rest[key];
+  }
+  return canonical;
+};
+
+const getFunctionName = (tool: unknown): string | null => {
+  if (!tool || typeof tool !== "object" || Array.isArray(tool)) {
+    return null;
+  }
+  const toolRecord = tool as Record<string, unknown>;
+  const functionDefinition = toolRecord["function"];
+  if (
+    !functionDefinition ||
+    typeof functionDefinition !== "object" ||
+    Array.isArray(functionDefinition)
+  ) {
+    return null;
+  }
+  const name = (functionDefinition as Record<string, unknown>)["name"];
+  return typeof name === "string" ? name : null;
 };
 
 const collapseTextContentParts = (content: unknown): string | null => {

--- a/controller/src/modules/proxy/tokenization-routes.ts
+++ b/controller/src/modules/proxy/tokenization-routes.ts
@@ -1,6 +1,7 @@
 import { observeControllerFunction } from "../../core/function-observability";
 import type { RouteRegistrar } from "../../http/route-registrar";
 import { fetchInference } from "../../services/inference-client";
+import { normalizeToolRequest } from "./content-normalizer";
 
 export const registerTokenizationRoutes: RouteRegistrar = (app, context) => {
   app.post("/v1/tokenize", async (ctx) => {
@@ -126,6 +127,7 @@ export const registerTokenizationRoutes: RouteRegistrar = (app, context) => {
       if (tools.length > 0) {
         testRequest["tools"] = tools;
       }
+      normalizeToolRequest(testRequest);
       const response = await fetchInference(context, "/v1/chat/completions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
Normalize the order of tool definitions (and strip the default `tool_choice: "auto"`) before a request is serialized to the local inference server, so semantically-identical tool sets produce byte-identical request prefixes.

## Why (local-model)
vLLM / SGLang / llama.cpp use automatic prefix caching (KV-block reuse for shared prompt prefixes). Stable request bytes → higher prefix-cache hit rate → faster TTFT and less GPU recompute on repeated / long-context turns. This is an inference-efficiency win, not an API-cost concern.

## Changes
- `controller/src/modules/proxy/content-normalizer.ts`: `normalizeToolRequest` canonicalizes tool ordering; legacy `functions` are converted then sorted; nonstandard fields preserved.
- Applied on both the proxy forwarding path (`openai-routes.ts`) and the tokenization path (`tokenization-routes.ts`) so both serialize post-normalization.
- Adds `content-normalizer.test.ts`.

## Verification
- `cd controller && bun test src/modules/proxy/content-normalizer.test.ts` → 4 pass, 0 fail
- `cd controller && bun run typecheck` → clean

## Non-goals
- No nested JSON-Schema canonicalization (deferred — the small normalizer is sufficient for tool-order stability).
- Request semantics unchanged; only ordering + the redundant default are normalized.
