### PR TITLE
refactor: share controller extra-arg serialization

### DIFF
--- a/controller/src/modules/engines/argument-utilities.ts
+++ b/controller/src/modules/engines/argument-utilities.ts
@@ -13,6 +13,19 @@ export const extractFlag = (args: string[], flag: string): string | undefined =>
   return undefined;
 };
 
+export const getExtraArgument = (
+  extraArguments: Record<string, unknown>,
+  key: string,
+): unknown => {
+  if (Object.prototype.hasOwnProperty.call(extraArguments, key)) return extraArguments[key];
+  const kebab = key.replace(/_/g, "-");
+  if (Object.prototype.hasOwnProperty.call(extraArguments, kebab)) return extraArguments[kebab];
+  const snake = key.replace(/-/g, "_");
+  return Object.prototype.hasOwnProperty.call(extraArguments, snake)
+    ? extraArguments[snake]
+    : undefined;
+};
+
 const executableName = (value: string | undefined): string => {
   if (!value) return "";
   return value.split(/[\\/]/).filter(Boolean).at(-1)?.toLowerCase() ?? value.toLowerCase();

--- a/controller/src/modules/engines/process/backend-builder.ts
+++ b/controller/src/modules/engines/process/backend-builder.ts
@@ -13,6 +13,9 @@ import { resolveBinary } from "../../../core/command";
 import { managedLlamaServerPath } from "../runtimes/managed-llamacpp";
 import { getEngineSpec } from "../engine-spec";
 import { resolveRecipeGpuUuids } from "../../system/gpu-leases";
+import { getExtraArgument } from "../argument-utilities";
+
+export { getExtraArgument };
 
 export const normalizeJsonArgument = (value: unknown): unknown => {
   if (Array.isArray(value)) {
@@ -29,20 +32,45 @@ export const normalizeJsonArgument = (value: unknown): unknown => {
   }
   return value;
 };
-export const getExtraArgument = (extraArguments: Record<string, unknown>, key: string): unknown => {
-  if (Object.prototype.hasOwnProperty.call(extraArguments, key)) {
-    return extraArguments[key];
+
+type ExtraArgumentSerializer = (flag: string, key: string, value: unknown) => string[];
+
+const appendSerializedArguments = (
+  command: string[],
+  extraArguments: Record<string, unknown>,
+  serialize: ExtraArgumentSerializer,
+): string[] => {
+  for (const [key, value] of Object.entries(extraArguments)) {
+    if (isInternalRecipeKey(key)) continue;
+    const flag = `--${key.replace(/_/g, "-")}`;
+    if (command.includes(flag)) continue;
+    command.push(...serialize(flag, key, value));
   }
-  const kebab = key.replace(/_/g, "-");
-  if (Object.prototype.hasOwnProperty.call(extraArguments, kebab)) {
-    return extraArguments[kebab];
-  }
-  const snake = key.replace(/-/g, "_");
-  if (Object.prototype.hasOwnProperty.call(extraArguments, snake)) {
-    return extraArguments[snake];
-  }
-  return undefined;
+  return command;
 };
+
+const serializeExtraArgument: ExtraArgumentSerializer = (flag, key, value) => {
+  if (value === true) return [flag];
+  if (value === false) {
+    return key.replace(/-/g, "_").toLowerCase() === "enable_expert_parallelism" ? [] : [flag];
+  }
+  if (value === undefined || value === null) return [];
+  if (typeof value === "string" && isJsonStringArgumentKey(key)) {
+    const trimmed = value.trim();
+    if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+      try {
+        return [flag, JSON.stringify(normalizeJsonArgument(JSON.parse(trimmed) as unknown))];
+      } catch {
+        return [flag, value];
+      }
+    }
+  }
+  if (Array.isArray(value) || (value && typeof value === "object")) {
+    return [flag, JSON.stringify(normalizeJsonArgument(value))];
+  }
+  return [flag, String(value)];
+};
+
 export const getPythonPath = (recipe: Recipe): string | undefined => {
   if (recipe.python_path && existsSync(recipe.python_path)) {
     return recipe.python_path;
@@ -59,50 +87,7 @@ export const getPythonPath = (recipe: Recipe): string | undefined => {
 export const appendExtraArguments = (
   command: string[],
   extraArguments: Record<string, unknown>,
-): string[] => {
-  for (const [key, value] of Object.entries(extraArguments)) {
-    const normalizedKey = key.replace(/-/g, "_").toLowerCase();
-    if (isInternalRecipeKey(key)) {
-      continue;
-    }
-    const flag = `--${key.replace(/_/g, "-")}`;
-    if (command.includes(flag)) {
-      continue;
-    }
-    if (value === true) {
-      command.push(flag);
-      continue;
-    }
-    if (value === false) {
-      if (!["enable_expert_parallelism", "enable-expert-parallelism"].includes(normalizedKey)) {
-        command.push(flag);
-      }
-      continue;
-    }
-    if (value === undefined || value === null) {
-      continue;
-    }
-    if (typeof value === "string" && isJsonStringArgumentKey(key)) {
-      const trimmed = value.trim();
-      if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
-        try {
-          const parsed = JSON.parse(trimmed) as unknown;
-          command.push(flag, JSON.stringify(normalizeJsonArgument(parsed)));
-          continue;
-        } catch {
-          command.push(flag, value);
-          continue;
-        }
-      }
-    }
-    if (Array.isArray(value) || (value && typeof value === "object")) {
-      command.push(flag, JSON.stringify(normalizeJsonArgument(value)));
-      continue;
-    }
-    command.push(flag, String(value));
-  }
-  return command;
-};
+): string[] => appendSerializedArguments(command, extraArguments, serializeExtraArgument);
 
 /**
  * Filter `extraArguments` against the vLLM `serve` flag allowlist and pass the
@@ -409,42 +394,20 @@ export const resolveLlamaBinary = (recipe: Recipe, config: Config): string => {
   const managed = managedLlamaServerPath(config);
   return resolveBinary("llama-server") ?? (existsSync(managed) ? managed : "llama-server");
 };
+
+const serializeLlamacppArgument: ExtraArgumentSerializer = (flag, _key, value) => {
+  if (value === true) return [flag];
+  if (value === false || value === undefined || value === null || value === "") return [];
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) =>
+      entry === undefined || entry === null || entry === "" ? [] : [flag, String(entry)],
+    );
+  }
+  if (typeof value === "object") return [flag, JSON.stringify(value)];
+  return [flag, String(value)];
+};
+
 export const appendLlamacppArguments = (
   command: string[],
   extraArguments: Record<string, unknown>,
-): string[] => {
-  for (const [key, value] of Object.entries(extraArguments)) {
-    if (isInternalRecipeKey(key)) {
-      continue;
-    }
-    const flag = `--${key.replace(/_/g, "-")}`;
-    if (command.includes(flag)) {
-      continue;
-    }
-    if (value === true) {
-      command.push(flag);
-      continue;
-    }
-    if (value === false) {
-      continue;
-    }
-    if (value === undefined || value === null || value === "") {
-      continue;
-    }
-    if (Array.isArray(value)) {
-      for (const entry of value) {
-        if (entry === undefined || entry === null || entry === "") {
-          continue;
-        }
-        command.push(flag, String(entry));
-      }
-      continue;
-    }
-    if (typeof value === "object") {
-      command.push(flag, JSON.stringify(value));
-      continue;
-    }
-    command.push(flag, String(value));
-  }
-  return command;
-};
+): string[] => appendSerializedArguments(command, extraArguments, serializeLlamacppArgument);

--- a/controller/src/modules/engines/process/process-utilities.ts
+++ b/controller/src/modules/engines/process/process-utilities.ts
@@ -3,7 +3,10 @@ import { dirname } from "node:path";
 import type { Recipe } from "../../models/types";
 import type { Backend } from "@local-studio/contracts/recipes";
 import { detectEngineFromArguments } from "../engine-spec";
-import { extractFlag as extractFlagUtility } from "../argument-utilities";
+import {
+  extractFlag as extractFlagUtility,
+  getExtraArgument,
+} from "../argument-utilities";
 import { isManagedPythonBackend, managedVenvPython } from "../runtimes/managed-venv";
 import type { Config } from "../../../config/env";
 
@@ -69,7 +72,7 @@ export const buildEnvironment = (
   }
 
   const extraEnvironment =
-    recipe.extra_args["env_vars"] || recipe.extra_args["env-vars"] || recipe.extra_args["envVars"];
+    getExtraArgument(recipe.extra_args, "env_vars") ?? recipe.extra_args["envVars"];
   if (extraEnvironment && typeof extraEnvironment === "object") {
     for (const [key, value] of Object.entries(extraEnvironment as Record<string, unknown>)) {
       if (value !== undefined && value !== null) {
@@ -82,35 +85,22 @@ export const buildEnvironment = (
     env[key] = value;
   }
 
-  const readExtraArgument = (key: string): unknown => {
-    if (Object.prototype.hasOwnProperty.call(recipe.extra_args, key)) {
-      return recipe.extra_args[key];
-    }
-    const kebab = key.replace(/_/g, "-");
-    if (Object.prototype.hasOwnProperty.call(recipe.extra_args, kebab)) {
-      return recipe.extra_args[kebab];
-    }
-    const snake = key.replace(/-/g, "_");
-    if (Object.prototype.hasOwnProperty.call(recipe.extra_args, snake)) {
-      return recipe.extra_args[snake];
-    }
-    return undefined;
-  };
-
   const isDefined = (value: unknown): boolean => {
     return value !== undefined && value !== null && value !== false;
   };
 
   const visibleDevices =
-    readExtraArgument("visible_devices") ??
-    readExtraArgument("VISIBLE_DEVICES") ??
-    readExtraArgument("CUDA_VISIBLE_DEVICES") ??
-    readExtraArgument("cuda_visible_devices") ??
-    readExtraArgument("cuda-visible-devices");
+    getExtraArgument(recipe.extra_args, "visible_devices") ??
+    getExtraArgument(recipe.extra_args, "VISIBLE_DEVICES") ??
+    getExtraArgument(recipe.extra_args, "CUDA_VISIBLE_DEVICES") ??
+    getExtraArgument(recipe.extra_args, "cuda_visible_devices") ??
+    getExtraArgument(recipe.extra_args, "cuda-visible-devices");
   const hipVisibleDevices =
-    readExtraArgument("hip_visible_devices") ?? readExtraArgument("HIP_VISIBLE_DEVICES");
+    getExtraArgument(recipe.extra_args, "hip_visible_devices") ??
+    getExtraArgument(recipe.extra_args, "HIP_VISIBLE_DEVICES");
   const rocrVisibleDevices =
-    readExtraArgument("rocr_visible_devices") ?? readExtraArgument("ROCR_VISIBLE_DEVICES");
+    getExtraArgument(recipe.extra_args, "rocr_visible_devices") ??
+    getExtraArgument(recipe.extra_args, "ROCR_VISIBLE_DEVICES");
 
   const forcedTool = (process.env["LOCAL_STUDIO_GPU_SMI_TOOL"] ?? "").trim().toLowerCase();
   const platform =

--- a/controller/src/modules/system/gpu-leases.ts
+++ b/controller/src/modules/system/gpu-leases.ts
@@ -3,6 +3,7 @@ import { chmod, link, mkdir, readFile, rmdir, stat, unlink, writeFile } from "no
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Effect, Schema, Semaphore } from "effect";
+import { getExtraArgument } from "../engines/argument-utilities";
 import type { GpuInfo, Recipe } from "../models/types";
 
 const fullNvidiaUuid =
@@ -320,19 +321,9 @@ function isUnknownRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function extraArgument(extraArguments: Record<string, unknown>, key: string): unknown {
-  if (Object.prototype.hasOwnProperty.call(extraArguments, key)) return extraArguments[key];
-  const kebab = key.replace(/_/g, "-");
-  if (Object.prototype.hasOwnProperty.call(extraArguments, kebab)) return extraArguments[kebab];
-  const snake = key.replace(/-/g, "_");
-  return Object.prototype.hasOwnProperty.call(extraArguments, snake)
-    ? extraArguments[snake]
-    : undefined;
-}
-
 function directVisibilitySelector(recipe: Recipe): string | null {
   for (const key of directVisibilityKeys) {
-    const value = extraArgument(recipe.extra_args, key);
+    const value = getExtraArgument(recipe.extra_args, key);
     if (value === undefined || value === null) continue;
     return value === false ? null : String(value);
   }
@@ -342,7 +333,7 @@ function directVisibilitySelector(recipe: Recipe): string | null {
 function environmentVisibilitySelector(recipe: Recipe): string | null {
   let selector = recipe.env_vars?.["CUDA_VISIBLE_DEVICES"] ?? null;
   const extraEnvironment =
-    recipe.extra_args["env_vars"] || recipe.extra_args["env-vars"] || recipe.extra_args["envVars"];
+    getExtraArgument(recipe.extra_args, "env_vars") ?? recipe.extra_args["envVars"];
   if (!isUnknownRecord(extraEnvironment)) return selector;
   const value = extraEnvironment["CUDA_VISIBLE_DEVICES"];
   if (value !== undefined && value !== null) selector = String(value);

--- a/tests/controller/integration/vllm-extra-args.test.ts
+++ b/tests/controller/integration/vllm-extra-args.test.ts
@@ -2,8 +2,62 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 import {
   appendExtraArguments,
+  appendLlamacppArguments,
   appendVllmExtraArguments,
 } from "../../../controller/src/modules/engines/process/backend-builder";
+
+describe("CLI extra_args serialization", () => {
+  const extraArguments = {
+    "existing-flag": "ignored",
+    enabled: true,
+    disabled: false,
+    enable_expert_parallelism: false,
+    empty: "",
+    list: ["first", "second"],
+    object: { "nested-key": 1 },
+    description: "internal",
+    missing: null,
+  };
+
+  it("preserves the generic backend argument policy", () => {
+    const command = ["runtime", "--existing-flag", "original"];
+
+    appendExtraArguments(command, extraArguments);
+
+    expect(command).toEqual([
+      "runtime",
+      "--existing-flag",
+      "original",
+      "--enabled",
+      "--disabled",
+      "--empty",
+      "",
+      "--list",
+      '["first","second"]',
+      "--object",
+      '{"nested_key":1}',
+    ]);
+  });
+
+  it("preserves the llama.cpp argument policy", () => {
+    const command = ["llama-server", "--existing-flag", "original"];
+
+    appendLlamacppArguments(command, extraArguments);
+
+    expect(command).toEqual([
+      "llama-server",
+      "--existing-flag",
+      "original",
+      "--enabled",
+      "--list",
+      "first",
+      "--list",
+      "second",
+      "--object",
+      '{"nested-key":1}',
+    ]);
+  });
+});
 
 describe("vLLM extra_args allowlist", () => {
   let savedAllow: string | undefined;


### PR DESCRIPTION
Closes #144

## Summary
- reuse one snake/kebab lookup across command, environment, and GPU lease paths
- share internal-key filtering and duplicate-flag handling while keeping the generic and llama.cpp value policies separate
- cover both serialization policies with exact argv tests

## Testing
- `cd controller && bun run check`
- `cd controller && bun run typecheck`
- `cd controller && bun run lint`
- `cd controller && bun run test:unit` (129 passed)
- `cd controller && bun run test:integration` (113 passed)