### PR TITLE
fix(build): normalize path separators in the shared-contracts check

### DIFF
--- a/scripts/validate-shared-contracts.mjs
+++ b/scripts/validate-shared-contracts.mjs
@@ -94,7 +94,7 @@ function walk(dir) {
 }
 
 function inspect(filePath) {
-  const rel = relative(root, filePath);
+  const rel = relative(root, filePath).replaceAll("\\", "/");
   const source = readFileSync(filePath, "utf8");
   collectExportedDeclarations(rel, source);
   for (const name of contractNames) {


### PR DESCRIPTION
## Summary

`validate-shared-contracts.mjs` matched `relative()` output against a forward-slash allowlist; on Windows `relative()` yields backslash paths, so the check failed on every clean tree and `npm run check` could never pass there. The relative path is now normalized to `/` before comparison, which also keeps the duplicate-declaration report consistent across hosts. Fixes #182.

## Validation

```bash
npm run check:contracts   # passes on Windows 11; POSIX output has no backslashes to replace
```

## UI changes

None.

## Risks / rollout notes

None — `replaceAll("\\", "/")` is a no-op on POSIX `relative()` output.
