### PR TITLE
fix(controller): resolve binaries cross-platform via Bun.which

### DIFF
--- a/controller/src/core/command.test.ts
+++ b/controller/src/core/command.test.ts
@@ -1,6 +1,10 @@
-import { expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
 import { Effect, Fiber } from "effect";
-import { runCommandAsync, runCommandAsyncEffect } from "./command";
+
+import { resolveBinary, runCommandAsync, runCommandAsyncEffect } from "./command";
 
 test("retains only bounded stdout and stderr tails", async () => {
   const result = await runCommandAsync(
@@ -51,4 +55,118 @@ test("effect interruption kills and settles the child process", async () => {
 
   await Effect.runPromise(Fiber.interrupt(fiber));
   expect(closed).toBe(true);
+});
+
+const executableName = (name: string): string =>
+  process.platform === "win32" ? `${name}.exe` : name;
+
+const createExecutable = (directory: string, name: string): string => {
+  const filePath = join(directory, executableName(name));
+  writeFileSync(filePath, "");
+  chmodSync(filePath, 0o755);
+  return filePath;
+};
+
+describe("resolveBinary", () => {
+  let temporaryDirectory: string;
+  let savedPath: string | undefined;
+  let savedRuntimeBin: string | undefined;
+  let savedSnap: string | undefined;
+  let savedHome: string | undefined;
+
+  const restoreEnv = (key: string, value: string | undefined): void => {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  };
+
+  beforeEach(() => {
+    temporaryDirectory = mkdtempSync(join(tmpdir(), "resolve-binary-"));
+    savedPath = process.env["PATH"];
+    savedRuntimeBin = process.env["LOCAL_STUDIO_RUNTIME_BIN"];
+    savedSnap = process.env["SNAP"];
+    savedHome = process.env["HOME"];
+    delete process.env["LOCAL_STUDIO_RUNTIME_BIN"];
+    delete process.env["SNAP"];
+  });
+
+  afterEach(() => {
+    restoreEnv("PATH", savedPath);
+    restoreEnv("LOCAL_STUDIO_RUNTIME_BIN", savedRuntimeBin);
+    restoreEnv("SNAP", savedSnap);
+    restoreEnv("HOME", savedHome);
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  test("resolves a bare name from PATH using the platform delimiter", () => {
+    const expected = createExecutable(temporaryDirectory, "local-studio-test-tool");
+    process.env["PATH"] = temporaryDirectory;
+    expect(resolveBinary("local-studio-test-tool")).toBe(expected);
+  });
+
+  test("searches every PATH entry, not just the first", () => {
+    const emptyDirectory = join(temporaryDirectory, "empty");
+    const toolDirectory = join(temporaryDirectory, "tools");
+    mkdirSync(emptyDirectory);
+    mkdirSync(toolDirectory);
+    const expected = createExecutable(toolDirectory, "local-studio-test-tool");
+    process.env["PATH"] = [emptyDirectory, toolDirectory].join(delimiter);
+    expect(resolveBinary("local-studio-test-tool")).toBe(expected);
+  });
+
+  test("resolves from a PATH entry wrapped in quotes", () => {
+    const expected = createExecutable(temporaryDirectory, "local-studio-test-tool");
+    process.env["PATH"] = `"${temporaryDirectory}"`;
+    expect(resolveBinary("local-studio-test-tool")).toBe(expected);
+  });
+
+  test("returns null when the binary is not on PATH", () => {
+    process.env["PATH"] = temporaryDirectory;
+    expect(resolveBinary("local-studio-missing-tool")).toBeNull();
+  });
+
+  test("returns null for an empty name", () => {
+    expect(resolveBinary("")).toBeNull();
+  });
+
+  test("resolves an explicit path directly", () => {
+    const expected = createExecutable(temporaryDirectory, "local-studio-test-tool");
+    expect(resolveBinary(expected)).toBe(expected);
+  });
+
+  test("returns null for an explicit path that does not exist", () => {
+    expect(
+      resolveBinary(join(temporaryDirectory, executableName("local-studio-missing-tool"))),
+    ).toBeNull();
+  });
+
+  test("prefers LOCAL_STUDIO_RUNTIME_BIN over PATH", () => {
+    const runtimeDirectory = join(temporaryDirectory, "runtime-bin");
+    const pathDirectory = join(temporaryDirectory, "path-bin");
+    mkdirSync(runtimeDirectory);
+    mkdirSync(pathDirectory);
+    const expected = createExecutable(runtimeDirectory, "local-studio-test-tool");
+    createExecutable(pathDirectory, "local-studio-test-tool");
+    process.env["LOCAL_STUDIO_RUNTIME_BIN"] = runtimeDirectory;
+    process.env["PATH"] = pathDirectory;
+    expect(resolveBinary("local-studio-test-tool")).toBe(expected);
+  });
+
+  test("falls back to HOME local bin after PATH", () => {
+    const homeDirectory = join(temporaryDirectory, "home");
+    const localBin = join(homeDirectory, ".local", "bin");
+    mkdirSync(localBin, { recursive: true });
+    const expected = createExecutable(localBin, "local-studio-test-tool");
+    process.env["HOME"] = homeDirectory;
+    process.env["PATH"] = join(temporaryDirectory, "does-not-exist");
+    expect(resolveBinary("local-studio-test-tool")).toBe(expected);
+  });
+
+  test("returns null for a file without the execute bit", () => {
+    if (process.platform === "win32") return;
+    const filePath = join(temporaryDirectory, "local-studio-test-tool");
+    writeFileSync(filePath, "");
+    chmodSync(filePath, 0o644);
+    process.env["PATH"] = temporaryDirectory;
+    expect(resolveBinary("local-studio-test-tool")).toBeNull();
+  });
 });

--- a/controller/src/core/command.test.ts
+++ b/controller/src/core/command.test.ts
@@ -74,7 +74,7 @@ describe("resolveBinary", () => {
   let savedSnap: string | undefined;
   let savedHome: string | undefined;
 
-  const restoreEnv = (key: string, value: string | undefined): void => {
+  const restoreEnvironment = (key: string, value: string | undefined): void => {
     if (value === undefined) delete process.env[key];
     else process.env[key] = value;
   };
@@ -90,10 +90,10 @@ describe("resolveBinary", () => {
   });
 
   afterEach(() => {
-    restoreEnv("PATH", savedPath);
-    restoreEnv("LOCAL_STUDIO_RUNTIME_BIN", savedRuntimeBin);
-    restoreEnv("SNAP", savedSnap);
-    restoreEnv("HOME", savedHome);
+    restoreEnvironment("PATH", savedPath);
+    restoreEnvironment("LOCAL_STUDIO_RUNTIME_BIN", savedRuntimeBin);
+    restoreEnvironment("SNAP", savedSnap);
+    restoreEnvironment("HOME", savedHome);
     rmSync(temporaryDirectory, { recursive: true, force: true });
   });
 

--- a/controller/src/core/command.ts
+++ b/controller/src/core/command.ts
@@ -1,6 +1,5 @@
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { delimiter, join, resolve } from "node:path";
 import type { Readable } from "node:stream";
 import { Effect } from "effect";
 
@@ -236,54 +235,32 @@ export const runCommandAsync = (
   options: AsyncCommandOptions,
 ): Promise<AsyncCommandResult> => Effect.runPromise(runCommandAsyncEffect(command, args, options));
 
-const isExecutableFile = (filePath: string): boolean => {
-  try {
-    const stats = statSync(filePath);
-    return stats.isFile();
-  } catch {
-    return false;
-  }
+const runtimeBinDirectory = (): string | null =>
+  process.env["LOCAL_STUDIO_RUNTIME_BIN"] ??
+  (process.env["SNAP"] ? resolve(process.cwd(), "runtime", "bin") : null);
+
+const homeBinDirectories = (): string[] => {
+  const directories: string[] = [];
+  const home = process.env["HOME"];
+  if (home) directories.push(join(home, ".local", "bin"), join(home, "bin"));
+  const user = process.env["USER"] ?? process.env["LOGNAME"];
+  if (user) directories.push(join("/home", user, ".local", "bin"), join("/home", user, "bin"));
+  return directories;
 };
+
+const binarySearchPath = (): string => {
+  const runtimeBin = runtimeBinDirectory();
+  const pathEntries = (process.env["PATH"] ?? "").split(delimiter).filter(Boolean);
+  return [...(runtimeBin ? [runtimeBin] : []), ...pathEntries, ...homeBinDirectories()].join(
+    delimiter,
+  );
+};
+
+const isExplicitPath = (binaryName: string): boolean =>
+  binaryName.includes("/") || binaryName.includes("\\");
 
 export const resolveBinary = (binaryName: string): string | null => {
   if (!binaryName) return null;
-
-  if (binaryName.includes("/")) {
-    const resolved = resolve(binaryName);
-    return isExecutableFile(resolved) ? resolved : null;
-  }
-
-  const searchPaths: string[] = [];
-  const runtimeOverride = process.env["LOCAL_STUDIO_RUNTIME_BIN"];
-  const runtimeBin =
-    runtimeOverride ?? (process.env["SNAP"] ? resolve(process.cwd(), "runtime", "bin") : null);
-  if (runtimeBin && existsSync(runtimeBin)) {
-    searchPaths.push(runtimeBin);
-  }
-
-  const pathValue = process.env["PATH"];
-  if (pathValue) {
-    for (const entry of pathValue.split(":")) {
-      if (entry) searchPaths.push(entry);
-    }
-  }
-
-  const home = process.env["HOME"];
-  if (home) {
-    searchPaths.push(join(home, ".local", "bin"));
-    searchPaths.push(join(home, "bin"));
-  }
-
-  const user = process.env["USER"] ?? process.env["LOGNAME"];
-  if (user) {
-    searchPaths.push(join("/home", user, ".local", "bin"));
-    searchPaths.push(join("/home", user, "bin"));
-  }
-
-  for (const entry of searchPaths) {
-    const candidate = join(entry, binaryName);
-    if (isExecutableFile(candidate)) return candidate;
-  }
-
-  return null;
+  if (isExplicitPath(binaryName)) return Bun.which(resolve(binaryName));
+  return Bun.which(binaryName, { PATH: binarySearchPath() });
 };

--- a/controller/src/core/command.ts
+++ b/controller/src/core/command.ts
@@ -248,9 +248,14 @@ const homeBinDirectories = (): string[] => {
   return directories;
 };
 
+const sanitizePathEntry = (entry: string): string => entry.trim().replace(/^"|"$/g, "");
+
 const binarySearchPath = (): string => {
   const runtimeBin = runtimeBinDirectory();
-  const pathEntries = (process.env["PATH"] ?? "").split(delimiter).filter(Boolean);
+  const pathEntries = (process.env["PATH"] ?? "")
+    .split(delimiter)
+    .map(sanitizePathEntry)
+    .filter(Boolean);
   return [...(runtimeBin ? [runtimeBin] : []), ...pathEntries, ...homeBinDirectories()].join(
     delimiter,
   );


### PR DESCRIPTION
Relands #174 by @luminary19 (closed after the source branch became unavailable — commits keep their original authorship), rebased onto current main.

Fixes #173.

## Summary
- `resolveBinary` previously hand-rolled a POSIX-only PATH walk (`:` delimiter, no `PATHEXT`, `/`-only explicit-path detection), so Windows GPU monitoring reported no tools even with `nvidia-smi` on PATH.
- Replaces the walk with `Bun.which()` while preserving the existing search-tier semantics (`LOCAL_STUDIO_RUNTIME_BIN` → PATH → home bins), plus quoted-PATH-entry sanitization.
- Rebase note: main had since grown its own `controller/src/core/command.test.ts` (runCommand abort/tail tests); the two suites are merged into one file.

## Verification
- `bun test src/core/command.test.ts` — 13 pass (3 pre-existing + 10 from the PR)
- `bun run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)