### PR TITLE
refactor: dedupe recipe launch-command extra-args into shared serializer

### DIFF
--- a/controller/src/modules/engines/process/backend-builder.ts
+++ b/controller/src/modules/engines/process/backend-builder.ts
@@ -3,6 +3,10 @@ import { dirname, join } from "node:path";
 import type { Recipe } from "../../models/types";
 import type { Config } from "../../../config/env";
 import { stripForeignFlagKeys } from "../../../../../shared/contracts/engine-args";
+import {
+  appendExtraArguments as appendSharedExtraArgs,
+  appendLlamacppExtraArguments as appendSharedLlamacppExtraArgs,
+} from "../../../../../shared/command-builder";
 import { resolveBinary } from "../../../core/command";
 import { resolveVllmRecipePythonPath } from "../runtimes/vllm-python-path";
 import {
@@ -10,6 +14,26 @@ import {
   getDefaultToolCallParser,
   shouldEnableExpertParallel,
 } from "./model-runtime-defaults";
+
+const BACKEND_ONLY_INTERNAL_KEYS: ReadonlySet<string> = new Set([
+  "llama_bin",
+  "mlx_python",
+  "docker_container",
+  "docker_image",
+  "docker-container",
+]);
+
+const BACKEND_ONLY_LLAMACPP_INTERNAL_KEYS: ReadonlySet<string> = new Set([
+  "llama_bin",
+  "docker_container",
+  "docker_image",
+  "docker-container",
+]);
+
+const ENABLE_EXPERT_PARALLELISM_FALSE_EXCEPTION: ReadonlySet<string> = new Set([
+  "enable_expert_parallelism",
+]);
+
 export const normalizeJsonArgument = (value: unknown): unknown => {
   if (Array.isArray(value)) {
     return value.map((item) => normalizeJsonArgument(item));
@@ -54,72 +78,6 @@ export const getPythonPath = (recipe: Recipe): string | undefined => {
 };
 const getVllmPythonPath = (recipe: Recipe): string | undefined => {
   return resolveVllmRecipePythonPath(recipe.python_path) ?? undefined;
-};
-export const appendExtraArguments = (
-  command: string[],
-  extraArguments: Record<string, unknown>
-): string[] => {
-  const internalKeys = new Set([
-    "venv_path",
-    "env_vars",
-    "visible_devices",
-    "cuda_visible_devices",
-    "hip_visible_devices",
-    "rocr_visible_devices",
-    "description",
-    "tags",
-    "status",
-    "llama_bin",
-    "mlx_python",
-    "launch_command",
-    "custom_command",
-    "docker_container",
-    "docker_image",
-    "docker-container",
-  ]);
-  const jsonStringKeys = new Set(["speculative_config", "default_chat_template_kwargs"]);
-  for (const [key, value] of Object.entries(extraArguments)) {
-    const normalizedKey = key.replace(/-/g, "_").toLowerCase();
-    if (internalKeys.has(normalizedKey)) {
-      continue;
-    }
-    const flag = `--${key.replace(/_/g, "-")}`;
-    if (command.includes(flag)) {
-      continue;
-    }
-    if (value === true) {
-      command.push(flag);
-      continue;
-    }
-    if (value === false) {
-      if (!["enable_expert_parallelism", "enable-expert-parallelism"].includes(normalizedKey)) {
-        command.push(flag);
-      }
-      continue;
-    }
-    if (value === undefined || value === null) {
-      continue;
-    }
-    if (typeof value === "string" && jsonStringKeys.has(normalizedKey)) {
-      const trimmed = value.trim();
-      if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
-        try {
-          const parsed = JSON.parse(trimmed) as unknown;
-          command.push(flag, JSON.stringify(normalizeJsonArgument(parsed)));
-          continue;
-        } catch {
-          command.push(flag, value);
-          continue;
-        }
-      }
-    }
-    if (Array.isArray(value) || (value && typeof value === "object")) {
-      command.push(flag, JSON.stringify(normalizeJsonArgument(value)));
-      continue;
-    }
-    command.push(flag, String(value));
-  }
-  return command;
 };
 const normalizeLaunchCommand = (command: string): string => {
   return command
@@ -255,7 +213,11 @@ export const buildVllmCommand = (recipe: Recipe): string[] => {
   if (recipe.dtype) {
     command.push("--dtype", recipe.dtype);
   }
-  return appendExtraArguments(command, recipe.extra_args);
+  return appendSharedExtraArgs(command, recipe.extra_args, {
+    extraInternalKeys: BACKEND_ONLY_INTERNAL_KEYS,
+    normalizeJson: normalizeJsonArgument,
+    falseBooleanExceptions: ENABLE_EXPERT_PARALLELISM_FALSE_EXCEPTION,
+  });
 };
 const executableBaseName = (value: string): string => {
   return value.split(/[\\/]/).filter(Boolean).at(-1)?.toLowerCase() ?? value.toLowerCase();
@@ -273,7 +235,15 @@ export const buildMlxCommand = (recipe: Recipe, config: Config): string[] => {
   const python = getPythonPath(recipe) || config.mlx_python || "python3";
   const command = [python, "-m", "mlx_lm.server"];
   command.push("--model", recipe.model_path, "--host", recipe.host, "--port", String(recipe.port));
-  return appendExtraArguments(command, stripForeignFlagKeys("mlx", recipe.extra_args));
+  return appendSharedExtraArgs(
+    command,
+    stripForeignFlagKeys("mlx", recipe.extra_args),
+    {
+      extraInternalKeys: BACKEND_ONLY_INTERNAL_KEYS,
+      normalizeJson: normalizeJsonArgument,
+      falseBooleanExceptions: ENABLE_EXPERT_PARALLELISM_FALSE_EXCEPTION,
+    },
+  );
 };
 export const buildBackendCommand = (recipe: Recipe, config: Config): string[] => {
   const launchCommand = getLaunchCommandOverride(recipe);
@@ -306,61 +276,6 @@ const resolveLlamaBinary = (recipe: Recipe, config: Config): string => {
   }
   return resolveBinary("llama-server") ?? "llama-server";
 };
-const appendLlamacppArguments = (
-  command: string[],
-  extraArguments: Record<string, unknown>
-): string[] => {
-  const internalKeys = new Set([
-    "venv_path",
-    "env_vars",
-    "visible_devices",
-    "cuda_visible_devices",
-    "hip_visible_devices",
-    "rocr_visible_devices",
-    "description",
-    "tags",
-    "status",
-    "llama_bin",
-    "docker_container",
-    "docker_image",
-    "docker-container",
-  ]);
-  for (const [key, value] of Object.entries(extraArguments)) {
-    const normalizedKey = key.replace(/-/g, "_").toLowerCase();
-    if (internalKeys.has(normalizedKey)) {
-      continue;
-    }
-    const flag = `--${key.replace(/_/g, "-")}`;
-    if (command.includes(flag)) {
-      continue;
-    }
-    if (value === true) {
-      command.push(flag);
-      continue;
-    }
-    if (value === false) {
-      continue;
-    }
-    if (value === undefined || value === null || value === "") {
-      continue;
-    }
-    if (Array.isArray(value)) {
-      for (const entry of value) {
-        if (entry === undefined || entry === null || entry === "") {
-          continue;
-        }
-        command.push(flag, String(entry));
-      }
-      continue;
-    }
-    if (typeof value === "object") {
-      command.push(flag, JSON.stringify(value));
-      continue;
-    }
-    command.push(flag, String(value));
-  }
-  return command;
-};
 export const buildLlamacppCommand = (recipe: Recipe, config: Config): string[] => {
   const command: string[] = [resolveLlamaBinary(recipe, config)];
   command.push("--model", recipe.model_path, "--host", recipe.host, "--port", String(recipe.port));
@@ -371,7 +286,14 @@ export const buildLlamacppCommand = (recipe: Recipe, config: Config): string[] =
   if (!ctxOverride && recipe.max_model_len > 0) {
     command.push("--ctx-size", String(recipe.max_model_len));
   }
-  return appendLlamacppArguments(command, stripForeignFlagKeys("llamacpp", recipe.extra_args));
+  return appendSharedLlamacppExtraArgs(
+    command,
+    stripForeignFlagKeys("llamacpp", recipe.extra_args),
+    {
+      extraInternalKeys: BACKEND_ONLY_LLAMACPP_INTERNAL_KEYS,
+      skipEmptyString: true,
+    },
+  );
 };
 export const buildSglangCommand = (recipe: Recipe, config: Config): string[] => {
   const python = getPythonPath(recipe) || config.sglang_python || "python";
@@ -414,5 +336,13 @@ export const buildSglangCommand = (recipe: Recipe, config: Config): string[] => 
   if (reasoningParser) {
     command.push("--reasoning-parser", reasoningParser);
   }
-  return appendExtraArguments(command, stripForeignFlagKeys("sglang", recipe.extra_args));
+  return appendSharedExtraArgs(
+    command,
+    stripForeignFlagKeys("sglang", recipe.extra_args),
+    {
+      extraInternalKeys: BACKEND_ONLY_INTERNAL_KEYS,
+      normalizeJson: normalizeJsonArgument,
+      falseBooleanExceptions: ENABLE_EXPERT_PARALLELISM_FALSE_EXCEPTION,
+    },
+  );
 };

--- a/controller/src/shared/command-builder.test.ts
+++ b/controller/src/shared/command-builder.test.ts
@@ -1,0 +1,418 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  appendExtraArguments,
+  appendLlamacppExtraArguments,
+  INTERNAL_EXTRA_ARG_KEYS,
+  INTERNAL_LLAMACPP_EXTRA_ARG_KEYS,
+  JSON_STRING_EXTRA_ARG_KEYS,
+} from "../../../shared/command-builder";
+import {
+  buildBackendCommand,
+  buildVllmCommand,
+  buildSglangCommand,
+  buildLlamacppCommand,
+  buildMlxCommand,
+} from "../modules/engines/process/backend-builder";
+import type { Config } from "../config/env";
+
+const normalizeJsonArgument = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeJsonArgument(item));
+  }
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.entries(record).map(([key, entry]) => [
+        key.replace(/-/g, "_"),
+        normalizeJsonArgument(entry),
+      ]),
+    );
+  }
+  return value;
+};
+
+const BACKEND_ONLY_INTERNAL_KEYS: ReadonlySet<string> = new Set([
+  "llama_bin",
+  "mlx_python",
+  "docker_container",
+  "docker_image",
+  "docker-container",
+]);
+
+const BACKEND_ONLY_LLAMACPP_INTERNAL_KEYS: ReadonlySet<string> = new Set([
+  "llama_bin",
+  "docker_container",
+  "docker_image",
+  "docker-container",
+]);
+
+describe("appendExtraArguments", () => {
+  test("emits string, number, boolean true, and boolean false values in argv mode", () => {
+    const args = appendExtraArguments(
+      [],
+      {
+        string_arg: "hello",
+        number_arg: 42,
+        bool_true: true,
+        bool_false: false,
+      },
+      { extraInternalKeys: BACKEND_ONLY_INTERNAL_KEYS },
+    );
+    expect(args).toEqual([
+      "--string-arg",
+      "hello",
+      "--number-arg",
+      "42",
+      "--bool-true",
+      "--bool-false",
+    ]);
+  });
+
+  test("skips the enable_expert_parallelism boolean-false exception", () => {
+    const args = appendExtraArguments(
+      [],
+      {
+        enable_expert_parallelism: false,
+        other_flag: false,
+      },
+      {
+        extraInternalKeys: BACKEND_ONLY_INTERNAL_KEYS,
+        falseBooleanExceptions: new Set(["enable_expert_parallelism"]),
+      },
+    );
+    expect(args).toEqual(["--other-flag"]);
+  });
+
+  test("serializes JSON-string extra args as parsed JSON", () => {
+    const args = appendExtraArguments(
+      [],
+      {
+        speculative_config: '{"method":"rejection"}',
+      },
+      { extraInternalKeys: BACKEND_ONLY_INTERNAL_KEYS, normalizeJson: normalizeJsonArgument },
+    );
+    expect(args).toEqual(["--speculative-config", JSON.stringify({ method: "rejection" })]);
+  });
+
+  test("falls back to the raw string when JSON-string parsing fails", () => {
+    const args = appendExtraArguments(
+      [],
+      {
+        speculative_config: "not-json",
+      },
+      { extraInternalKeys: BACKEND_ONLY_INTERNAL_KEYS, normalizeJson: normalizeJsonArgument },
+    );
+    expect(args).toEqual(["--speculative-config", "not-json"]);
+  });
+
+  test("serializes arrays and objects as a single JSON blob", () => {
+    const args = appendExtraArguments(
+      [],
+      {
+        lora_adapters: [{ name: "l1" }],
+        scalar: "plain",
+      },
+      { extraInternalKeys: BACKEND_ONLY_INTERNAL_KEYS, normalizeJson: normalizeJsonArgument },
+    );
+    expect(args).toEqual([
+      "--lora-adapters",
+      JSON.stringify([{ name: "l1" }]),
+      "--scalar",
+      "plain",
+    ]);
+  });
+
+  test("does not push empty strings in argv mode by default", () => {
+    const args = appendExtraArguments(
+      [],
+      { empty_string: "" },
+      { extraInternalKeys: BACKEND_ONLY_INTERNAL_KEYS },
+    );
+    expect(args).toEqual(["--empty-string", ""]);
+  });
+
+  test("shell-quoted mode wraps strings and JSON values for preview", () => {
+    const args = appendExtraArguments(
+      [],
+      {
+        string_arg: "hello",
+        speculative_config: '{"method":"rejection"}',
+        lora_adapters: [{ name: "l1" }],
+      },
+      { shellQuoting: true, skipEmptyString: true },
+    );
+    expect(args).toEqual([
+      "--string-arg hello",
+      `--speculative-config '${JSON.stringify({ method: "rejection" })}'`,
+      `--lora-adapters '${JSON.stringify([{ name: "l1" }])}'`,
+    ]);
+  });
+
+  test("filters shared internal keys", () => {
+    const args = appendExtraArguments(
+      [],
+      {
+        venv_path: "/env",
+        launch_command: "echo hi",
+        visible_arg: "yes",
+      },
+      { shellQuoting: true, skipEmptyString: true },
+    );
+    expect(args).toEqual(["--visible-arg yes"]);
+  });
+
+  test("filters backend-only internal keys", () => {
+    const args = appendExtraArguments(
+      [],
+      {
+        llama_bin: "/bin/llama-server",
+        docker_container: "foo",
+        visible_arg: "yes",
+      },
+      { extraInternalKeys: BACKEND_ONLY_INTERNAL_KEYS },
+    );
+    expect(args).toEqual(["--visible-arg", "yes"]);
+  });
+
+  test("dedupes flags already present in argv", () => {
+    const args = appendExtraArguments(
+      ["--visible-arg", "first"],
+      { visible_arg: "second" },
+      { extraInternalKeys: BACKEND_ONLY_INTERNAL_KEYS },
+    );
+    expect(args).toEqual(["--visible-arg", "first"]);
+  });
+
+  test("dedupes flags already present in shell-quoted combined args", () => {
+    const args = appendExtraArguments(
+      ["--visible-arg first"],
+      { visible_arg: "second" },
+      { shellQuoting: true, skipEmptyString: true },
+    );
+    expect(args).toEqual(["--visible-arg first"]);
+  });
+});
+
+describe("appendLlamacppExtraArguments", () => {
+  test("iterates arrays and skips boolean false", () => {
+    const args = appendLlamacppExtraArguments(
+      [],
+      {
+        tensor_split: [0.5, 0.5],
+        no_mmap: false,
+        ctx_size: 4096,
+      },
+      { extraInternalKeys: BACKEND_ONLY_LLAMACPP_INTERNAL_KEYS, skipEmptyString: true },
+    );
+    expect(args).toEqual([
+      "--tensor-split",
+      "0.5",
+      "--tensor-split",
+      "0.5",
+      "--ctx-size",
+      "4096",
+    ]);
+  });
+
+  test("serializes objects as JSON", () => {
+    const args = appendLlamacppExtraArguments(
+      [],
+      { sampling_json: { temperature: 0.5 } },
+      { extraInternalKeys: BACKEND_ONLY_LLAMACPP_INTERNAL_KEYS, skipEmptyString: true },
+    );
+    expect(args).toEqual(["--sampling-json", JSON.stringify({ temperature: 0.5 })]);
+  });
+
+  test("shell-quoted mode emits combined flag-value strings", () => {
+    const args = appendLlamacppExtraArguments(
+      [],
+      {
+        tensor_split: [0.5, 0.5],
+        sampling_json: { temperature: 0.5 },
+        ctx_size: 4096,
+      },
+      {
+        extraInternalKeys: BACKEND_ONLY_LLAMACPP_INTERNAL_KEYS,
+        shellQuoting: true,
+        skipEmptyString: true,
+      },
+    );
+    expect(args).toEqual([
+      "--tensor-split 0.5",
+      "--tensor-split 0.5",
+      `--sampling-json '${JSON.stringify({ temperature: 0.5 })}'`,
+      "--ctx-size 4096",
+    ]);
+  });
+
+  test("filters shared and backend-only internal keys", () => {
+    const args = appendLlamacppExtraArguments(
+      [],
+      {
+        venv_path: "/env",
+        llama_bin: "/bin/llama-server",
+        visible_arg: "yes",
+      },
+      { extraInternalKeys: BACKEND_ONLY_LLAMACPP_INTERNAL_KEYS, skipEmptyString: true },
+    );
+    expect(args).toEqual(["--visible-arg", "yes"]);
+  });
+
+  test("skips empty strings when requested", () => {
+    const args = appendLlamacppExtraArguments(
+      [],
+      { tensor_split: ["", "0.5"], empty: "" },
+      { extraInternalKeys: BACKEND_ONLY_LLAMACPP_INTERNAL_KEYS, skipEmptyString: true },
+    );
+    expect(args).toEqual(["--tensor-split", "0.5"]);
+  });
+});
+
+describe("exported key tables", () => {
+  test("JSON_STRING_EXTRA_ARG_KEYS contains the known JSON-string keys", () => {
+    expect(JSON_STRING_EXTRA_ARG_KEYS["speculative_config"]).toBe(true);
+    expect(JSON_STRING_EXTRA_ARG_KEYS["default_chat_template_kwargs"]).toBe(true);
+  });
+
+  test("INTERNAL_EXTRA_ARG_KEYS contains the frontend/backend common vllm/sglang keys", () => {
+    expect(INTERNAL_EXTRA_ARG_KEYS["launch_command"]).toBe(true);
+    expect(INTERNAL_EXTRA_ARG_KEYS["custom_command"]).toBe(true);
+    expect(INTERNAL_EXTRA_ARG_KEYS["llama_bin"]).toBeUndefined();
+  });
+
+  test("INTERNAL_LLAMACPP_EXTRA_ARG_KEYS contains the common llama.cpp keys", () => {
+    expect(INTERNAL_LLAMACPP_EXTRA_ARG_KEYS["status"]).toBe(true);
+    expect(INTERNAL_LLAMACPP_EXTRA_ARG_KEYS["llama_bin"]).toBeUndefined();
+  });
+});
+
+const minimalConfig: Config = {
+  host: "127.0.0.1",
+  port: 8000,
+  inference_host: "127.0.0.1",
+  inference_port: 8001,
+  data_dir: "/tmp",
+  db_path: "/tmp/test.db",
+  models_dir: "/tmp/models",
+  strict_openai_models: false,
+  providers: [],
+};
+
+const baseRecipe = {
+  id: "test" as never,
+  name: "Test",
+  model_path: "/models/model",
+  env_vars: null,
+  tensor_parallel_size: 1,
+  pipeline_parallel_size: 1,
+  max_model_len: 4096,
+  gpu_memory_utilization: 0.9,
+  kv_cache_dtype: "auto",
+  max_num_seqs: 256,
+  trust_remote_code: false,
+  tool_call_parser: null,
+  reasoning_parser: null,
+  enable_auto_tool_choice: false,
+  quantization: null,
+  dtype: null,
+  host: "0.0.0.0",
+  port: 8000,
+  served_model_name: null,
+  python_path: null,
+  extra_args: {
+    string_arg: "hello",
+    number_arg: 42,
+    bool_true: true,
+    bool_false: false,
+    speculative_config: '{"method":"rejection"}',
+    lora_adapters: [{ name: "l1" }],
+    internal_key: "hidden",
+  },
+  max_thinking_tokens: null,
+  thinking_mode: "conservative",
+};
+
+describe("shared serializer parity with backend-builder", () => {
+  test("vllm shared args are contained in the built command", () => {
+    const recipe = { ...baseRecipe, backend: "vllm" as never };
+    const command = buildVllmCommand(recipe);
+    const shared = appendExtraArguments(
+      [],
+      recipe.extra_args,
+      {
+        extraInternalKeys: BACKEND_ONLY_INTERNAL_KEYS,
+        normalizeJson: normalizeJsonArgument,
+        falseBooleanExceptions: new Set(["enable_expert_parallelism"]),
+      },
+    );
+    for (const arg of shared) {
+      expect(command).toContain(arg);
+    }
+  });
+
+  test("sglang shared args are contained in the built command", () => {
+    const recipe = { ...baseRecipe, backend: "sglang" as never };
+    const command = buildSglangCommand(recipe, minimalConfig);
+    const shared = appendExtraArguments(
+      [],
+      recipe.extra_args,
+      {
+        extraInternalKeys: BACKEND_ONLY_INTERNAL_KEYS,
+        normalizeJson: normalizeJsonArgument,
+        falseBooleanExceptions: new Set(["enable_expert_parallelism"]),
+      },
+    );
+    for (const arg of shared) {
+      expect(command).toContain(arg);
+    }
+  });
+
+  test("llamacpp shared args are contained in the built command", () => {
+    const recipe = { ...baseRecipe, backend: "llamacpp" as never };
+    const command = buildLlamacppCommand(recipe, minimalConfig);
+    const shared = appendLlamacppExtraArguments(
+      [],
+      recipe.extra_args,
+      {
+        extraInternalKeys: BACKEND_ONLY_LLAMACPP_INTERNAL_KEYS,
+        skipEmptyString: true,
+      },
+    );
+    for (const arg of shared) {
+      expect(command).toContain(arg);
+    }
+  });
+
+  test("mlx shared args are contained in the built command", () => {
+    const recipe = { ...baseRecipe, backend: "mlx" as never };
+    const command = buildMlxCommand(recipe, minimalConfig);
+    const shared = appendExtraArguments(
+      [],
+      recipe.extra_args,
+      {
+        extraInternalKeys: BACKEND_ONLY_INTERNAL_KEYS,
+        normalizeJson: normalizeJsonArgument,
+        falseBooleanExceptions: new Set(["enable_expert_parallelism"]),
+      },
+    );
+    for (const arg of shared) {
+      expect(command).toContain(arg);
+    }
+  });
+
+  test("buildBackendCommand uses the shared extra-args logic for launch overrides", () => {
+    const recipe = {
+      ...baseRecipe,
+      backend: "vllm" as never,
+      extra_args: {
+        ...baseRecipe.extra_args,
+        launch_command: 'echo "override"',
+      },
+    };
+    process.env["VLLM_STUDIO_ALLOW_CUSTOM_LAUNCH_COMMAND"] = "true";
+    const command = buildBackendCommand(recipe, minimalConfig);
+    delete process.env["VLLM_STUDIO_ALLOW_CUSTOM_LAUNCH_COMMAND"];
+    expect(command).toEqual(["echo", "override"]);
+  });
+});

--- a/frontend/src/features/recipes/recipe-command.ts
+++ b/frontend/src/features/recipes/recipe-command.ts
@@ -1,124 +1,16 @@
+import type { Recipe } from "@/lib/types";
 import type { RecipeEditor } from "./recipe-editor";
 import { normalizeExtraArgKey } from "./extra-args";
 import { prepareRecipeForSave } from "./prepare-recipe";
-
-const appendExtraArgsToCommand = (args: string[], extraArgs: Record<string, unknown>): string[] => {
-  const internalKeys = new Set([
-    "venv_path",
-    "env_vars",
-    "visible_devices",
-    "cuda_visible_devices",
-    "hip_visible_devices",
-    "rocr_visible_devices",
-    "description",
-    "tags",
-    "status",
-    "launch_command",
-    "custom_command",
-  ]);
-  const jsonStringKeys = new Set(["speculative_config", "default_chat_template_kwargs"]);
-  const existingFlags = new Set(
-    args.flatMap((line) => line.split(" ").filter((part) => part.startsWith("--"))),
-  );
-
-  for (const [key, value] of Object.entries(extraArgs)) {
-    const normalizedKey = normalizeExtraArgKey(key);
-    if (internalKeys.has(normalizedKey)) continue;
-
-    const flag = `--${key.replace(/_/g, "-")}`;
-    if (existingFlags.has(flag)) continue;
-
-    if (value === true || value === false) {
-      args.push(flag);
-      existingFlags.add(flag);
-      continue;
-    }
-    if (value === undefined || value === null || value === "") continue;
-
-    if (typeof value === "string" && jsonStringKeys.has(normalizedKey)) {
-      const trimmed = value.trim();
-      if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
-        try {
-          const parsed = JSON.parse(trimmed) as unknown;
-          args.push(`${flag} '${JSON.stringify(parsed)}'`);
-          existingFlags.add(flag);
-          continue;
-        } catch {
-          args.push(`${flag} '${value}'`);
-          existingFlags.add(flag);
-          continue;
-        }
-      }
-    }
-
-    if (Array.isArray(value) || (value && typeof value === "object")) {
-      args.push(`${flag} '${JSON.stringify(value)}'`);
-      existingFlags.add(flag);
-      continue;
-    }
-
-    args.push(`${flag} ${value}`);
-    existingFlags.add(flag);
-  }
-
-  return args;
-};
+import {
+  appendExtraArguments,
+  appendLlamacppExtraArguments,
+} from "../../../../shared/command-builder";
 
 const hasExtraArgument = (extraArgs: Record<string, unknown>, key: string): boolean => {
   const normalized = normalizeExtraArgKey(key);
   return Object.keys(extraArgs).some((entry) => normalizeExtraArgKey(entry) === normalized);
 };
-
-const appendLlamacppArgsToCommand = (
-  args: string[],
-  extraArgs: Record<string, unknown>,
-): string[] => {
-  const internalKeys = new Set([
-    "venv_path",
-    "env_vars",
-    "visible_devices",
-    "cuda_visible_devices",
-    "hip_visible_devices",
-    "rocr_visible_devices",
-    "description",
-    "tags",
-    "status",
-  ]);
-
-  for (const [key, value] of Object.entries(extraArgs)) {
-    const normalizedKey = normalizeExtraArgKey(key);
-    if (internalKeys.has(normalizedKey)) continue;
-
-    const flag = `--${key.replace(/_/g, "-")}`;
-    if (args.some((entry) => entry.startsWith(flag))) continue;
-
-    if (value === true) {
-      args.push(flag);
-      continue;
-    }
-    if (value === false) continue;
-    if (value === undefined || value === null || value === "") continue;
-
-    if (Array.isArray(value)) {
-      for (const entry of value) {
-        if (entry === undefined || entry === null || entry === "") continue;
-        args.push(`${flag} ${entry}`);
-      }
-      continue;
-    }
-
-    if (typeof value === "object") {
-      args.push(`${flag} '${JSON.stringify(value)}'`);
-      continue;
-    }
-
-    args.push(`${flag} ${value}`);
-  }
-
-  return args;
-};
-
-type RecipeCommandPayload = ReturnType<typeof prepareRecipeForSave>;
 
 export const generateCommand = (
   recipe: RecipeEditor,
@@ -161,7 +53,7 @@ function appendModelArgument(args: string[], backend: string, modelPath?: string
   else args.push(modelPath);
 }
 
-function appendNetworkArguments(args: string[], backend: string, payload: RecipeCommandPayload) {
+function appendNetworkArguments(args: string[], backend: string, payload: Recipe) {
   if (payload.host && payload.host !== "0.0.0.0") args.push(`--host ${payload.host}`);
   if (payload.port && payload.port !== 8000) args.push(`--port ${payload.port}`);
   if (payload.served_model_name && backend !== "mlx") {
@@ -173,7 +65,7 @@ function appendNetworkArguments(args: string[], backend: string, payload: Recipe
   }
 }
 
-function appendParallelArguments(args: string[], backend: string, payload: RecipeCommandPayload) {
+function appendParallelArguments(args: string[], backend: string, payload: Recipe) {
   if (backend === "llamacpp" || backend === "mlx") return;
   if (payload.tensor_parallel_size && payload.tensor_parallel_size > 1) {
     args.push(`--tensor-parallel-size ${payload.tensor_parallel_size}`);
@@ -183,7 +75,7 @@ function appendParallelArguments(args: string[], backend: string, payload: Recip
   }
 }
 
-function appendContextArguments(args: string[], backend: string, payload: RecipeCommandPayload) {
+function appendContextArguments(args: string[], backend: string, payload: Recipe) {
   const ctxOverride = payload.extra_args?.["ctx-size"] ?? payload.extra_args?.["ctx_size"];
   if (backend === "llamacpp") {
     if (!ctxOverride && payload.max_model_len) args.push(`--ctx-size ${payload.max_model_len}`);
@@ -216,20 +108,22 @@ function appendContextArguments(args: string[], backend: string, payload: Recipe
   }
 }
 
-function appendBackendSpecificArguments(
-  args: string[],
-  backend: string,
-  payload: RecipeCommandPayload,
-) {
+function appendBackendSpecificArguments(args: string[], backend: string, payload: Recipe) {
   if (backend === "llamacpp" || backend === "mlx") {
-    appendLlamacppArgsToCommand(args, payload.extra_args ?? {});
+    appendLlamacppExtraArguments(args, payload.extra_args ?? {}, {
+      shellQuoting: true,
+      skipEmptyString: true,
+    });
     return;
   }
   appendRuntimeOptions(args, backend, payload);
-  appendExtraArgsToCommand(args, payload.extra_args ?? {});
+  appendExtraArguments(args, payload.extra_args ?? {}, {
+    shellQuoting: true,
+    skipEmptyString: true,
+  });
 }
 
-function appendRuntimeOptions(args: string[], backend: string, payload: RecipeCommandPayload) {
+function appendRuntimeOptions(args: string[], backend: string, payload: Recipe) {
   if (payload.quantization) args.push(`--quantization ${payload.quantization}`);
   if (payload.dtype && payload.dtype !== "auto") args.push(`--dtype ${payload.dtype}`);
   if (payload.trust_remote_code) args.push("--trust-remote-code");
@@ -240,7 +134,7 @@ function appendRuntimeOptions(args: string[], backend: string, payload: RecipeCo
   }
 }
 
-function appendToolOptions(args: string[], backend: string, payload: RecipeCommandPayload) {
+function appendToolOptions(args: string[], backend: string, payload: Recipe) {
   if (payload.tool_call_parser) {
     args.push(`--tool-call-parser ${payload.tool_call_parser}`);
     if (backend !== "sglang") args.push("--enable-auto-tool-choice");

--- a/shared/command-builder.ts
+++ b/shared/command-builder.ts
@@ -1,0 +1,263 @@
+/**
+ * Shared command serialization helpers for recipe launch-command construction.
+ *
+ * This module intentionally contains ONLY the duplicated extra-args iteration
+ * cores (internal-key filtering, JSON-string handling, boolean/array/object
+ * emission). Per-side behavior that differs (shell quoting vs argv elements,
+ * JSON-key normalization, backend-only internal keys, boolean-false
+ * exceptions) is controlled by options so that emitted flags stay
+ * byte-identical.
+ *
+ * The key normalizer here is snake_case, matching the existing frontend
+ * (`extra-args.ts`) and controller (`backend-builder.ts`) internal-key lookup.
+ * It is deliberately NOT the kebab-case `normalizeEngineArgKey` in
+ * `shared/contracts/engine-args.ts`; using the kebab-case normalizer would not
+ * change any emitted flag, but it would be an unnecessary behavioral shift in
+ * the lookup layer.
+ */
+
+/** Internal keys filtered for the vLLM/SGLang extra-args loop. */
+export const INTERNAL_EXTRA_ARG_KEYS: Readonly<Record<string, true>> = {
+  venv_path: true,
+  env_vars: true,
+  visible_devices: true,
+  cuda_visible_devices: true,
+  hip_visible_devices: true,
+  rocr_visible_devices: true,
+  description: true,
+  tags: true,
+  status: true,
+  launch_command: true,
+  custom_command: true,
+};
+
+/** Internal keys filtered for the llama.cpp extra-args loop. */
+export const INTERNAL_LLAMACPP_EXTRA_ARG_KEYS: Readonly<Record<string, true>> = {
+  venv_path: true,
+  env_vars: true,
+  visible_devices: true,
+  cuda_visible_devices: true,
+  hip_visible_devices: true,
+  rocr_visible_devices: true,
+  description: true,
+  tags: true,
+  status: true,
+};
+
+/** Extra-arg keys whose string values are parsed as JSON before emission. */
+export const JSON_STRING_EXTRA_ARG_KEYS: Readonly<Record<string, true>> = {
+  speculative_config: true,
+  default_chat_template_kwargs: true,
+};
+
+export interface AppendExtraArgsOptions {
+  /** Additional keys to treat as internal/filtered beyond the shared base set. */
+  extraInternalKeys?: ReadonlySet<string>;
+  /** If `true` (default), boolean `false` values emit the flag. */
+  emitFalseBooleans?: boolean;
+  /** Normalized internal keys for which boolean `false` must NOT emit the flag. */
+  falseBooleanExceptions?: ReadonlySet<string>;
+  /** If `true`, emit values as shell-quoted single strings for preview. */
+  shellQuoting?: boolean;
+  /** Optional JSON-value normalizer (controller uses `normalizeJsonArgument`). */
+  normalizeJson?: (value: unknown) => unknown;
+  /** If `true`, skip empty string values. */
+  skipEmptyString?: boolean;
+}
+
+/**
+ * Append vLLM/SGLang-style extra arguments to an existing arg list.
+ *
+ * Arrays and objects are emitted as a single JSON blob. Boolean `false` emits
+ * the flag by default (matching current controller behavior), except for keys
+ * listed in `falseBooleanExceptions`.
+ */
+export const appendExtraArguments = (
+  args: string[],
+  extraArgs: Record<string, unknown>,
+  options: AppendExtraArgsOptions = {},
+): string[] => {
+  const {
+    extraInternalKeys,
+    emitFalseBooleans = true,
+    falseBooleanExceptions = new Set<string>(),
+    shellQuoting = false,
+    normalizeJson,
+    skipEmptyString = false,
+  } = options;
+
+  const hasFlag = shellQuoting
+    ? (flag: string): boolean => {
+        const existingFlags = new Set(
+          args
+            .flatMap((line) => line.split(" "))
+            .filter((part) => part.startsWith("--")),
+        );
+        return existingFlags.has(flag);
+      }
+    : (flag: string): boolean => args.includes(flag);
+
+  for (const [key, value] of Object.entries(extraArgs)) {
+    const normalizedKey = key.replace(/-/g, "_").toLowerCase();
+    if (INTERNAL_EXTRA_ARG_KEYS[normalizedKey]) {
+      continue;
+    }
+    if (extraInternalKeys?.has(normalizedKey)) {
+      continue;
+    }
+
+    const flag = `--${key.replace(/_/g, "-")}`;
+    if (hasFlag(flag)) {
+      continue;
+    }
+
+    if (value === true) {
+      args.push(flag);
+      continue;
+    }
+
+    if (value === false) {
+      if (emitFalseBooleans && !falseBooleanExceptions.has(normalizedKey)) {
+        args.push(flag);
+      }
+      continue;
+    }
+
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    if (skipEmptyString && value === "") {
+      continue;
+    }
+
+    if (
+      typeof value === "string" &&
+      JSON_STRING_EXTRA_ARG_KEYS[normalizedKey]
+    ) {
+      const trimmed = value.trim();
+      if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+        try {
+          const parsed = JSON.parse(trimmed) as unknown;
+          const normalized = normalizeJson ? normalizeJson(parsed) : parsed;
+          pushQuoted(args, flag, JSON.stringify(normalized), shellQuoting);
+          continue;
+        } catch {
+          pushQuoted(args, flag, value, shellQuoting);
+          continue;
+        }
+      }
+    }
+
+    if (Array.isArray(value) || (value && typeof value === "object")) {
+      const normalized = normalizeJson ? normalizeJson(value) : value;
+      pushQuoted(args, flag, JSON.stringify(normalized), shellQuoting);
+      continue;
+    }
+
+    pushUnquoted(args, flag, String(value), shellQuoting);
+  }
+
+  return args;
+};
+
+/**
+ * Append llama.cpp-style extra arguments to an existing arg list.
+ *
+ * Arrays are iterated and each non-empty element is emitted separately.
+ * Boolean `false` is always skipped (matching both frontend and controller
+ * llama.cpp behavior).
+ */
+export const appendLlamacppExtraArguments = (
+  args: string[],
+  extraArgs: Record<string, unknown>,
+  options: AppendExtraArgsOptions = {},
+): string[] => {
+  const { extraInternalKeys, shellQuoting = false, skipEmptyString = false } =
+    options;
+
+  const hasFlag = shellQuoting
+    ? (flag: string): boolean => args.some((entry) => entry.startsWith(flag))
+    : (flag: string): boolean => args.includes(flag);
+
+  for (const [key, value] of Object.entries(extraArgs)) {
+    const normalizedKey = key.replace(/-/g, "_").toLowerCase();
+    if (INTERNAL_LLAMACPP_EXTRA_ARG_KEYS[normalizedKey]) {
+      continue;
+    }
+    if (extraInternalKeys?.has(normalizedKey)) {
+      continue;
+    }
+
+    const flag = `--${key.replace(/_/g, "-")}`;
+    if (hasFlag(flag)) {
+      continue;
+    }
+
+    if (value === true) {
+      args.push(flag);
+      continue;
+    }
+
+    if (value === false) {
+      continue;
+    }
+
+    if (
+      value === undefined ||
+      value === null ||
+      (skipEmptyString && value === "")
+    ) {
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        if (
+          entry === undefined ||
+          entry === null ||
+          (skipEmptyString && entry === "")
+        ) {
+          continue;
+        }
+        pushUnquoted(args, flag, String(entry), shellQuoting);
+      }
+      continue;
+    }
+
+    if (typeof value === "object") {
+      pushQuoted(args, flag, JSON.stringify(value), shellQuoting);
+      continue;
+    }
+
+    pushUnquoted(args, flag, String(value), shellQuoting);
+  }
+
+  return args;
+};
+
+const pushQuoted = (
+  args: string[],
+  flag: string,
+  value: string,
+  shellQuoting: boolean,
+): void => {
+  if (shellQuoting) {
+    args.push(`${flag} '${value}'`);
+  } else {
+    args.push(flag, value);
+  }
+};
+
+const pushUnquoted = (
+  args: string[],
+  flag: string,
+  value: string,
+  shellQuoting: boolean,
+): void => {
+  if (shellQuoting) {
+    args.push(`${flag} ${value}`);
+  } else {
+    args.push(flag, value);
+  }
+};


### PR DESCRIPTION
## Summary
Extract the byte-identical launch-command extra-args logic that was duplicated between the frontend recipe preview and the controller launch builder into a single `shared/command-builder.ts`. Behavior-preserving.

## Changes
- New `shared/command-builder.ts`: internal-key sets, JSON-string keys, and the extra-args serialization, parameterized per-side via an options object (false-boolean handling, shell quoting, JSON normalization).
- `controller/src/modules/engines/process/backend-builder.ts` and `frontend/src/features/recipes/recipe-command.ts` consume it. Divergent / security behavior is kept per-side (model-runtime-default heuristics, `VLLM_STUDIO_ALLOW_CUSTOM_LAUNCH_COMMAND` env-gating, binary path resolution, the `enable_expert_parallelism` false-exception).

## Verification
- Before/after equivalence check: emitted launch argv is **byte-identical** across representative recipes (string / number / array / object / JSON-string `speculative_config` / boolean values, internal-key filtering, the `enable_expert_parallelism` exception, `llama_bin` security rejection, empty strings).
- `cd controller && bun run typecheck` → clean; `bun test src/shared/command-builder.test.ts` → 24 pass; frontend `typecheck` + `build` → clean.

## Non-goals
- No dry-run endpoint; the preview stays offline/string-formatted exactly as before.
