### PR TITLE
fix(controller): parse the CUDA UMD version banner from newer drivers

### DIFF
--- a/controller/src/modules/engines/runtimes/cuda-version.test.ts
+++ b/controller/src/modules/engines/runtimes/cuda-version.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { extractCudaVersion } from "./cuda-version";
+
+describe("extractCudaVersion", () => {
+  test("parses the classic nvidia-smi banner", () => {
+    expect(
+      extractCudaVersion(
+        "| NVIDIA-SMI 555.85    Driver Version: 555.85    CUDA Version: 12.5 |",
+      ),
+    ).toBe("12.5");
+  });
+
+  test("parses the driver 610+ UMD banner", () => {
+    expect(
+      extractCudaVersion(
+        "| NVIDIA-SMI 610.47    KMD Version: 610.47    CUDA UMD Version: 13.3 |",
+      ),
+    ).toBe("13.3");
+  });
+
+  test("returns null when no CUDA version is present", () => {
+    expect(extractCudaVersion("no gpu here")).toBeNull();
+  });
+});

--- a/controller/src/modules/engines/runtimes/cuda-version.ts
+++ b/controller/src/modules/engines/runtimes/cuda-version.ts
@@ -1,0 +1,5 @@
+export const extractCudaVersion = (output: string): string | null => {
+  const match = output.match(/CUDA (?:UMD )?Version\s*:\s*([0-9.]+)/i);
+  if (match) return match[1] ?? null;
+  return null;
+};

--- a/controller/src/modules/engines/runtimes/runtime-info.ts
+++ b/controller/src/modules/engines/runtimes/runtime-info.ts
@@ -12,6 +12,7 @@ import type {
 import type { Config } from "../../../config/env";
 import { resolveBinary, runCommand, runCommandAsync } from "../../../core/command";
 import { getGpuInfo, queryNvidiaSmiSnapshot } from "../../system/platform/gpu";
+import { extractCudaVersion } from "./cuda-version";
 import { getVllmRuntimeInfo } from "./vllm-runtime";
 import { probeGpuMonitoringAsync } from "../../system/platform/compatibility-report";
 import { getRocmInfo, resolveRocmSmiTool } from "../../system/platform/rocm-info";
@@ -175,11 +176,6 @@ export const getLlamacppRuntimeInfo = (config: Config): RuntimeBackendInfo => {
   };
 };
 
-const extractCudaVersion = (output: string): string | null => {
-  const match = output.match(/CUDA Version\s*:\s*([0-9.]+)/i);
-  if (match) return match[1] ?? null;
-  return null;
-};
 
 const extractNvccVersion = (output: string): string | null => {
   const match = output.match(/release\s+([0-9.]+)/i);


### PR DESCRIPTION
## Summary

NVIDIA driver 610+ renamed the `nvidia-smi` banner field from `CUDA Version:` to `CUDA UMD Version:`, so CUDA detection silently returned nothing on toolkit-less machines running the new driver series (the `nvcc` fallback masked it elsewhere). The parser moves to a small `cuda-version.ts` module and accepts both spellings; unit tests cover the old banner, the new banner, and no banner. Fixes #184.

## Validation

```bash
cd controller
bun run typecheck
bun run lint
bun test ./src/modules/engines/runtimes/cuda-version.test.ts   # 3 pass
```

Verified live on driver 610.47 (Windows 11, RTX 4070): `/runtime/info` reports the CUDA version again. Pre-610 banners are unaffected — the old spelling still matches.

## UI changes

None.

## Risks / rollout notes

None — pure parser widening; the extracted module is consumed only by runtime-info today.
