### PR TITLE
fix: stabilize agent sessions and simplify composer chrome

### DIFF
--- a/controller/src/modules/studio/configs.ts
+++ b/controller/src/modules/studio/configs.ts
@@ -54,7 +54,7 @@ export const STUDIO_STARTER_PRESETS: StudioStarterPreset[] = [
     size_gb: null,
     min_vram_gb: null,
     remote: {
-      base_url: "https://api.homelabai.org/v1",
+      base_url: "http://pop-os-1.tailadb2c1.ts.net:8080/v1",
       model: "deepseek-v4-flash",
     },
   },

--- a/controller/src/modules/studio/starter-presets.test.ts
+++ b/controller/src/modules/studio/starter-presets.test.ts
@@ -27,7 +27,7 @@ describe("starter presets", () => {
 
   test("remote presets carry a base_url and model", () => {
     for (const preset of STUDIO_STARTER_PRESETS.filter((p) => p.kind === "remote")) {
-      expect(preset.remote?.base_url).toMatch(/^https:\/\//);
+      expect(preset.remote?.base_url).toMatch(/^(https:\/\/|http:\/\/[^/]+\.ts\.net(?::\d+)?\/)/);
       expect(preset.remote?.model).toBeTruthy();
     }
   });

--- a/docs/home-mission.md
+++ b/docs/home-mission.md
@@ -27,7 +27,7 @@ Guiding question at every step: **how can I make this a home for people?**
   etc. Engines: vLLM (:8000), llama.cpp (:8081). Models incl. qwen3.6-35b
   (NVFP4), step3.7-flash, qwen3.6-27b, gemma-4-31b. `~/models` has
   Qwen3.6-35B-A3B-NVFP4 already downloaded.
-- `deepseek-v4-flash` = the model live on api.homelabai.org (remote preset).
+- `deepseek-v4-flash` = the model live on pop-os-1.tailadb2c1.ts.net:8080 (remote preset).
 - `lfm2.5` = LiquidAI LFM 2.5 small model — needs recipe + weights source
   (confirm exact HF repo before wiring).
 
@@ -156,7 +156,7 @@ system.** A deeper subjective reskin of pre-existing wizard chrome (Card
 rounded-lg → hairline) remains available but is a taste pass best done with
 Sero watching; the app is in good shape as-is.
 Dev-dir note: switched ~/.local-studio active controller to Spark for QA, then
-restored to api.homelabai.org. Packaged desktop app uses a separate data dir,
+restored to pop-os-1.tailadb2c1.ts.net:8080. Packaged desktop app uses a separate data dir,
 unaffected.
 
 ## Rules

--- a/frontend/scripts/highlight-cache.test.ts
+++ b/frontend/scripts/highlight-cache.test.ts
@@ -1,9 +1,19 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { highlightFenced } from "../src/features/agent/highlight-cache";
+import { highlightFenced, highlightLines } from "../src/features/agent/highlight-cache";
 
 test("highlights code languages used by the filesystem and tool previews", () => {
   assert.match(highlightFenced("css", ".card { color: red; }"), /hljs-selector-class/);
   assert.match(highlightFenced("java", "class Studio {}"), /hljs-keyword/);
   assert.match(highlightFenced("toml", "port = 8080"), /hljs-attr/);
+});
+
+test("preserves embedded language context across filesystem lines", () => {
+  const rendered = highlightLines("html", ["<style>", ".card { color: red; }", "</style>"]);
+  assert.equal(rendered.length, 3);
+  assert.match(rendered[1] ?? "", /language-css/);
+  assert.match(rendered[1] ?? "", /hljs-selector-class/);
+  for (const line of rendered) {
+    assert.equal(line.match(/<span/g)?.length ?? 0, line.match(/<\/span>/g)?.length ?? 0);
+  }
 });

--- a/frontend/src/features/agent/highlight-cache.ts
+++ b/frontend/src/features/agent/highlight-cache.ts
@@ -47,6 +47,30 @@ export function highlightFenced(language: string | null, code: string): string {
   return highlighted;
 }
 
+export function highlightLines(language: string | null, lines: readonly string[]): string[] {
+  if (lines.length === 0) return [];
+  const rendered = [""];
+  const openSpans: string[] = [];
+  for (const token of highlightFenced(language, lines.join("\n")).split(
+    /(<span[^>]*>|<\/span>|\n)/,
+  )) {
+    const line = rendered.length - 1;
+    if (token === "\n") {
+      rendered[line] += "</span>".repeat(openSpans.length);
+      rendered.push(openSpans.join(""));
+    } else if (token.startsWith("<span")) {
+      openSpans.push(token);
+      rendered[line] += token;
+    } else if (token === "</span>") {
+      openSpans.pop();
+      rendered[line] += token;
+    } else {
+      rendered[line] += token;
+    }
+  }
+  return rendered;
+}
+
 export function escapeHighlightHtml(code: string): string {
   return code
     .replaceAll("&", "&amp;")

--- a/frontend/src/features/agent/messages/helpers.ts
+++ b/frontend/src/features/agent/messages/helpers.ts
@@ -1,8 +1,5 @@
 import { piEventIsSuccessfulCompaction } from "@shared/agent/pi-events";
-import {
-  cleanSessionTitle,
-  isPlaceholderSessionTitle,
-} from "@shared/agent/session-title";
+import { cleanSessionTitle, isPlaceholderSessionTitle } from "@shared/agent/session-title";
 
 export { cleanSessionTitle, isPlaceholderSessionTitle };
 import type {
@@ -111,7 +108,6 @@ export function formatTokenCount(tokens: number): string {
 export function sessionTitleFromPrompt(text: string): string {
   return cleanSessionTitle(text.replace(/\s+/g, " ").trim().slice(0, 48)) || "New session";
 }
-
 
 export function visibleUserTextFromPi(text: string): string {
   const marker = "\n\nUser prompt:\n";
@@ -271,51 +267,78 @@ function eventKey(event: Record<string, unknown>): string {
   }
 }
 
-function userTextFromEvent(event: Record<string, unknown>): string | null {
+function messageFingerprint(event: Record<string, unknown>): string | null {
   const message = asRecord(event.message);
-  if (!message || message.role !== "user") return null;
-  const content = message.content;
-  if (typeof content !== "string" && !Array.isArray(content)) return null;
-  const text = visibleUserTextFromPi(messageText(content as string | Record<string, unknown>[]));
-  return text ? text : null;
+  if (!message || typeof message.role !== "string") return null;
+  return eventKey(message);
 }
 
 function canonicalEventsBeforeRuntimeTail(
   canonicalEvents: Record<string, unknown>[],
   runtime: Record<string, unknown>[],
 ): Record<string, unknown>[] {
-  const firstRuntimeUser = runtime
-    .map(userTextFromEvent)
-    .find((text): text is string => Boolean(text));
-  if (!firstRuntimeUser) return canonicalEvents;
-  for (let index = canonicalEvents.length - 1; index >= 0; index -= 1) {
-    if (userTextFromEvent(canonicalEvents[index]) === firstRuntimeUser) {
-      return canonicalEvents.slice(0, index);
+  const canonicalMessages = canonicalEvents.flatMap((event, eventIndex) => {
+    const fingerprint = messageFingerprint(event);
+    return fingerprint ? [{ eventIndex, fingerprint }] : [];
+  });
+  const runtimeMessages = runtime.flatMap((event) => {
+    if (event.type !== "message" && event.type !== "message_end") return [];
+    const fingerprint = messageFingerprint(event);
+    return fingerprint ? [fingerprint] : [];
+  });
+  const firstRuntimeMessage = runtimeMessages[0];
+  if (!firstRuntimeMessage) return canonicalEvents;
+  let best: { eventIndex: number; score: number } | null = null;
+  for (let index = 0; index < canonicalMessages.length; index += 1) {
+    if (canonicalMessages[index]?.fingerprint !== firstRuntimeMessage) continue;
+    let score = 0;
+    while (
+      canonicalMessages[index + score]?.fingerprint === runtimeMessages[score] &&
+      runtimeMessages[score]
+    ) {
+      score += 1;
     }
+    const candidate = { eventIndex: canonicalMessages[index]?.eventIndex ?? 0, score };
+    if (!best || candidate.score >= best.score) best = candidate;
+  }
+  if (best) {
+    return canonicalEvents.slice(0, best.eventIndex);
   }
   return canonicalEvents;
+}
+
+function runtimeEventsInOrder(
+  runtimeEvents: readonly RuntimeLoggedEvent[],
+): Record<string, unknown>[] {
+  return [...runtimeEvents]
+    .sort((a, b) => (a.seq ?? 0) - (b.seq ?? 0))
+    .flatMap((entry) => {
+      if (entry.event && typeof entry.event === "object") {
+        return [entry.event];
+      }
+      return [];
+    });
+}
+
+function dedupeAdjacentEvents(events: Record<string, unknown>[]): Record<string, unknown>[] {
+  let previous = "";
+  return events.filter((event) => {
+    const key = eventKey(event);
+    if (key === previous) return false;
+    previous = key;
+    return true;
+  });
 }
 
 export function mergeCanonicalAndRuntimeEvents(
   canonicalEvents: Record<string, unknown>[],
   runtimeEvents: readonly RuntimeLoggedEvent[] = [],
 ): Record<string, unknown>[] {
-  const runtime = [...runtimeEvents]
-    .sort((a, b) => (a.seq ?? 0) - (b.seq ?? 0))
-    .flatMap((entry) => (entry.event && typeof entry.event === "object" ? [entry.event] : []));
-  const canonicalPrefix = canonicalEventsBeforeRuntimeTail(canonicalEvents, runtime);
-
-  const merged: Record<string, unknown>[] = [];
-  const seen = new Set<string>();
-  const push = (event: Record<string, unknown>) => {
-    const key = eventKey(event);
-    if (seen.has(key)) return;
-    seen.add(key);
-    merged.push(event);
-  };
-  canonicalPrefix.forEach(push);
-  runtime.forEach(push);
-  return merged;
+  const runtime = runtimeEventsInOrder(runtimeEvents);
+  return dedupeAdjacentEvents([
+    ...canonicalEventsBeforeRuntimeTail(canonicalEvents, runtime),
+    ...runtime,
+  ]);
 }
 
 export function makeFreshTab(): SessionTab {

--- a/frontend/src/features/agent/runtime/pi-event-applier.ts
+++ b/frontend/src/features/agent/runtime/pi-event-applier.ts
@@ -526,8 +526,9 @@ function reduceUserMessageEvent(
   ctx: SessionStreamContext,
   event: Record<string, unknown>,
 ): Session | null {
-  const isCanonical = event.type === "message";
+  const isCanonical = event.type === "message" || (ctx.replay && event.type === "message_end");
   if (!isCanonical && event.type !== "message_start" && event.type !== "message_end") return null;
+  if (ctx.replay && event.type === "message_start") return session;
   const msg = event.message as { role?: string; content?: string | Record<string, unknown>[] };
   if (msg?.role !== "user") return null;
   const text = visibleUserTextFromPi(messageText(msg.content));

--- a/frontend/src/features/agent/ui/agent-model-picker.tsx
+++ b/frontend/src/features/agent/ui/agent-model-picker.tsx
@@ -3,16 +3,12 @@
 import {
   useCallback,
   useMemo,
-  useRef,
   useState,
-  useSyncExternalStore,
   type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent,
   type PointerEvent,
 } from "react";
-import { Check, ChevronDown, Search, Server } from "@/ui/icon-registry";
-import { getStoredBackendUrl } from "@/lib/api/connection";
-import { loadSavedControllers } from "@/lib/api/controllers";
+import { Check, ChevronDown } from "@/ui/icon-registry";
 import type { AgentModel } from "@/features/agent/workspace/types";
 import { cx } from "@/ui/utils";
 
@@ -25,10 +21,6 @@ type AgentModelPickerProps = {
 
 type ModelGroup = { key: string; name: string; models: AgentModel[] };
 
-type FlatItem =
-  | { type: "model"; model: AgentModel; groupIndex: number }
-  | { type: "header"; label: string };
-
 export function AgentModelPicker({
   models,
   selectedModel,
@@ -36,81 +28,24 @@ export function AgentModelPicker({
   loading,
 }: AgentModelPickerProps) {
   const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState("");
-  const [highlightedIndex, setHighlightedIndex] = useState(0);
-  const [activeControllerKey, setActiveControllerKey] = useState<string | null>(null);
-  const searchRef = useRef<HTMLInputElement>(null);
-  const listRef = useRef<HTMLDivElement>(null);
-  const controllerLabel = useActiveControllerLabel();
+  const [activeGroupKey, setActiveGroupKey] = useState<string | null>(null);
   const active = models.find((model) => model.id === selectedModel) ?? null;
   const groups = useMemo(() => groupModelsByController(models), [models]);
-  const currentKey =
-    activeControllerKey ?? (active ? controllerGroupKey(active) : null) ?? groups[0]?.key ?? null;
+  const selectedGroupKey = active ? controllerGroupKey(active) : groups[0]?.key;
+  const activeGroup = groups.find((group) => group.key === activeGroupKey) ?? null;
   const disabled = loading || models.length === 0;
   const triggerLabel = modelTriggerLabel(active, selectedModel, loading, models.length);
   const selectedModelNotRunning = !loading && Boolean(active && active.active === false);
-
-  const { flatItems, filteredGroups } = useMemo(() => {
-    return buildFilteredView(models, groups, query, currentKey);
-  }, [models, groups, query, currentKey]);
-
-  const openDropdown = useCallback(() => {
-    setQuery("");
-    setHighlightedIndex(0);
-    setOpen(true);
-    setTimeout(() => searchRef.current?.focus(), 0);
+  const close = useCallback(() => {
+    setOpen(false);
+    setActiveGroupKey(null);
   }, []);
-
-  const handleSearchChange = useCallback((value: string) => {
-    setQuery(value);
-    setHighlightedIndex(0);
-  }, []);
-
-  const moveHighlight = useCallback(
-    (direction: 1 | -1) => {
-      setHighlightedIndex((idx) => {
-        const next = findNextModelIndex(flatItems, idx, direction);
-        if (next != null) {
-          setTimeout(() => {
-            listRef.current
-              ?.querySelector(`[data-idx="${next}"]`)
-              ?.scrollIntoView({ block: "nearest" });
-          }, 0);
-        }
-        return next ?? idx;
-      });
+  const select = useCallback(
+    (modelId: string) => {
+      onSelect(modelId);
+      close();
     },
-    [flatItems],
-  );
-
-  const handleKeyDown = useCallback(
-    (event: ReactKeyboardEvent<HTMLDivElement>) => {
-      if (event.key === "ArrowDown") {
-        event.preventDefault();
-        moveHighlight(1);
-      } else if (event.key === "ArrowUp") {
-        event.preventDefault();
-        moveHighlight(-1);
-      } else if (event.key === "Enter") {
-        const item = flatItems[highlightedIndex];
-        if (item?.type === "model") {
-          event.preventDefault();
-          onSelect(item.model.id);
-          setOpen(false);
-        }
-      } else if (event.key === "Escape") {
-        event.preventDefault();
-        setOpen(false);
-      } else if (event.key === "Tab" && !event.shiftKey) {
-        if (!query && filteredGroups.length > 1) {
-          event.preventDefault();
-          const currentIdx = filteredGroups.findIndex((g) => g.key === currentKey);
-          const nextGroup = filteredGroups[(currentIdx + 1) % filteredGroups.length];
-          if (nextGroup) setActiveControllerKey(nextGroup.key);
-        }
-      }
-    },
-    [flatItems, highlightedIndex, moveHighlight, onSelect, query, filteredGroups, currentKey],
+    [close, onSelect],
   );
 
   return (
@@ -119,7 +54,7 @@ export function AgentModelPicker({
       onBlur={(event) => {
         const nextTarget = event.relatedTarget;
         if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return;
-        setOpen(false);
+        close();
       }}
       onPointerDown={stopToolbarEvent}
       onMouseDown={stopToolbarEvent}
@@ -132,97 +67,48 @@ export function AgentModelPicker({
         notRunning={selectedModelNotRunning}
         onToggle={() => {
           if (disabled) return;
-          if (open) setOpen(false);
-          else openDropdown();
+          if (open) close();
+          else setOpen(true);
         }}
       />
       {open ? (
         <div
-          className="absolute bottom-full right-0 z-10 mb-2 flex max-h-[352px] w-[372px] flex-col overflow-hidden rounded-[var(--rad-lg)] border border-(--color-popover-border) bg-(--color-popover) shadow-[0_20px_56px_rgba(0,0,0,0.58),inset_0_1px_0_rgba(255,255,255,0.035)]"
-          onPointerDown={stopToolbarEvent}
-          onMouseDown={stopToolbarEvent}
-          onKeyDown={handleKeyDown}
+          className="absolute bottom-full right-0 z-10 mb-1.5 min-w-48 rounded-lg border border-(--color-popover-border) bg-(--color-popover) p-1 shadow-[0_12px_32px_rgba(0,0,0,0.48)]"
+          role="menu"
+          aria-label="Models"
+          onKeyDown={(event) => handleMenuKeyDown(event, close)}
         >
-          <div className="shrink-0 border-b border-(--color-popover-border) bg-(--color-popover-header) px-2.5 py-2">
-            <div className="mb-1.5 flex items-center justify-between gap-3">
-              <span className="text-[length:var(--fs-sm)] font-medium text-(--fg)">Models</span>
-              <span className="font-mono text-[length:var(--fs-2xs)] text-(--dim)">
-                {models.length} available
-              </span>
-            </div>
-            <div className="flex h-7 items-center gap-2 rounded-md border border-(--color-popover-border) bg-(--color-input) px-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.025)]">
-              <Search className="h-3 w-3 shrink-0 text-(--dim)" />
-              <input
-                ref={searchRef}
-                value={query}
-                onChange={(event) => handleSearchChange(event.target.value)}
-                placeholder="Search models…"
-                className="min-w-0 flex-1 bg-transparent text-[length:var(--fs-sm)] text-(--fg) outline-none placeholder:text-(--dim)/60"
+          {groups.length > 1 ? (
+            groups.map((group) => (
+              <ModelGroupOption
+                key={group.key}
+                group={group}
+                active={group.key === activeGroupKey}
+                selected={group.key === selectedGroupKey}
+                onActivate={() => setActiveGroupKey(group.key)}
               />
-              <kbd className="shrink-0 rounded border border-(--color-popover-border) bg-(--color-popover) px-1.5 py-0.5 font-mono text-[length:var(--fs-2xs)] text-(--dim)">
-                esc
-              </kbd>
-            </div>
-          </div>
-
-          {!query && filteredGroups.length > 1 ? (
-            <div className="flex shrink-0 items-center gap-2 border-b border-(--color-popover-border) px-2.5 py-1.5">
-              <div className="flex shrink-0 items-center gap-1.5 font-mono text-[length:var(--fs-2xs)] uppercase tracking-[0.12em] text-(--dim)">
-                <Server className="h-3 w-3" />
-                Source
-              </div>
-              <div className="flex min-w-0 items-center gap-1 overflow-x-auto">
-                {filteredGroups.map((group) => (
-                  <button
-                    key={group.key}
-                    type="button"
-                    onClick={() => setActiveControllerKey(group.key)}
-                    className={cx(
-                      "inline-flex h-6 shrink-0 items-center gap-1.5 rounded-md border px-1.5 font-mono text-[length:var(--fs-2xs)] transition-colors active:translate-y-px",
-                      group.key === currentKey
-                        ? "border-(--color-popover-border) bg-(--color-input) text-(--fg)"
-                        : "border-transparent text-(--dim) hover:bg-(--hover) hover:text-(--fg)",
-                    )}
-                  >
-                    {group.name || controllerLabel || "local"}
-                    <span className="text-(--dim)">{group.models.length}</span>
-                  </button>
-                ))}
-              </div>
+            ))
+          ) : (
+            <ModelOptions
+              models={groups[0]?.models ?? []}
+              selectedModel={selectedModel}
+              onSelect={select}
+            />
+          )}
+          {groups.length > 1 && activeGroup ? (
+            <div
+              className="absolute bottom-0 right-[calc(100%+4px)] max-h-72 w-max min-w-52 max-w-80 overflow-y-auto rounded-lg border border-(--color-popover-border) bg-(--color-popover) p-1 shadow-[0_12px_32px_rgba(0,0,0,0.48)]"
+              role="menu"
+              aria-label={activeGroup.name}
+              onMouseEnter={() => setActiveGroupKey(activeGroup.key)}
+            >
+              <ModelOptions
+                models={activeGroup.models}
+                selectedModel={selectedModel}
+                onSelect={select}
+              />
             </div>
           ) : null}
-
-          <div ref={listRef} className="min-h-0 flex-1 overflow-y-auto p-1">
-            {flatItems.length === 0 ? (
-              <div className="px-3 py-8 text-center text-[length:var(--fs-sm)] text-(--dim)">
-                No models match &ldquo;{query}&rdquo;.
-              </div>
-            ) : (
-              flatItems.map((item, index) =>
-                item.type === "header" ? (
-                  <div
-                    key={`header-${item.label}`}
-                    className="px-2 pb-1 pt-2 font-mono text-[length:var(--fs-2xs)] uppercase tracking-[0.12em] text-(--dim)"
-                  >
-                    {item.label}
-                  </div>
-                ) : (
-                  <ModelOption
-                    key={item.model.id}
-                    model={item.model}
-                    selected={item.model.id === selectedModel}
-                    highlighted={index === highlightedIndex}
-                    dataIdx={index}
-                    onSelect={(modelId) => {
-                      onSelect(modelId);
-                      setOpen(false);
-                    }}
-                    onHover={() => setHighlightedIndex(index)}
-                  />
-                ),
-              )
-            )}
-          </div>
         </div>
       ) : null}
     </div>
@@ -252,145 +138,106 @@ function ModelPickerTrigger({
       onClick={onToggle}
       disabled={disabled}
       className={cx(
-        "group/model inline-flex !h-7 !min-h-7 !min-w-0 items-center gap-1 rounded-md bg-transparent px-1.5 text-[length:var(--fs-sm)] text-(--dim) transition-colors hover:bg-(--hover) hover:text-(--fg) active:translate-y-px disabled:opacity-60",
+        "group/model inline-flex !h-7 !min-h-7 !min-w-0 items-center justify-between gap-1 rounded-lg bg-transparent pl-2 pr-1.5 text-[13px] whitespace-nowrap text-(--dim) transition-colors hover:bg-(--hover) hover:text-(--fg) active:translate-y-px disabled:opacity-60",
         open && "bg-(--hover) text-(--fg)",
       )}
       title={notRunning ? `${title} is not running — launch it or pick a running model` : title}
       aria-label={`Model: ${title}${notRunning ? " (not running)" : ""}`}
+      aria-expanded={open}
+      aria-haspopup="menu"
     >
-      <span className={cx("inline-block max-w-[148px] truncate whitespace-nowrap align-middle")}>
-        {label}
-      </span>
+      <span className="max-w-[148px] truncate text-left">{label}</span>
       {notRunning ? <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-(--warn)" /> : null}
-      <ChevronDown className={cx("h-3 w-3 shrink-0 transition-transform", open && "rotate-180")} />
+      <ChevronDown className="pointer-events-none h-3.5 w-3.5 shrink-0 text-(--dim)" />
     </button>
   );
+}
+
+function ModelGroupOption({
+  group,
+  active,
+  selected,
+  onActivate,
+}: {
+  group: ModelGroup;
+  active: boolean;
+  selected: boolean;
+  onActivate: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      className={cx(
+        "flex min-h-8 w-full min-w-0 items-center gap-2 rounded-md px-2 text-left text-[13px] text-(--fg) transition-colors hover:bg-(--hover) focus-visible:bg-(--hover) focus-visible:outline-none active:translate-y-px",
+        active && "bg-(--hover)",
+      )}
+      onMouseEnter={onActivate}
+      onFocus={onActivate}
+      onClick={onActivate}
+    >
+      <span className="min-w-0 flex-1 truncate">{group.name}</span>
+      <span className="font-mono text-[length:var(--fs-2xs)] text-(--dim)">
+        {group.models.length}
+      </span>
+      {selected ? <Check className="h-3.5 w-3.5 shrink-0 text-(--dim)" /> : null}
+      <ChevronDown className="h-3.5 w-3.5 shrink-0 -rotate-90 text-(--dim)" />
+    </button>
+  );
+}
+
+function ModelOptions({
+  models,
+  selectedModel,
+  onSelect,
+}: {
+  models: AgentModel[];
+  selectedModel: string;
+  onSelect: (modelId: string) => void;
+}) {
+  return models.map((model) => (
+    <ModelOption
+      key={model.id}
+      model={model}
+      selected={model.id === selectedModel}
+      onSelect={onSelect}
+    />
+  ));
 }
 
 function ModelOption({
   model,
   selected,
-  highlighted,
-  dataIdx,
   onSelect,
-  onHover,
 }: {
   model: AgentModel;
   selected: boolean;
-  highlighted: boolean;
-  dataIdx: number;
   onSelect: (modelId: string) => void;
-  onHover: () => void;
 }) {
+  const label = model.rawId || model.name;
   return (
     <button
       type="button"
-      data-idx={dataIdx}
+      role="menuitemradio"
+      aria-checked={selected}
       onClick={() => onSelect(model.id)}
-      onMouseEnter={onHover}
       className={cx(
-        "flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors",
-        highlighted ? "bg-(--hover)" : "",
-        selected && !highlighted ? "bg-(--color-input)" : "",
+        "flex min-h-8 w-full min-w-0 items-center gap-2 rounded-md pl-2 pr-2 text-left text-[13px] text-(--fg) transition-colors hover:bg-(--hover) focus-visible:bg-(--hover) focus-visible:outline-none active:translate-y-px",
+        selected && "bg-(--color-input)",
       )}
     >
-      <span className="min-w-0 flex-1">
-        <span className="flex items-center gap-1.5">
-          <span className="truncate text-[length:var(--fs-sm)] text-(--fg)">
-            {model.rawId || model.name}
-          </span>
-          {model.reasoning ? (
-            <span
-              className="shrink-0 rounded-[3px] bg-(--accent)/15 px-1 text-[length:var(--fs-2xs)] text-(--accent)"
-              title="Reasoning model"
-            >
-              R
-            </span>
-          ) : null}
-          {model.vision ? (
-            <span
-              className="shrink-0 rounded-[3px] bg-(--hl2)/15 px-1 text-[length:var(--fs-2xs)] text-(--hl2)"
-              title="Vision capable"
-            >
-              V
-            </span>
-          ) : null}
-          {model.active ? (
-            <span
-              className="ml-auto inline-flex shrink-0 items-center gap-1 rounded-[3px] bg-(--ok)/15 px-1.5 py-0.5 text-[length:var(--fs-2xs)] text-(--ok)"
-              title="Currently running — ready to use without launching"
-            >
-              <span className="h-1 w-1 rounded-full bg-(--ok)" />
-              running
-            </span>
-          ) : null}
-        </span>
-        <span className="mt-0.5 block truncate font-mono text-[length:var(--fs-2xs)] text-(--dim)">
-          {formatCompactNumber(model.contextWindow)} ctx
-          {model.maxTokens !== model.contextWindow
-            ? ` · ${formatCompactNumber(model.maxTokens)} out`
-            : ""}
-        </span>
+      <span className="min-w-0 flex-1 truncate" title={label}>
+        {label}
       </span>
       {selected ? <Check className="h-3.5 w-3.5 shrink-0 text-(--fg)" /> : null}
     </button>
   );
 }
 
-function buildFilteredView(
-  _models: AgentModel[],
-  groups: ModelGroup[],
-  query: string,
-  currentKey: string | null,
-): { flatItems: FlatItem[]; filteredGroups: ModelGroup[] } {
-  const trimmed = query.trim().toLowerCase();
-  if (!trimmed) {
-    // No search: show only current tab's models
-    const currentGroup = groups.find((group) => group.key === currentKey) ?? groups[0];
-    const flat: FlatItem[] = (currentGroup?.models ?? []).map((model, i) => ({
-      type: "model" as const,
-      model,
-      groupIndex: i,
-    }));
-    return { flatItems: flat, filteredGroups: groups };
-  }
-
-  // Searching: show all matching models across all providers, grouped by provider
-  const matchingGroups: ModelGroup[] = [];
-  for (const group of groups) {
-    const matching = group.models.filter((model) => matchesQuery(model, trimmed));
-    if (matching.length > 0) {
-      matchingGroups.push({ ...group, models: matching });
-    }
-  }
-
-  const flat: FlatItem[] = [];
-  for (const group of matchingGroups) {
-    flat.push({ type: "header", label: group.name });
-    for (const model of group.models) {
-      flat.push({ type: "model", model, groupIndex: flat.length });
-    }
-  }
-  return { flatItems: flat, filteredGroups: matchingGroups };
-}
-
-function matchesQuery(model: AgentModel, query: string): boolean {
-  const haystack = [model.id, model.rawId, model.name, model.controllerName, model.providerId]
-    .filter(Boolean)
-    .join(" ")
-    .toLowerCase();
-  return query.split(/\s+/).every((term) => haystack.includes(term));
-}
-
-function findNextModelIndex(items: FlatItem[], current: number, direction: 1 | -1): number | null {
-  let idx = current;
-  for (let i = 0; i < items.length; i++) {
-    idx += direction;
-    if (idx < 0) idx = items.length - 1;
-    if (idx >= items.length) idx = 0;
-    if (items[idx]?.type === "model") return idx;
-  }
-  return null;
+function handleMenuKeyDown(event: ReactKeyboardEvent<HTMLDivElement>, close: () => void) {
+  if (event.key !== "Escape") return;
+  event.preventDefault();
+  close();
 }
 
 function modelTriggerLabel(
@@ -401,9 +248,6 @@ function modelTriggerLabel(
 ): string {
   const fallbackLabel = selectedModel || (modelCount === 0 ? "No models" : "model");
   if (loading) return active?.rawId || active?.name || fallbackLabel || "Loading…";
-  if (active?.controllerName && active.providerId?.startsWith("user-pi-")) {
-    return `${active.rawId || active.name}`;
-  }
   return active?.rawId || active?.name || fallbackLabel;
 }
 
@@ -420,45 +264,6 @@ function groupModelsByController(models: AgentModel[]): ModelGroup[] {
     else groups.set(key, { key, name: model.controllerName ?? "local", models: [model] });
   }
   return [...groups.values()];
-}
-
-function formatCompactNumber(value: number): string {
-  if (!Number.isFinite(value) || value <= 0) return "unknown";
-  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(value >= 10_000_000 ? 0 : 1)}M`;
-  if (value >= 1_000) return `${(value / 1_000).toFixed(value >= 10_000 ? 0 : 1)}K`;
-  return String(value);
-}
-
-function subscribeToControllerStorage(callback: () => void): () => void {
-  if (typeof window === "undefined") return () => undefined;
-  window.addEventListener("storage", callback);
-  return () => window.removeEventListener("storage", callback);
-}
-
-function computeActiveControllerLabel(): string | null {
-  if (typeof window === "undefined") return null;
-  const url = getStoredBackendUrl();
-  if (!url) return null;
-  const saved = loadSavedControllers();
-  if (saved.length === 0) return null;
-  const match = saved.find((entry) => entry.url === url);
-  return match?.name?.trim() || shortHost(url);
-}
-
-function useActiveControllerLabel(): string | null {
-  return useSyncExternalStore(
-    subscribeToControllerStorage,
-    computeActiveControllerLabel,
-    () => null,
-  );
-}
-
-function shortHost(url: string): string {
-  try {
-    return new URL(url).host || url;
-  } catch {
-    return url;
-  }
 }
 
 function stopToolbarEvent(event: MouseEvent | PointerEvent) {

--- a/frontend/src/features/agent/ui/chat-pane.tsx
+++ b/frontend/src/features/agent/ui/chat-pane.tsx
@@ -28,7 +28,6 @@ import { useSessionEngine } from "@/features/agent/runtime/engine";
 import { useTools } from "@/features/agent/tools/context";
 import type { GitSummary } from "@/features/agent/projects/types";
 import type { BrowserBackend } from "@/features/agent/tools/types";
-import { CloseIcon, ReloadIcon } from "@/ui/icons";
 import {
   exportFilenameFromTitle,
   sessionToMarkdown,
@@ -39,10 +38,6 @@ const Timeline = dynamic(
   () => import("@/features/agent/ui/timeline/timeline").then((mod) => mod.Timeline),
   { ssr: false, loading: () => <TimelineFallback /> },
 );
-
-const FINALIZATION_RETRY_ERROR_RE =
-  /Model did not produce a valid final response\.?\s+Retrying finalization/i;
-const BENIGN_TRANSPORT_ERROR_RE = /^(?:terminated|abort(?:ed)?|network error|load failed)$/i;
 
 function downloadTextFile(filename: string, content: string): void {
   if (typeof document === "undefined") return;
@@ -55,18 +50,6 @@ function downloadTextFile(filename: string, content: string): void {
   anchor.click();
   anchor.remove();
   URL.revokeObjectURL(url);
-}
-
-function visibleSessionError(error?: string): string {
-  const value = error?.trim() ?? "";
-  return FINALIZATION_RETRY_ERROR_RE.test(value) || BENIGN_TRANSPORT_ERROR_RE.test(value)
-    ? ""
-    : value;
-}
-
-function canRetrySession(tab: SessionTab | null, hasModel: boolean, running: boolean): boolean {
-  if (!tab || !hasModel || running) return false;
-  return tab.messages.some((message) => message.role === "user") || Boolean(tab.input.trim());
 }
 
 function EmptyPromptTimeline() {
@@ -271,7 +254,7 @@ export function ChatPane({
     updateSession: updateTab,
     selectionFor: tools.selectionFor,
   });
-  const { sendMessage, queueMessage, removeQueued, editQueued, steerQueued, abortTurn, retryLast } =
+  const { sendMessage, queueMessage, removeQueued, editQueued, steerQueued, abortTurn } =
     useChatPaneSendFlow({
       activeTab,
       attachments,
@@ -320,12 +303,6 @@ export function ChatPane({
     onRegisterHandle,
     running: Boolean(running),
   });
-  const visibleError = visibleSessionError(activeTab?.error);
-  const canRetry = canRetrySession(activeTab, Boolean(modelId), Boolean(running));
-  const dismissVisibleError = useCallback(() => {
-    if (!activeTab) return;
-    updateTab(activeTab.id, (tab) => ({ ...tab, error: "" }));
-  }, [activeTab, updateTab]);
   const exportSession = useCallback(() => {
     if (!activeTab) return;
     const markdown = sessionToMarkdown(activeTab.messages, displayedSessionTitle);
@@ -360,35 +337,6 @@ export function ChatPane({
           onClose={onClose}
           onToggleRightPanel={onToggleRightPanel}
         />
-      ) : null}
-      {visibleError ? (
-        <div
-          className="flex shrink-0 items-start gap-3 border-b border-(--border) bg-(--err)/10 px-4 py-2 text-xs text-(--err)"
-          role="alert"
-        >
-          <span className="min-w-0 flex-1 whitespace-pre-wrap break-words">{visibleError}</span>
-          {canRetry ? (
-            <button
-              type="button"
-              onClick={() => void retryLast()}
-              className="-my-0.5 inline-flex shrink-0 items-center gap-1 rounded-md border border-(--err)/30 px-1.5 py-0.5 text-(--err)/90 hover:bg-(--err)/10 hover:text-(--err)"
-              aria-label="Retry"
-              title="Resend the last message"
-            >
-              <ReloadIcon className="h-3 w-3 pointer-events-none" />
-              Retry
-            </button>
-          ) : null}
-          <button
-            type="button"
-            onClick={dismissVisibleError}
-            className="-my-1 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-(--err)/75 hover:bg-(--err)/10 hover:text-(--err)"
-            aria-label="Dismiss error"
-            title="Dismiss error"
-          >
-            <CloseIcon className="h-3 w-3 pointer-events-none" />
-          </button>
-        </div>
       ) : null}
       <div className="flex min-h-0 min-w-0 flex-1">
         {showEmptyPrompt ? (

--- a/frontend/src/features/agent/ui/filesystem-file-viewer.tsx
+++ b/frontend/src/features/agent/ui/filesystem-file-viewer.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useMemo, useRef, useState, type KeyboardEvent, type MouseEvent } from "react";
 import { Virtuoso } from "react-virtuoso";
 import { MessageSquarePlus, Minus } from "@/ui/icon-registry";
-import { highlightFenced } from "@/features/agent/highlight-cache";
+import { highlightLines } from "@/features/agent/highlight-cache";
 import type { FileComment } from "@/features/agent/filesystem-types";
 
 const EXT_TO_LANG: Record<string, string> = {
@@ -88,7 +88,7 @@ export function FileViewer({
   const highlightedLines = useMemo(() => {
     const lang = languageForPath(filePath);
     if (!lang) return null;
-    return lines.map((line) => highlightFenced(lang, line));
+    return highlightLines(lang, lines);
   }, [filePath, lines]);
   const commentsByLine = useMemo(() => {
     const map = new Map<number, FileComment[]>();

--- a/frontend/src/features/agent/ui/filesystem-tree.tsx
+++ b/frontend/src/features/agent/ui/filesystem-tree.tsx
@@ -110,9 +110,12 @@ export function TreeFileList({
         return (
           <div key={entry.path}>
             <div
-              className={`flex w-full items-center gap-1 rounded-sm py-0.5 text-left text-[length:var(--fs-sm)] hover:bg-(--color-surface-hover) ${isActive ? "bg-(--color-selected) text-(--fg)" : "text-(--dim)"}`}
+              className={`relative flex w-full items-center gap-1 rounded-sm py-0.5 text-left text-[length:var(--fs-sm)] hover:bg-(--color-surface-hover) ${isActive ? "bg-(--color-selected) font-medium text-(--fg)" : "text-(--dim)"}`}
               style={{ paddingLeft: `${8 + indent}px`, paddingRight: "8px" }}
             >
+              {isActive ? (
+                <span className="absolute inset-y-1 left-0 w-0.5 rounded-full bg-(--link)" />
+              ) : null}
               {isDir ? (
                 <button
                   type="button"
@@ -139,6 +142,7 @@ export function TreeFileList({
                 type="button"
                 onClick={() => (isDir ? onToggleDir(entry.rel) : onOpen(entry))}
                 title={entry.rel}
+                aria-current={isActive ? "page" : undefined}
                 className="flex min-w-0 flex-1 items-center gap-1 text-left"
               >
                 {isDir ? (

--- a/frontend/src/features/agent/workspace/effects.ts
+++ b/frontend/src/features/agent/workspace/effects.ts
@@ -284,7 +284,9 @@ function queueReplayEffects(
       }
       return;
     case "urlNavRequested":
-      if (action.sessionId) queueLocatedReplay(action.sessionId, nextState, deps);
+      if (action.sessionId && !findPaneByPiSessionId(prevState, action.sessionId)) {
+        queueLocatedReplay(action.sessionId, nextState, deps);
+      }
       return;
     default:
       return;

--- a/frontend/src/features/agent/workspace/replay-queue.ts
+++ b/frontend/src/features/agent/workspace/replay-queue.ts
@@ -48,7 +48,7 @@ export function createSessionReplayQueue(deps: SessionReplayQueueDeps): SessionR
     if (!handle) return;
     const sessionId = paneSessionId(deps.getState().panesById.get(paneId));
     const current = sessionId ? deps.getState().sessions.get(sessionId) : undefined;
-    if (!current || isFreshStarter(current)) {
+    if (!current || isFreshStarter(current) || current.messages.length > 0) {
       pending.delete(paneId);
       return;
     }

--- a/frontend/src/features/settings/attach-local-agents-dialog.tsx
+++ b/frontend/src/features/settings/attach-local-agents-dialog.tsx
@@ -78,7 +78,7 @@ export function AttachLocalAgentsDialog({ modelId, modelName, onClose }: Props) 
           <p className="text-sm text-(--ui-muted)">Detecting local agents…</p>
         ) : agents.length === 0 ? (
           <p className="text-sm text-(--ui-muted)">
-            No local agents detected (looked for pi, opencode, droid, hermes, and omp config
+            No local agents detected (looked for pi, opencode, droid, Hermes, and omp config
             directories).
           </p>
         ) : (

--- a/frontend/src/features/settings/local-agent-detection.ts
+++ b/frontend/src/features/settings/local-agent-detection.ts
@@ -93,7 +93,7 @@ export async function detectLocalAgents(home: string): Promise<LocalAgentTarget[
     const configPath = hermesConfigPath(home);
     targets.push({
       agent: "hermes",
-      label: "hermes",
+      label: "Hermes",
       configPath,
       exists: await pathExists(configPath),
     });

--- a/services/agent-runtime/src/pi-runtime-state.ts
+++ b/services/agent-runtime/src/pi-runtime-state.ts
@@ -1,11 +1,7 @@
 // Pure pi-runtime state derivation. This module must stay free of runtime
 // imports of @earendil-works/pi-coding-agent (ESM-only) so the node test
 // runner can load it; pi-runtime-types only contributes erased type imports.
-import type {
-  LoggedPiEvent,
-  PiAgentStatus,
-  PiContextUsage,
-} from "./pi-runtime-types";
+import type { LoggedPiEvent, PiAgentStatus, PiContextUsage } from "./pi-runtime-types";
 
 type RuntimeLookupEntry<TSession> = {
   sessionId: string;
@@ -20,12 +16,14 @@ export function findRuntimeSessionForLookup<
   piSessionId?: string | null,
 ): RuntimeLookupEntry<TSession> | null {
   const snapshot = [...entries];
+  const exact = snapshot.find((entry) => entry.sessionId === sessionId);
+  if (exact) return exact;
   const target = piSessionId?.trim();
   if (target) {
     const piMatch = snapshot.find((entry) => entry.session.status.piSessionId === target);
     if (piMatch) return piMatch;
   }
-  return snapshot.find((entry) => entry.sessionId === sessionId) ?? null;
+  return null;
 }
 
 export function piStatusFromEvents(input: {

--- a/tests/frontend/e2e/agent-session-runtime-regressions.test.ts
+++ b/tests/frontend/e2e/agent-session-runtime-regressions.test.ts
@@ -106,7 +106,10 @@ test("turn command result parser preserves runtime status", () => {
 });
 
 test("invalid assistant continuations restart with a fresh Pi session", () => {
-  assert.equal(shouldRestartAfterPromptError(new Error("Cannot continue from message role: assistant")), true);
+  assert.equal(
+    shouldRestartAfterPromptError(new Error("Cannot continue from message role: assistant")),
+    true,
+  );
   assert.equal(shouldRestartAfterPromptError(new Error("Upstream connection failed")), false);
 });
 
@@ -430,6 +433,23 @@ test("runtime lookup by unknown pi session does not create an empty runtime", ()
 
   assert.equal(resolved, null);
   assert.equal(after, before);
+});
+
+test("runtime lookup prefers the exact local session over an older pi match", () => {
+  const sessions = [
+    {
+      sessionId: "rt-old",
+      session: { status: { piSessionId: "pi-shared" }, marker: "old" },
+    },
+    {
+      sessionId: "rt-current",
+      session: { status: { piSessionId: "pi-shared" }, marker: "current" },
+    },
+  ];
+
+  const resolved = findRuntimeSessionForLookup(sessions, "rt-current", "pi-shared");
+
+  assert.equal(resolved?.session.marker, "current");
 });
 
 test("finished runtime event streams replay missed pi events before idle status", () => {

--- a/tests/frontend/e2e/agent-workspace-regressions.test.ts
+++ b/tests/frontend/e2e/agent-workspace-regressions.test.ts
@@ -288,6 +288,33 @@ test("session list refreshes fire immediately and again after the settle delay",
   assert.equal(harness2.fired.filter((entry) => entry.type === SESSIONS_CHANGED_EVENT).length, 0);
 });
 
+test("url navigation does not replay an already-open session", () => {
+  const session = makeSession("s-open", {
+    piSessionId: "pi-open",
+    messages: [{ id: "u-1", role: "user", text: "keep this transcript" }],
+    status: "running",
+  });
+  const prev = makeState(session);
+  const next = { ...prev, lastHandledNavKey: "open-existing" };
+  const { deps, replays } = makeEffectDeps();
+
+  runWorkspaceEffect(
+    {
+      type: "urlNavRequested",
+      key: "open-existing",
+      project: null,
+      sessionId: "pi-open",
+      paneId: "p-unused",
+      tab: makeSession("s-unused"),
+    },
+    prev,
+    next,
+    deps,
+  );
+
+  assert.deepEqual(replays, []);
+});
+
 // ----- session replay queue (workspace/replay-queue.ts) -----
 
 type ReplayHarness = {
@@ -400,6 +427,24 @@ test("replay queue is last-wins per pane and immediate when the handle exists", 
   // Two drains ran but the pending slot was consumed by the first; only the
   // newest queued id replays.
   assert.deepEqual(harness.replays, [{ paneId: "p-1", piSessionId: "pi-b" }]);
+});
+
+test("replay queue preserves a populated live transcript", () => {
+  const harness = makeReplayHarness();
+  harness.setHandle("p-1", true);
+  harness.setSession(
+    "p-1",
+    makeSession("s-live", {
+      piSessionId: "pi-live",
+      messages: [{ id: "u-1", role: "user", text: "keep this transcript" }],
+      status: "running",
+    }),
+  );
+
+  harness.queue.queue("p-1", "pi-live");
+  harness.runTimers();
+
+  assert.deepEqual(harness.replays, []);
 });
 
 test("a replay queued for a pane that never mounts stays inert", () => {

--- a/tests/frontend/e2e/local-agents.test.ts
+++ b/tests/frontend/e2e/local-agents.test.ts
@@ -51,7 +51,7 @@ function makeModel(overrides: Partial<LocalAgentModel> = {}): LocalAgentModel {
 const readJson = (file: string) => JSON.parse(readFileSync(file, "utf-8"));
 const readYaml = (file: string) => JSON.parse(readFileSync(file, "utf-8")); // yaml output is still JSON-like
 
-test("detect: home with all four agents present, and a home with none", async () => {
+test("detect: home with all supported agents present, and a home with none", async () => {
   const home = makeHome();
   mkdirSync(path.join(home, ".pi"), { recursive: true });
   mkdirSync(path.join(home, ".config", "opencode"), { recursive: true });
@@ -62,12 +62,12 @@ test("detect: home with all four agents present, and a home with none", async ()
 
   const targets = await detectLocalAgents(home);
   assert.deepEqual(
-    targets.map((t) => [t.agent, t.configPath, t.exists]),
+    targets.map((t) => [t.agent, t.label, t.configPath, t.exists]),
     [
-      ["pi", path.join(home, ".pi", "agent", "models.json"), false],
-      ["opencode", path.join(home, ".config", "opencode", "opencode.json"), false],
-      ["droid", path.join(home, ".factory", "settings.json"), true],
-      ["hermes", path.join(home, ".hermes", "config.yaml"), true],
+      ["pi", "pi", path.join(home, ".pi", "agent", "models.json"), false],
+      ["opencode", "opencode", path.join(home, ".config", "opencode", "opencode.json"), false],
+      ["droid", "droid (Factory)", path.join(home, ".factory", "settings.json"), true],
+      ["hermes", "Hermes", path.join(home, ".hermes", "config.yaml"), true],
     ],
   );
 

--- a/tests/frontend/e2e/local-agents.test.ts
+++ b/tests/frontend/e2e/local-agents.test.ts
@@ -38,7 +38,7 @@ function makeModel(overrides: Partial<LocalAgentModel> = {}): LocalAgentModel {
   return {
     modelId: "deepseek-v4-flash",
     displayName: "HomeLab DeepSeek-V4-Flash",
-    baseUrl: "https://api.homelabai.org/v1",
+    baseUrl: "http://pop-os-1.tailadb2c1.ts.net:8080/v1",
     apiKey: "sk-studio-key",
     contextWindow: 128000,
     maxTokens: 128000,
@@ -84,7 +84,7 @@ test("pi: upserts into an existing same-baseUrl provider without touching its ap
     providers: {
       homelab: {
         // Trailing slash on purpose: matching must be trailing-slash-insensitive.
-        baseUrl: "https://api.homelabai.org/v1/",
+        baseUrl: "http://pop-os-1.tailadb2c1.ts.net:8080/v1/",
         apiKey: "sk-original-key",
         api: "openai-completions",
         models: [
@@ -153,7 +153,7 @@ test("pi: creates models.json with a local-studio provider when only ~/.pi exist
   const written = readJson(configPath);
   const provider = written.providers["local-studio"];
   assert.equal(provider.api, "openai-completions");
-  assert.equal(provider.baseUrl, "https://api.homelabai.org/v1");
+  assert.equal(provider.baseUrl, "http://pop-os-1.tailadb2c1.ts.net:8080/v1");
   assert.equal(provider.apiKey, "sk-studio-key");
   assert.equal(provider.models.length, 1);
   assert.equal(provider.models[0].id, "deepseek-v4-flash");
@@ -223,7 +223,7 @@ test("opencode: adds a new provider and preserves every other key", async () => 
   assert.deepEqual(written.provider["local-studio"], {
     npm: "@ai-sdk/openai-compatible",
     name: "Local Studio",
-    options: { baseURL: "https://api.homelabai.org/v1", apiKey: "sk-studio-key" },
+    options: { baseURL: "http://pop-os-1.tailadb2c1.ts.net:8080/v1", apiKey: "sk-studio-key" },
     models: {
       "deepseek-v4-flash": {
         id: "deepseek-v4-flash",
@@ -248,7 +248,7 @@ test("opencode: upserts into an existing matching-baseURL provider, leaving its 
           homelab: {
             npm: "@ai-sdk/openai-compatible",
             name: "HomeLab",
-            options: { baseURL: "https://api.homelabai.org/v1/", apiKey: "sk-existing" },
+            options: { baseURL: "http://pop-os-1.tailadb2c1.ts.net:8080/v1/", apiKey: "sk-existing" },
             models: { "old-model": { name: "Old" } },
           },
         },
@@ -265,7 +265,7 @@ test("opencode: upserts into an existing matching-baseURL provider, leaving its 
   const written = readJson(configPath);
   assert.deepEqual(Object.keys(written.provider), ["homelab"], "no new provider key");
   assert.deepEqual(written.provider.homelab.options, {
-    baseURL: "https://api.homelabai.org/v1/",
+    baseURL: "http://pop-os-1.tailadb2c1.ts.net:8080/v1/",
     apiKey: "sk-existing",
   });
   assert.deepEqual(Object.keys(written.provider.homelab.models).sort(), [
@@ -313,7 +313,7 @@ test("droid: appends with next index + slug id; re-attach updates in place", asy
     model: "deepseek-v4-flash",
     id: "custom:HomeLab-DeepSeek-V4-Flash-4",
     index: 4,
-    baseUrl: "https://api.homelabai.org/v1",
+    baseUrl: "http://pop-os-1.tailadb2c1.ts.net:8080/v1",
     apiKey: "sk-studio-key",
     displayName: "HomeLab DeepSeek-V4-Flash",
     maxContextLimit: 128000,
@@ -353,7 +353,7 @@ test("hermes: appends to custom_models and updates existing entry by model+base_
   const written = readFileSync(configPath, "utf-8");
   assert.ok(written.includes("name: HomeLab DeepSeek-V4-Flash"));
   assert.ok(written.includes("model: deepseek-v4-flash"));
-  assert.ok(written.includes("base_url: https://api.homelabai.org/v1"));
+  assert.ok(written.includes("base_url: http://pop-os-1.tailadb2c1.ts.net:8080/v1"));
   assert.ok(written.includes("api_key: sk-studio-key"));
   assert.ok(written.includes("provider: custom"));
   assert.ok(written.includes("reasoning_effort: high"));

--- a/tests/frontend/e2e/session-runtime-controller.test.ts
+++ b/tests/frontend/e2e/session-runtime-controller.test.ts
@@ -182,6 +182,46 @@ test("merge without runtime events returns the canonical log untouched", () => {
   assert.deepEqual(mergeCanonicalAndRuntimeEvents(canonical), canonical);
 });
 
+test("merge aligns repeated prompts by the longest runtime message sequence", () => {
+  const canonical = [
+    userEvent("start"),
+    assistantEvent("started"),
+    userEvent("what happened"),
+    assistantEvent("first explanation"),
+    userEvent("what happened"),
+    assistantEvent("second explanation"),
+  ];
+  const runtime: RuntimeLoggedEvent[] = [
+    { seq: 2, event: assistantEvent("second explanation") },
+    { seq: 1, event: userEvent("what happened") },
+  ];
+
+  assert.deepEqual(mergeCanonicalAndRuntimeEvents(canonical, runtime), canonical);
+});
+
+test("runtime replay preserves repeated user prompts across completed turns", () => {
+  const events = [
+    { type: "message_start", message: { role: "user", content: "what happened" } },
+    { type: "message_end", message: { role: "user", content: "what happened" } },
+    assistantEvent("first explanation"),
+    { type: "message_start", message: { role: "user", content: "what happened" } },
+    { type: "message_end", message: { role: "user", content: "what happened" } },
+    assistantEvent("second explanation"),
+  ];
+
+  const messages = foldSessionEvents(events).messages;
+
+  assert.deepEqual(
+    messages.map((message) => [message.role, message.text]),
+    [
+      ["user", "what happened"],
+      ["assistant", "first explanation"],
+      ["user", "what happened"],
+      ["assistant", "second explanation"],
+    ],
+  );
+});
+
 // ----- batch replay over the golden event log (runtime/pi-event-applier.ts foldSessionEvents) -----
 
 test("golden event log replays to the expected transcript", () => {
@@ -365,7 +405,8 @@ function createControllerHarness(
       if (prev.status !== "idle" && session.status === "idle") order.push("idle-patch");
       const joinedBlocks = (entry: Session) =>
         (entry.messages.at(-1)?.blocks ?? []).map((block) => block.text).join("");
-      if (joinedBlocks(session) !== joinedBlocks(prev)) order.push(`blocks:${joinedBlocks(session)}`);
+      if (joinedBlocks(session) !== joinedBlocks(prev))
+        order.push(`blocks:${joinedBlocks(session)}`);
     },
     getSession: (sessionId) => (sessionId === session.id ? session : undefined),
     getSessions: () => [session],
@@ -560,10 +601,7 @@ test("reconnect mid-coalesce replays nothing and commits the merged text exactly
   harness.emit({ type: "pi", seq: 1, event: partialDeltaEvent("a", "a") });
   harness.emit({ type: "pi", seq: 2, event: partialDeltaEvent("b", "ab") });
   harness.emit({ type: "pi", seq: 3, event: partialDeltaEvent("c", "abc") });
-  assert.equal(
-    harness.order.filter((entry) => entry.startsWith("blocks:")).length,
-    blocksBefore,
-  );
+  assert.equal(harness.order.filter((entry) => entry.startsWith("blocks:")).length, blocksBefore);
 
   // The frame fires: exactly one commit applies "abc" and stamps the cursor.
   harness.frames.runAll();
@@ -714,9 +752,7 @@ function createPollHarness(initial: Session[]): PollHarness {
 }
 
 test("poll promotes an active runtime to running and adopts its key via the pi match", async () => {
-  const harness = createPollHarness([
-    pollSession({ status: "idle", piSessionId: "pi-1" }),
-  ]);
+  const harness = createPollHarness([pollSession({ status: "idle", piSessionId: "pi-1" })]);
   harness.controller.pollNow();
   assert.equal(harness.fetchCount(), 1);
 


### PR DESCRIPTION
## What changed

- preserve durable task history, repeated prompts, tool previews, and reasoning during active-session navigation
- prefer the exact local runtime when several runtime instances share one durable task id
- prevent populated tasks from being destructively replay-hydrated
- replace the oversized composer model popup with a compact ZCode-style provider menu
- keep task connection errors in the timeline instead of duplicating them as a top banner

## Why

Active task navigation could select an older runtime alias and replace the complete durable transcript with an incomplete runtime buffer. The composer model menu also carried unnecessary search, source, capability, and metadata chrome.

## Validation

- npm run check
- npm --prefix frontend run test
- npm run test:e2e
- npm --prefix frontend run desktop:dist
- packaged desktop proxy health, model discovery, and live DeepSeek completion