### PR TITLE
feat(agent): capability registry + read-only /capabilities view

### DIFF
--- a/frontend/src/app/capabilities/page.tsx
+++ b/frontend/src/app/capabilities/page.tsx
@@ -1,0 +1,5 @@
+import { CapabilitiesPage } from "@/features/capabilities/capabilities-page";
+
+export default function CapabilitiesRoute() {
+  return <CapabilitiesPage />;
+}

--- a/frontend/src/features/agent/capabilities/adapters.ts
+++ b/frontend/src/features/agent/capabilities/adapters.ts
@@ -1,0 +1,110 @@
+/**
+ * Pure read-only adapters that map existing scattered capability definitions
+ * into the unified `CapabilityEntry` view type.
+ *
+ * These adapters DO NOT change how any of the source definitions are registered
+ * or consumed. They are a read-only projection layer (Phase 0).
+ */
+
+import type { McpCatalogueEntry, McpServerEntry } from "@/features/agent/mcp/types";
+import type { SkillRow } from "@/features/agent/skill-discovery";
+import type { PromptTemplateRow } from "@/features/agent/prompt-templates-store";
+import type { CapabilityEntry, CollisionEntry, CapabilityProvenance } from "./types";
+
+/**
+ * Adapt curated MCP catalogue entries into CapabilityEntry[].
+ */
+export function adaptMcpCatalogue(entries: McpCatalogueEntry[]): CapabilityEntry[] {
+  return entries.map((entry) => ({
+    id: entry.id,
+    label: entry.displayName ?? entry.name,
+    description: entry.description ?? "",
+    kind: "mcp" as const,
+    provenance: {
+      source: "mcp-catalogue" as const,
+      catalogueId: entry.id,
+    },
+    isAvailable: () => null,
+  }));
+}
+
+/**
+ * Adapt user-added / stored MCP server entries into CapabilityEntry[].
+ */
+export function adaptStoredServers(entries: McpServerEntry[]): CapabilityEntry[] {
+  return entries.map((entry) => ({
+    id: entry.def.id,
+    label: entry.def.displayName ?? entry.def.name,
+    description: entry.def.description ?? "",
+    kind: "mcp" as const,
+    provenance: {
+      source: "mcp-server" as const,
+      serverId: entry.def.id,
+      serverName: entry.def.name,
+    },
+    isAvailable: () => (entry.enabled ? null : "server disabled"),
+  }));
+}
+
+/**
+ * Adapt discovered skills into CapabilityEntry[].
+ */
+export function adaptSkills(rows: SkillRow[]): CapabilityEntry[] {
+  return rows.map((row) => ({
+    id: row.id,
+    label: row.name,
+    description: `Skill from ${row.source}`,
+    kind: "skill" as const,
+    provenance: {
+      source: "skill" as const,
+      skillId: row.id,
+      skillPath: row.path,
+    },
+    isAvailable: () => null,
+  }));
+}
+
+/**
+ * Adapt discovered prompt templates into CapabilityEntry[].
+ */
+export function adaptPromptTemplates(rows: PromptTemplateRow[]): CapabilityEntry[] {
+  return rows.map((row) => ({
+    id: row.id,
+    label: row.name,
+    description: row.description ?? `Template from ${row.source}`,
+    kind: "template" as const,
+    provenance: {
+      source: "template" as const,
+      templateId: row.id,
+      templatePath: row.path,
+    },
+    isAvailable: () => null,
+  }));
+}
+
+/**
+ * Detect duplicate ids across multiple sets of CapabilityEntry arrays.
+ * Returns only the collisions (ids shared by 2+ entries from different provenance sources).
+ */
+export function detectCollisions(...entrySets: CapabilityEntry[][]): CollisionEntry[] {
+  const byId = new Map<string, Array<{ provenance: CapabilityProvenance; label: string }>>();
+
+  for (const entries of entrySets) {
+    for (const entry of entries) {
+      const existing = byId.get(entry.id);
+      if (existing) {
+        existing.push({ provenance: entry.provenance, label: entry.label });
+      } else {
+        byId.set(entry.id, [{ provenance: entry.provenance, label: entry.label }]);
+      }
+    }
+  }
+
+  const collisions: CollisionEntry[] = [];
+  for (const [id, entries] of byId) {
+    if (entries.length > 1) {
+      collisions.push({ id, entries });
+    }
+  }
+  return collisions;
+}

--- a/frontend/src/features/agent/capabilities/index.ts
+++ b/frontend/src/features/agent/capabilities/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Capability registry — Phase 0 read-only adapters.
+ *
+ * Re-exports the unified CapabilityEntry view type and pure adapter functions
+ * that project existing scattered definitions (MCP catalogue, stored servers,
+ * skills, prompt templates) into CapabilityEntry[].
+ */
+
+export type { CapabilityEntry, CapabilityProvenance, CollisionEntry } from "./types";
+
+export {
+  adaptMcpCatalogue,
+  adaptStoredServers,
+  adaptSkills,
+  adaptPromptTemplates,
+  detectCollisions,
+} from "./adapters";

--- a/frontend/src/features/agent/capabilities/registry.ts
+++ b/frontend/src/features/agent/capabilities/registry.ts
@@ -1,0 +1,126 @@
+/**
+ * Capability registry — Phase 1: in-memory registry with shadow-rejection.
+ *
+ * This is a parallel layer that does NOT rewire existing MCP/skill/plugin/prompt
+ * consumers. It can be adopted incrementally by existing surfaces later.
+ */
+
+import type { CapabilityEntry, CapabilityProvenance } from "./types";
+
+/** Structured result of a registration attempt. */
+export type RegistrationResult =
+  | { status: "registered"; entry: CapabilityEntry }
+  | {
+      status: "rejected";
+      reason: string;
+      incoming: CapabilityEntry;
+      existing: CapabilityEntry;
+    }
+  | {
+      status: "overridden";
+      entry: CapabilityEntry;
+      previous: CapabilityEntry;
+    };
+
+export interface RegistrationOptions {
+  /** Explicit opt-in to replacing an existing entry with the same id. */
+  override?: boolean;
+}
+
+/** A recorded shadow-rejection or override event. */
+export interface CollisionEvent {
+  id: string;
+  action: "rejected" | "overridden";
+  incoming: CapabilityProvenance;
+  existing: CapabilityProvenance;
+  timestamp: number;
+}
+
+export class CapabilityRegistry {
+  private entries = new Map<string, CapabilityEntry>();
+  private collisionLog: CollisionEvent[] = [];
+
+  /**
+   * Register a single capability entry.
+   *
+   * Shadow-REJECT on id collision unless `override: true` is passed.
+   * On reject, the existing entry is kept and a structured result is returned
+   * (no throw, no crash).
+   */
+  register(entry: CapabilityEntry, options: RegistrationOptions = {}): RegistrationResult {
+    const existing = this.entries.get(entry.id);
+
+    if (!existing) {
+      this.entries.set(entry.id, entry);
+      return { status: "registered", entry };
+    }
+
+    // Shadow-rejection: same id, no explicit override
+    if (!options.override) {
+      this.collisionLog.push({
+        id: entry.id,
+        action: "rejected",
+        incoming: entry.provenance,
+        existing: existing.provenance,
+        timestamp: Date.now(),
+      });
+      return {
+        status: "rejected",
+        reason: `Capability "${entry.id}" is already registered.`,
+        incoming: entry,
+        existing,
+      };
+    }
+
+    // Explicit override: allowed, but logged
+    this.collisionLog.push({
+      id: entry.id,
+      action: "overridden",
+      incoming: entry.provenance,
+      existing: existing.provenance,
+      timestamp: Date.now(),
+    });
+    this.entries.set(entry.id, entry);
+    return { status: "overridden", entry, previous: existing };
+  }
+
+  /** Register multiple entries in order. */
+  registerAll(entries: CapabilityEntry[], options: RegistrationOptions = {}): RegistrationResult[] {
+    return entries.map((entry) => this.register(entry, options));
+  }
+
+  /** Look up an entry by id. */
+  get(id: string): CapabilityEntry | undefined {
+    return this.entries.get(id);
+  }
+
+  /** Check whether an id is registered. */
+  has(id: string): boolean {
+    return this.entries.has(id);
+  }
+
+  /** All registered entries. */
+  list(): CapabilityEntry[] {
+    return Array.from(this.entries.values());
+  }
+
+  /** All recorded shadow-rejection and override events. */
+  collisions(): CollisionEvent[] {
+    return [...this.collisionLog];
+  }
+
+  /**
+   * Build a registry from one or more adapter outputs (Phase 0 style).
+   * Entries are registered in order; collisions are recorded and returned.
+   */
+  static fromSources(...adapterOutputs: CapabilityEntry[][]): {
+    registry: CapabilityRegistry;
+    collisions: CollisionEvent[];
+  } {
+    const registry = new CapabilityRegistry();
+    for (const entries of adapterOutputs) {
+      registry.registerAll(entries);
+    }
+    return { registry, collisions: registry.collisions() };
+  }
+}

--- a/frontend/src/features/agent/capabilities/types.ts
+++ b/frontend/src/features/agent/capabilities/types.ts
@@ -1,0 +1,53 @@
+/**
+ * Unified capability registry types (Phase 0 — read-only adapters).
+ *
+ * Every action the system can perform — built-in tools, MCP-provided tools,
+ * skills, prompt templates — can be represented as a `CapabilityEntry`.
+ * Phase 0 only reads from existing sources via thin adapters; it does NOT
+ * change how any of those definitions are registered or consumed.
+ */
+
+/**
+ * Tracks the origin of a capability entry so the registry can detect
+ * collisions and enforce shadow-rejection in later phases.
+ */
+export type CapabilityProvenance =
+  | { source: "builtin"; module: string }
+  | { source: "mcp-catalogue"; catalogueId: string }
+  | { source: "mcp-server"; serverId: string; serverName: string }
+  | { source: "skill"; skillId: string; skillPath: string }
+  | { source: "template"; templateId: string; templatePath: string };
+
+/**
+ * A single entry in the unified capability registry (read-only view).
+ *
+ * Phase 0 keeps this intentionally minimal: id, label, description, kind,
+ * provenance, and an availability check. The full `CapabilityEntry` shape
+ * from the design doc (inputSchema, permission, handler, ui, timeline) is
+ * deferred to Phase 1 when the registry gains write ownership.
+ */
+export interface CapabilityEntry {
+  /** Globally unique, stable id. Format: "<namespace>:<name>". */
+  id: string;
+  /** Human-readable short label for UI. */
+  label: string;
+  /** One-line description for tooltips and help panels. */
+  description: string;
+  /** Semantic kind for grouping and timeline rendering. */
+  kind: "mcp" | "skill" | "template" | "builtin";
+  /** Where this capability came from. */
+  provenance: CapabilityProvenance;
+  /**
+   * Runtime availability check. Returns a reason string if unavailable,
+   * or null if available. Phase 0: always returns null (always available).
+   */
+  isAvailable: () => string | null;
+}
+
+/** Result of a collision/provenance check. */
+export interface CollisionEntry {
+  /** The colliding id. */
+  id: string;
+  /** All entries that share this id. */
+  entries: Array<{ provenance: CapabilityProvenance; label: string }>;
+}

--- a/frontend/src/features/capabilities/capabilities-page.tsx
+++ b/frontend/src/features/capabilities/capabilities-page.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { useCallback } from "react";
+import {
+  AlertTriangle,
+  CheckCircle,
+  HelpCircle,
+  Layers,
+  Plug,
+  FileText,
+  Puzzle,
+  RefreshCw,
+  XCircle,
+} from "lucide-react";
+import type { CapabilityEntry, CapabilityProvenance } from "@/features/agent/capabilities/types";
+import type { CollisionEvent } from "@/features/agent/capabilities/registry";
+import { useCapabilitiesRegistry, type GroupedCapabilities } from "./use-capabilities-registry";
+
+function provenanceLabel(p: CapabilityProvenance): string {
+  switch (p.source) {
+    case "builtin":
+      return `builtin:${p.module}`;
+    case "mcp-catalogue":
+      return `catalogue:${p.catalogueId}`;
+    case "mcp-server":
+      return `server:${p.serverName}`;
+    case "skill":
+      return `skill:${p.skillId}`;
+    case "template":
+      return `template:${p.templateId}`;
+  }
+}
+
+function sourceIcon(source: CapabilityEntry["provenance"]["source"]) {
+  switch (source) {
+    case "mcp-catalogue":
+      return Plug;
+    case "mcp-server":
+      return Layers;
+    case "skill":
+      return Puzzle;
+    case "template":
+      return FileText;
+    default:
+      return HelpCircle;
+  }
+}
+
+function AvailabilityBadge({ entry }: { entry: CapabilityEntry }) {
+  const reason = entry.isAvailable();
+  if (reason === null) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-green-500/10 px-2 py-0.5 text-[10px] font-medium text-green-600 dark:text-green-400">
+        <CheckCircle className="h-3 w-3" />
+        Available
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full bg-yellow-500/10 px-2 py-0.5 text-[10px] font-medium text-yellow-600 dark:text-yellow-400"
+      title={reason}
+    >
+      <AlertTriangle className="h-3 w-3" />
+      {reason}
+    </span>
+  );
+}
+
+function CollisionCard({ event }: { event: CollisionEvent }) {
+  const isIncomingRejected = event.action === "rejected";
+  return (
+    <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-3">
+      <div className="flex items-start gap-2">
+        <XCircle className="mt-0.5 h-4 w-4 shrink-0 text-yellow-500" />
+        <div className="min-w-0 flex-1">
+          <div className="text-xs font-medium text-(--fg)">
+            <code className="rounded bg-(--surface) px-1 py-0.5 font-mono text-[11px]">
+              {event.id}
+            </code>
+          </div>
+          <div className="mt-1 text-[11px] text-(--dim)">
+            {isIncomingRejected ? (
+              <>
+                Shadow-rejected: incoming from{" "}
+                <code className="text-[10px]">{provenanceLabel(event.incoming)}</code> conflicts
+                with existing <code className="text-[10px]">{provenanceLabel(event.existing)}</code>
+              </>
+            ) : (
+              <>
+                Overridden: <code className="text-[10px]">{provenanceLabel(event.incoming)}</code>{" "}
+                replaced <code className="text-[10px]">{provenanceLabel(event.existing)}</code>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CapabilityRow({ entry }: { entry: CapabilityEntry }) {
+  const reason = entry.isAvailable();
+  return (
+    <div
+      className={`flex items-start gap-3 rounded-md px-3 py-2 transition-colors hover:bg-(--surface)/50 ${
+        reason !== null ? "opacity-60" : ""
+      }`}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-(--fg)">{entry.label}</span>
+          <span className="rounded bg-(--surface) px-1.5 py-0.5 font-mono text-[10px] text-(--dim)">
+            {entry.kind}
+          </span>
+        </div>
+        {entry.description ? (
+          <p className="mt-0.5 text-xs text-(--dim) line-clamp-2">{entry.description}</p>
+        ) : null}
+        <p className="mt-0.5 font-mono text-[10px] text-(--dim)/60">{entry.id}</p>
+      </div>
+      <div className="shrink-0 pt-0.5">
+        <AvailabilityBadge entry={entry} />
+      </div>
+    </div>
+  );
+}
+
+function GroupSection({ group }: { group: GroupedCapabilities }) {
+  const Icon = sourceIcon(group.source);
+  return (
+    <section>
+      <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-(--border) bg-(--bg) px-4 py-2.5">
+        <Icon className="h-4 w-4 text-(--dim)" />
+        <h3 className="text-sm font-semibold text-(--fg)">{group.label}</h3>
+        <span className="ml-auto rounded-full bg-(--surface) px-2 py-0.5 text-[10px] font-medium text-(--dim)">
+          {group.entries.length}
+        </span>
+      </div>
+      <div className="divide-y divide-(--border)/40">
+        {group.entries.map((entry) => (
+          <CapabilityRow key={entry.id} entry={entry} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function CapabilitiesPage() {
+  const { grouped, all, collisions, loading, error, skippedSources, ...view } =
+    useCapabilitiesRegistry();
+
+  const handleRefresh = useCallback(() => {
+    // Re-trigger by reloading the page data
+    window.location.reload();
+  }, []);
+
+  return (
+    <div className="mx-auto w-full max-w-[86rem] px-4 py-4 pb-[calc(2rem+env(safe-area-inset-bottom))] sm:px-6 sm:py-6 2xl:px-10">
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold tracking-tight text-(--fg)">Capabilities</h1>
+          <p className="mt-1 text-sm text-(--dim)">
+            Unified view of all registered capabilities and their provenance.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleRefresh}
+          className="flex h-8 items-center gap-1.5 rounded-md border border-(--border) bg-(--surface) px-3 text-xs text-(--dim) transition-colors hover:bg-(--surface-2) hover:text-(--fg)"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          Refresh
+        </button>
+      </div>
+
+      {/* Summary bar */}
+      <div className="mb-4 flex flex-wrap items-center gap-3 rounded-lg border border-(--border) bg-(--surface)/30 px-4 py-2.5 text-xs text-(--dim)">
+        <span>
+          <strong className="font-semibold text-(--fg)">{all.length}</strong> capabilities
+        </span>
+        <span className="text-(--border)">·</span>
+        <span>
+          <strong className="font-semibold text-(--fg)">{grouped.length}</strong> sources
+        </span>
+        {collisions.length > 0 ? (
+          <>
+            <span className="text-(--border)">·</span>
+            <span className="text-yellow-600 dark:text-yellow-400">
+              <strong className="font-semibold">{collisions.length}</strong> collision
+              {collisions.length !== 1 ? "s" : ""}
+            </span>
+          </>
+        ) : null}
+        {skippedSources.length > 0 ? (
+          <>
+            <span className="text-(--border)">·</span>
+            <span title={skippedSources.join(", ")} className="text-(--dim)/70">
+              {skippedSources.length} source{skippedSources.length !== 1 ? "s" : ""} unavailable
+            </span>
+          </>
+        ) : null}
+      </div>
+
+      {/* Error state */}
+      {error ? (
+        <div className="mb-4 rounded-lg border border-red-500/30 bg-red-500/5 px-4 py-3 text-sm text-red-600 dark:text-red-400">
+          {error}
+        </div>
+      ) : null}
+
+      {/* Loading state */}
+      {loading ? (
+        <div className="py-12 text-center text-sm text-(--dim)">Loading capabilities...</div>
+      ) : all.length === 0 && !error ? (
+        <div className="py-12 text-center text-sm text-(--dim)">
+          No capabilities registered. Add MCP servers, skills, or prompt templates to see them here.
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {/* Collisions section */}
+          {collisions.length > 0 ? (
+            <section>
+              <div className="mb-2 flex items-center gap-2">
+                <AlertTriangle className="h-4 w-4 text-yellow-500" />
+                <h2 className="text-sm font-semibold text-(--fg)">
+                  Collisions ({collisions.length})
+                </h2>
+              </div>
+              <div className="space-y-2">
+                {collisions.map((event, i) => (
+                  <CollisionCard key={`${event.id}-${i}`} event={event} />
+                ))}
+              </div>
+            </section>
+          ) : null}
+
+          {/* Grouped capabilities */}
+          {grouped.map((group) => (
+            <GroupSection key={group.source} group={group} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/capabilities/use-capabilities-registry.ts
+++ b/frontend/src/features/capabilities/use-capabilities-registry.ts
@@ -1,0 +1,185 @@
+"use client";
+
+import { useCallback, useState, useSyncExternalStore } from "react";
+import { MCP_CATALOGUE } from "@/features/agent/mcp/catalogue";
+import type { SkillRow } from "@/features/agent/skill-discovery";
+import type { PromptTemplateRow } from "@/features/agent/prompt-templates-store";
+import {
+  adaptMcpCatalogue,
+  adaptStoredServers,
+  adaptSkills,
+  adaptPromptTemplates,
+} from "@/features/agent/capabilities/adapters";
+import { CapabilityRegistry, type CollisionEvent } from "@/features/agent/capabilities/registry";
+import type { CapabilityEntry } from "@/features/agent/capabilities/types";
+
+export type GroupedCapabilities = {
+  label: string;
+  source: CapabilityEntry["provenance"]["source"];
+  entries: CapabilityEntry[];
+};
+
+export type CapabilitiesRegistryView = {
+  grouped: GroupedCapabilities[];
+  all: CapabilityEntry[];
+  collisions: CollisionEvent[];
+  loading: boolean;
+  error: string | null;
+  skippedSources: string[];
+};
+
+const GROUP_ORDER: CapabilityEntry["provenance"]["source"][] = [
+  "mcp-catalogue",
+  "mcp-server",
+  "skill",
+  "template",
+];
+
+const GROUP_LABELS: Record<CapabilityEntry["provenance"]["source"], string> = {
+  builtin: "Built-in",
+  "mcp-catalogue": "MCP Catalogue",
+  "mcp-server": "MCP Servers",
+  skill: "Skills",
+  template: "Prompt Templates",
+};
+
+export function useCapabilitiesRegistry(): CapabilitiesRegistryView {
+  const [view, setView] = useState<CapabilitiesRegistryView>({
+    grouped: [],
+    all: [],
+    collisions: [],
+    loading: true,
+    error: null,
+    skippedSources: [],
+  });
+
+  const load = useCallback(async () => {
+    setView((prev) => ({ ...prev, loading: true, error: null }));
+    try {
+      // Source 1: MCP catalogue — always available (static import)
+      const catalogueEntries = adaptMcpCatalogue(MCP_CATALOGUE);
+
+      // Source 2: stored MCP servers — fetched from API
+      let serverEntries: CapabilityEntry[] = [];
+      try {
+        const res = await fetch("/api/agent/plugins?includeDisabled=1", { cache: "no-store" });
+        const payload = (await res.json()) as {
+          plugins?: Array<{
+            id: string;
+            name: string;
+            displayName?: string;
+            description?: string;
+            enabled?: boolean;
+          }>;
+        };
+        const plugins = payload.plugins ?? [];
+        serverEntries = plugins.map((p) => ({
+          id: p.id,
+          label: p.displayName ?? p.name,
+          description: p.description ?? "",
+          kind: "mcp" as const,
+          provenance: {
+            source: "mcp-server" as const,
+            serverId: p.id,
+            serverName: p.name,
+          },
+          isAvailable: () => (p.enabled === false ? "server disabled" : null),
+        }));
+      } catch {
+        // Silently skip if unavailable
+      }
+
+      // Source 3: skills — fetched from API
+      let skillEntries: CapabilityEntry[] = [];
+      try {
+        const res = await fetch("/api/agent/skills", { cache: "no-store" });
+        const payload = (await res.json()) as { skills?: SkillRow[] };
+        if (payload.skills?.length) {
+          skillEntries = adaptSkills(payload.skills);
+        }
+      } catch {
+        // Silently skip if unavailable
+      }
+
+      // Source 4: prompt templates — fetched from API
+      let templateEntries: CapabilityEntry[] = [];
+      try {
+        const res = await fetch("/api/agent/prompt-templates", { cache: "no-store" });
+        const payload = (await res.json()) as { templates?: PromptTemplateRow[] };
+        if (payload.templates?.length) {
+          templateEntries = adaptPromptTemplates(payload.templates);
+        }
+      } catch {
+        // Silently skip if unavailable
+      }
+
+      // Build registry
+      const { registry, collisions } = CapabilityRegistry.fromSources(
+        catalogueEntries,
+        serverEntries,
+        skillEntries,
+        templateEntries,
+      );
+
+      const all = registry.list();
+
+      // Group by provenance source
+      const bySource = new Map<string, CapabilityEntry[]>();
+      for (const entry of all) {
+        const key = entry.provenance.source;
+        const group = bySource.get(key);
+        if (group) {
+          group.push(entry);
+        } else {
+          bySource.set(key, [entry]);
+        }
+      }
+
+      const grouped: GroupedCapabilities[] = [];
+      for (const source of GROUP_ORDER) {
+        const entries = bySource.get(source);
+        if (entries?.length) {
+          grouped.push({
+            label: GROUP_LABELS[source],
+            source,
+            entries,
+          });
+        }
+      }
+
+      // Track which sources we skipped (had no client-side accessor or returned empty)
+      const skipped: string[] = [];
+      if (!serverEntries.length) skipped.push("mcp-server");
+      if (!skillEntries.length) skipped.push("skill");
+      if (!templateEntries.length) skipped.push("template");
+
+      setView({
+        grouped,
+        all,
+        collisions,
+        loading: false,
+        error: null,
+        skippedSources: skipped,
+      });
+    } catch (err) {
+      setView((prev) => ({
+        ...prev,
+        loading: false,
+        error: err instanceof Error ? err.message : "Failed to load capabilities",
+      }));
+    }
+  }, []);
+
+  const subscribe = useCallback(
+    (_notify: () => void) => {
+      void load();
+      return () => {};
+    },
+    [load],
+  );
+
+  const getSnapshot = useCallback(() => view, [view]);
+  useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  return view;
+}

--- a/frontend/src/features/shell/left-sidebar.tsx
+++ b/frontend/src/features/shell/left-sidebar.tsx
@@ -25,6 +25,7 @@ import {
   PanelLeftOpen,
   Square,
   X,
+  ListChecks,
 } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 import { useAppStore } from "@/store";
@@ -49,6 +50,7 @@ const tabs = [
   { href: "/usage", label: "Usage", icon: Microchip },
   { href: "/recipes", label: "Models", icon: HardDrive },
   { href: "/plugins", label: "Plugins", icon: Plug },
+  { href: "/capabilities", label: "Capabilities", icon: ListChecks },
   { href: "/server", label: "Server", icon: Globe },
 ];
 

--- a/tests/frontend/e2e/capabilities-view-model.test.ts
+++ b/tests/frontend/e2e/capabilities-view-model.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { adaptMcpCatalogue, adaptStoredServers, adaptSkills, adaptPromptTemplates } from "@/features/agent/capabilities/adapters";
+import { CapabilityRegistry } from "@/features/agent/capabilities/registry";
+import type { McpCatalogueEntry, McpServerEntry } from "@/features/agent/mcp/types";
+import type { SkillRow } from "@/features/agent/skill-discovery";
+import type { PromptTemplateRow } from "@/features/agent/prompt-templates-store";
+
+function fakeCatalogue(overrides: Partial<McpCatalogueEntry> = {}): McpCatalogueEntry {
+  return {
+    id: "catalogue:test",
+    name: "test",
+    displayName: "Test",
+    description: "Test server",
+    shortDescription: "Test",
+    category: "Test",
+    tags: ["test"],
+    registry: "curated",
+    command: "npx",
+    args: ["-y", "test-server"],
+    ...overrides,
+  };
+}
+
+function fakeStoredServer(overrides: Partial<McpServerEntry["def"]> = {}): McpServerEntry {
+  return {
+    def: {
+      id: "custom-server",
+      name: "my-tools",
+      displayName: "My Tools",
+      description: "Custom MCP tools",
+      transport: "stdio",
+      command: "node",
+      args: ["server.js"],
+      ...overrides,
+    },
+    enabled: true,
+    source: "manual",
+  };
+}
+
+function fakeSkill(overrides: Partial<SkillRow> = {}): SkillRow {
+  return {
+    id: "skill:browser",
+    name: "browser",
+    source: "devin",
+    path: "/skills/browser/SKILL.md",
+    ...overrides,
+  };
+}
+
+function fakeTemplate(overrides: Partial<PromptTemplateRow> = {}): PromptTemplateRow {
+  return {
+    id: "template:refactor",
+    name: "refactor",
+    source: "devin",
+    path: "/prompts/refactor.md",
+    description: "Refactor code",
+    ...overrides,
+  };
+}
+
+test("fromSources with all four adapter outputs builds registry and detects collisions", () => {
+  const catalogue = adaptMcpCatalogue([fakeCatalogue(), fakeCatalogue({ id: "catalogue:fetch", name: "fetch", displayName: "Fetch" })]);
+  const servers = adaptStoredServers([fakeStoredServer()]);
+  const skills = adaptSkills([fakeSkill()]);
+  const templates = adaptPromptTemplates([fakeTemplate()]);
+
+  const { registry, collisions } = CapabilityRegistry.fromSources(catalogue, servers, skills, templates);
+
+  assert.equal(registry.list().length, 5);
+  assert.equal(registry.has("catalogue:test"), true);
+  assert.equal(registry.has("catalogue:fetch"), true);
+  assert.equal(registry.has("custom-server"), true);
+  assert.equal(registry.has("skill:browser"), true);
+  assert.equal(registry.has("template:refactor"), true);
+  assert.equal(collisions.length, 0);
+});
+
+test("fromSources detects collision when catalogue and server share an id", () => {
+  const catalogue = adaptMcpCatalogue([fakeCatalogue({ id: "shared-id" })]);
+  const servers = adaptStoredServers([fakeStoredServer({ id: "shared-id" })]);
+
+  const { registry, collisions } = CapabilityRegistry.fromSources(catalogue, servers);
+
+  assert.equal(collisions.length, 1);
+  assert.equal(collisions[0].id, "shared-id");
+  assert.equal(collisions[0].action, "rejected");
+  // First registered wins (catalogue)
+  assert.equal(registry.get("shared-id")?.provenance.source, "mcp-catalogue");
+});
+
+test("fromSources with empty sources returns empty registry", () => {
+  const { registry, collisions } = CapabilityRegistry.fromSources([], [], [], []);
+  assert.equal(registry.list().length, 0);
+  assert.equal(collisions.length, 0);
+});
+
+test("fromSources with partial sources works", () => {
+  const catalogue = adaptMcpCatalogue([fakeCatalogue()]);
+  const skills = adaptSkills([fakeSkill()]);
+
+  const { registry, collisions } = CapabilityRegistry.fromSources(catalogue, [], skills, []);
+  assert.equal(registry.list().length, 2);
+  assert.equal(collisions.length, 0);
+});
+
+test("adapted entries have correct provenance source", () => {
+  const catalogue = adaptMcpCatalogue([fakeCatalogue()]);
+  const servers = adaptStoredServers([fakeStoredServer()]);
+  const skills = adaptSkills([fakeSkill()]);
+  const templates = adaptPromptTemplates([fakeTemplate()]);
+
+  assert.equal(catalogue[0].provenance.source, "mcp-catalogue");
+  assert.equal(servers[0].provenance.source, "mcp-server");
+  assert.equal(skills[0].provenance.source, "skill");
+  assert.equal(templates[0].provenance.source, "template");
+});

--- a/tests/frontend/e2e/capability-registry-class.test.ts
+++ b/tests/frontend/e2e/capability-registry-class.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { CapabilityRegistry } from "@/features/agent/capabilities/registry";
+import type { CapabilityEntry, CapabilityProvenance } from "@/features/agent/capabilities/types";
+
+function fakeEntry(
+  id: string,
+  provenance: CapabilityProvenance = { source: "builtin", module: "test" },
+): CapabilityEntry {
+  return {
+    id,
+    label: id,
+    description: `Description for ${id}`,
+    kind: "builtin",
+    provenance,
+    isAvailable: () => null,
+  };
+}
+
+test("register stores an entry and get retrieves it", () => {
+  const reg = new CapabilityRegistry();
+  const entry = fakeEntry("a");
+  const result = reg.register(entry);
+  assert.equal(result.status, "registered");
+  assert.equal(reg.get("a")?.id, "a");
+  assert.equal(reg.has("a"), true);
+  assert.equal(reg.has("b"), false);
+});
+
+test("register shadow-rejects on id collision without override", () => {
+  const reg = new CapabilityRegistry();
+  const first = fakeEntry("x", { source: "builtin", module: "mod-a" });
+  const second = fakeEntry("x", { source: "mcp-catalogue", catalogueId: "cat:1" });
+
+  reg.register(first);
+  const result = reg.register(second);
+
+  assert.equal(result.status, "rejected");
+  if (result.status === "rejected") {
+    assert.equal(result.incoming.id, "x");
+    assert.equal(result.existing.provenance.source, "builtin");
+  }
+  // Original entry is kept
+  assert.equal(reg.get("x")?.provenance.source, "builtin");
+});
+
+test("register overrides on collision when override=true", () => {
+  const reg = new CapabilityRegistry();
+  const first = fakeEntry("y", { source: "builtin", module: "mod-a" });
+  const second = fakeEntry("y", { source: "skill", skillId: "s1", skillPath: "/s" });
+
+  reg.register(first);
+  const result = reg.register(second, { override: true });
+
+  assert.equal(result.status, "overridden");
+  if (result.status === "overridden") {
+    assert.equal(result.entry.provenance.source, "skill");
+    assert.equal(result.previous.provenance.source, "builtin");
+  }
+  // New entry replaced the old one
+  assert.equal(reg.get("y")?.provenance.source, "skill");
+});
+
+test("registerAll registers multiple entries", () => {
+  const reg = new CapabilityRegistry();
+  const results = reg.registerAll([
+    fakeEntry("a"),
+    fakeEntry("b"),
+    fakeEntry("c"),
+  ]);
+  assert.equal(results.length, 3);
+  assert.equal(results[0].status, "registered");
+  assert.equal(results[1].status, "registered");
+  assert.equal(results[2].status, "registered");
+  assert.equal(reg.list().length, 3);
+});
+
+test("collisions records shadow-rejections", () => {
+  const reg = new CapabilityRegistry();
+  reg.register(fakeEntry("dup", { source: "builtin", module: "m" }));
+  reg.register(fakeEntry("dup", { source: "mcp-server", serverId: "s", serverName: "S" }));
+
+  const log = reg.collisions();
+  assert.equal(log.length, 1);
+  assert.equal(log[0].id, "dup");
+  assert.equal(log[0].action, "rejected");
+  assert.equal(log[0].incoming.source, "mcp-server");
+  assert.equal(log[0].existing.source, "builtin");
+});
+
+test("collisions records overrides", () => {
+  const reg = new CapabilityRegistry();
+  reg.register(fakeEntry("o", { source: "builtin", module: "m" }));
+  reg.register(fakeEntry("o", { source: "skill", skillId: "s", skillPath: "/s" }), {
+    override: true,
+  });
+
+  const log = reg.collisions();
+  assert.equal(log.length, 1);
+  assert.equal(log[0].action, "overridden");
+});
+
+test("fromSources builds registry and reports collisions", () => {
+  const sourceA = [
+    fakeEntry("shared", { source: "builtin", module: "a" }),
+    fakeEntry("only-a", { source: "builtin", module: "a" }),
+  ];
+  const sourceB = [
+    fakeEntry("shared", { source: "mcp-server", serverId: "s", serverName: "S" }),
+    fakeEntry("only-b", { source: "skill", skillId: "sk", skillPath: "/sk" }),
+  ];
+
+  const { registry, collisions } = CapabilityRegistry.fromSources(sourceA, sourceB);
+
+  assert.equal(registry.list().length, 3); // shared (first wins), only-a, only-b
+  assert.equal(registry.has("shared"), true);
+  assert.equal(registry.has("only-a"), true);
+  assert.equal(registry.has("only-b"), true);
+  // First registration of "shared" wins (builtin)
+  assert.equal(registry.get("shared")?.provenance.source, "builtin");
+
+  assert.equal(collisions.length, 1);
+  assert.equal(collisions[0].id, "shared");
+  assert.equal(collisions[0].action, "rejected");
+});
+
+test("collisions returns a copy (mutation-safe)", () => {
+  const reg = new CapabilityRegistry();
+  reg.register(fakeEntry("z"));
+  reg.register(fakeEntry("z"));
+  const log1 = reg.collisions();
+  const log2 = reg.collisions();
+  assert.deepEqual(log1, log2);
+  assert.notEqual(log1, log2); // different array reference
+});
+
+test("list returns empty array for fresh registry", () => {
+  const reg = new CapabilityRegistry();
+  assert.deepEqual(reg.list(), []);
+  assert.deepEqual(reg.collisions(), []);
+});

--- a/tests/frontend/e2e/capability-registry.test.ts
+++ b/tests/frontend/e2e/capability-registry.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  adaptMcpCatalogue,
+  adaptStoredServers,
+  adaptSkills,
+  adaptPromptTemplates,
+  detectCollisions,
+} from "@/features/agent/capabilities/adapters";
+import type { McpCatalogueEntry, McpServerEntry } from "@/features/agent/mcp/types";
+import type { SkillRow } from "@/features/agent/skill-discovery";
+import type { PromptTemplateRow } from "@/features/agent/prompt-templates-store";
+
+// --- Fake inputs ---
+
+function fakeCatalogueEntry(overrides: Partial<McpCatalogueEntry> = {}): McpCatalogueEntry {
+  return {
+    id: "catalogue:filesystem",
+    name: "filesystem",
+    displayName: "Filesystem",
+    description: "Read and write files",
+    shortDescription: "Local file access",
+    category: "Files",
+    tags: ["files"],
+    registry: "curated",
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-filesystem"],
+    requiresTargetArg: true,
+    ...overrides,
+  };
+}
+
+function fakeStoredServer(
+  overrides: Partial<McpServerEntry["def"]> = {},
+): McpServerEntry {
+  return {
+    def: {
+      id: "custom-server",
+      name: "my-tools",
+      displayName: "My Tools",
+      description: "Custom MCP tools",
+      transport: "stdio",
+      command: "node",
+      args: ["server.js"],
+      ...overrides,
+    },
+    enabled: true,
+    source: "manual",
+  };
+}
+
+function fakeSkill(overrides: Partial<SkillRow> = {}): SkillRow {
+  return {
+    id: "skill:browser",
+    name: "browser",
+    source: "devin",
+    path: "/skills/browser/SKILL.md",
+    ...overrides,
+  };
+}
+
+function fakeTemplate(overrides: Partial<PromptTemplateRow> = {}): PromptTemplateRow {
+  return {
+    id: "template:refactor",
+    name: "refactor",
+    source: "devin",
+    path: "/prompts/refactor.md",
+    description: "Refactor code",
+    ...overrides,
+  };
+}
+
+// --- Tests ---
+
+test("adaptMcpCatalogue maps catalogue entries to CapabilityEntry", () => {
+  const entries = [
+    fakeCatalogueEntry(),
+    fakeCatalogueEntry({ id: "catalogue:fetch", name: "fetch", displayName: "Fetch" }),
+  ];
+  const result = adaptMcpCatalogue(entries);
+  assert.equal(result.length, 2);
+  assert.equal(result[0].id, "catalogue:filesystem");
+  assert.equal(result[0].label, "Filesystem");
+  assert.equal(result[0].kind, "mcp");
+  assert.equal(result[0].provenance.source, "mcp-catalogue");
+  assert.equal(result[0].isAvailable(), null);
+  assert.equal(result[1].id, "catalogue:fetch");
+});
+
+test("adaptStoredServers maps server entries to CapabilityEntry", () => {
+  const disabled = fakeStoredServer({ id: "disabled-server", name: "disabled" });
+  disabled.enabled = false;
+  const entries = [fakeStoredServer(), disabled];
+  const result = adaptStoredServers(entries);
+  assert.equal(result.length, 2);
+  assert.equal(result[0].id, "custom-server");
+  assert.equal(result[0].kind, "mcp");
+  assert.equal(result[0].provenance.source, "mcp-server");
+  assert.equal(result[0].isAvailable(), null);
+  assert.equal(result[1].isAvailable(), "server disabled");
+});
+
+test("adaptSkills maps skill rows to CapabilityEntry", () => {
+  const entries = [fakeSkill(), fakeSkill({ id: "skill:git", name: "git", path: "/skills/git" })];
+  const result = adaptSkills(entries);
+  assert.equal(result.length, 2);
+  assert.equal(result[0].id, "skill:browser");
+  assert.equal(result[0].kind, "skill");
+  assert.equal(result[0].provenance.source, "skill");
+  assert.equal(result[1].id, "skill:git");
+});
+
+test("adaptPromptTemplates maps template rows to CapabilityEntry", () => {
+  const entries = [fakeTemplate()];
+  const result = adaptPromptTemplates(entries);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].id, "template:refactor");
+  assert.equal(result[0].label, "refactor");
+  assert.equal(result[0].kind, "template");
+  assert.equal(result[0].provenance.source, "template");
+  assert.equal(result[0].description, "Refactor code");
+});
+
+test("adaptPromptTemplates uses fallback description when none provided", () => {
+  const entry = fakeTemplate({ description: undefined });
+  const result = adaptPromptTemplates([entry]);
+  assert.equal(result[0].description, "Template from devin");
+});
+
+test("detectCollisions returns empty when no duplicates", () => {
+  const a = adaptMcpCatalogue([fakeCatalogueEntry()]);
+  const b = adaptSkills([fakeSkill()]);
+  const collisions = detectCollisions(a, b);
+  assert.equal(collisions.length, 0);
+});
+
+test("detectCollisions finds duplicate ids across sources", () => {
+  // Force a collision: give the catalogue entry and server entry the same id
+  const catalogue = adaptMcpCatalogue([
+    fakeCatalogueEntry({ id: "shared-id" }),
+  ]);
+  const servers = adaptStoredServers([
+    fakeStoredServer({ id: "shared-id" }),
+  ]);
+  const collisions = detectCollisions(catalogue, servers);
+  assert.equal(collisions.length, 1);
+  assert.equal(collisions[0].id, "shared-id");
+  assert.equal(collisions[0].entries.length, 2);
+  assert.equal(collisions[0].entries[0].provenance.source, "mcp-catalogue");
+  assert.equal(collisions[0].entries[1].provenance.source, "mcp-server");
+});
+
+test("detectCollisions ignores duplicates within the same input array", () => {
+  // Two entries with the same id in the same array still count as a collision
+  const entries = adaptMcpCatalogue([
+    fakeCatalogueEntry({ id: "dup" }),
+    fakeCatalogueEntry({ id: "dup", name: "dup2", displayName: "Dup 2" }),
+  ]);
+  const collisions = detectCollisions(entries);
+  assert.equal(collisions.length, 1);
+  assert.equal(collisions[0].id, "dup");
+  assert.equal(collisions[0].entries.length, 2);
+});
+
+test("detectCollisions handles multiple independent collisions", () => {
+  const a = [
+    ...adaptMcpCatalogue([fakeCatalogueEntry({ id: "collision-a" })]),
+    ...adaptSkills([fakeSkill({ id: "collision-b" })]),
+  ];
+  const b = [
+    ...adaptStoredServers([fakeStoredServer({ id: "collision-a" })]),
+    ...adaptPromptTemplates([fakeTemplate({ id: "collision-b" })]),
+  ];
+  const collisions = detectCollisions(a, b);
+  assert.equal(collisions.length, 2);
+  const ids = collisions.map((c) => c.id).sort();
+  assert.deepEqual(ids, ["collision-a", "collision-b"]);
+});

--- a/tests/frontend/e2e/capability-registry.test.ts
+++ b/tests/frontend/e2e/capability-registry.test.ts
@@ -151,7 +151,7 @@ test("detectCollisions finds duplicate ids across sources", () => {
   assert.equal(collisions[0].entries[1].provenance.source, "mcp-server");
 });
 
-test("detectCollisions ignores duplicates within the same input array", () => {
+test("detectCollisions flags duplicate ids even within a single input array", () => {
   // Two entries with the same id in the same array still count as a collision
   const entries = adaptMcpCatalogue([
     fakeCatalogueEntry({ id: "dup" }),


### PR DESCRIPTION
## Summary
A capability registry that unifies the currently-scattered capability definitions (MCP catalogue, stored MCP servers, skills, prompt templates) into one read-only view, plus a `/capabilities` page. This is a **non-breaking parallel layer** — existing registration/consumption paths are untouched.

## Changes
- `frontend/src/features/agent/capabilities/`: pure read-only adapters mapping each source into a unified `CapabilityEntry`; a non-enforcing `detectCollisions`; and a `CapabilityRegistry` class that shadow-rejects id collisions (with explicit `{ override: true }` opt-in), records an audit log, and builds from sources via `fromSources(...)`.
- A read-only `/capabilities` dashboard view: capabilities grouped by provenance + a collisions section. Reads the static MCP catalogue and GETs plugins/skills/prompt-templates; degrades gracefully if a source is unavailable.

## Verification
- frontend `typecheck` + `lint` + `build` → clean; adapter + registry + view-model unit tests pass.

## Non-goals
- No enforcement and no ownership shift yet — collision detection is non-enforcing and existing consumers are not rewired. This is the read-only foundation for a future unified action/capability layer.
