### PR TITLE
fix(controller): use per-user models dir and OS temp dir defaults on Windows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,7 +42,7 @@ LOCAL_STUDIO_INFERENCE_PORT=8000
 
 # Directory containing model weights. Must be writable: the controller tries to
 # create it on startup and warns if it cannot.
-LOCAL_STUDIO_MODELS_DIR=/models
+# LOCAL_STUDIO_MODELS_DIR=/models
 
 # Data directory for recipes and chat history
 LOCAL_STUDIO_DATA_DIR=./data

--- a/controller/src/config/env.ts
+++ b/controller/src/config/env.ts
@@ -1,7 +1,8 @@
 import { config as loadEnvironment } from "dotenv";
 import { Schema } from "effect";
 import { existsSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { loadPersistedConfig, type ProviderConfig } from "./persisted-config";
 import { parseBooleanFlag } from "../core/validation";
@@ -39,6 +40,9 @@ export const loadDotEnvironment = (): string | undefined => {
   }
   return envPath;
 };
+
+const defaultModelsDirectory = (): string =>
+  process.platform === "win32" ? join(homedir(), "models") : "/models";
 
 export const createConfig = (): Config => {
   loadDotEnvironment();
@@ -117,7 +121,7 @@ export const createConfig = (): Config => {
     LOCAL_STUDIO_INFERENCE_HOST: process.env["LOCAL_STUDIO_INFERENCE_HOST"] ?? "localhost",
     LOCAL_STUDIO_INFERENCE_PORT: coercePositiveInteger("LOCAL_STUDIO_INFERENCE_PORT", 8000),
     LOCAL_STUDIO_DATA_DIR: process.env["LOCAL_STUDIO_DATA_DIR"] ?? defaultDataDirectory,
-    LOCAL_STUDIO_MODELS_DIR: process.env["LOCAL_STUDIO_MODELS_DIR"] ?? "/models",
+    LOCAL_STUDIO_MODELS_DIR: process.env["LOCAL_STUDIO_MODELS_DIR"] ?? defaultModelsDirectory(),
   });
   const host = parsed.LOCAL_STUDIO_HOST.trim() || "127.0.0.1";
 

--- a/controller/src/core/log-files.ts
+++ b/controller/src/core/log-files.ts
@@ -8,11 +8,12 @@ import {
   closeSync,
   readSync,
 } from "node:fs";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 const LOG_PREFIX = "vllm_";
 const LOG_SUFFIX = ".log";
-const FALLBACK_LOG_DIR = "/tmp";
+const FALLBACK_LOG_DIR = tmpdir();
 
 export interface LogFileEntry {
   sessionId: string;


### PR DESCRIPTION
## Summary

The models-dir default (`/models`) and the log fallback dir (`/tmp`) are POSIX literals; on Windows the former points at a non-existent drive root and the latter throws inside the fallback path itself. This defaults the models dir to `~/models` on win32 (POSIX keeps `/models`), replaces the `/tmp` literal with `os.tmpdir()` (which is `/tmp` on Linux), and comments the template default in `.env.example` so the platform default applies unless overridden. Fixes #186.

## Validation

```bash
cd controller
bun run typecheck   # clean
bun run lint        # clean
```

Verified live on Windows 11: boot summary shows `models_dir=C:\Users\<user>\models`, and model listing + llama.cpp launch work end-to-end. Linux behavior is unchanged by construction: the non-win32 models default stays `/models` and `os.tmpdir()` returns `/tmp`.

Note: the controller `test:unit` suite currently has POSIX-only fixtures that fail when run on Windows (unrelated to this change — those are addressed in a separate test-portability PR); this branch touches only `env.ts` and `log-files.ts` and does not alter any test.

## UI changes

None.

## Risks / rollout notes

- Anyone who copied the `.env.example` `LOCAL_STUDIO_MODELS_DIR=/models` line verbatim must uncomment it to keep an explicit override; the in-code POSIX default is identical, so nothing changes on Linux/macOS unless that override was being relied upon.
