### PR TITLE
fix(build): make repo bootstrap cross-platform (services link junction, node-script git hooks)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ data/
 
 # Node.js
 node_modules/
+services/node_modules
 .next/
 .turbo/
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,css,md,json}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,css,md,json}\"",
     "depcheck": "depcheck --ignores=\"ws,hono,@hono/node-server,@types/ws,@types/react,@types/react-dom,@types/node,eslint-config-next,tailwindcss,@tailwindcss/postcss,depcheck,prettier,jscpd,knip,lint-staged,concurrently,electron-builder,madge\" --ignore-patterns=\"*.d.ts,.next/**,dist-desktop/**,desktop/dist/**\" --specials=next,webpack,babel --skip-missing",
-    "prepare": "cd .. && git rev-parse --git-dir >/dev/null 2>&1 && npm run setup:git-hooks || true",
+    "prepare": "node scripts/prepare-repo-hooks.mjs",
     "postinstall": "node scripts/patch-pi-ai-openai-text-boundaries.mjs && node scripts/link-services-node-modules.mjs",
     "check:deadcode": "knip",
     "check:dupes": "jscpd src",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.9",
   "private": true,
   "scripts": {
+    "predev": "node scripts/link-services-node-modules.mjs",
     "dev": "next dev",
     "build": "next build --webpack",
     "start": "node scripts/start-standalone.mjs",

--- a/frontend/scripts/link-services-node-modules.mjs
+++ b/frontend/scripts/link-services-node-modules.mjs
@@ -1,12 +1,3 @@
-// The @local-studio/agent-runtime package (services/agent-runtime) ships raw
-// .ts and is consumed via a file: symlink, so its sources resolve external
-// deps (effect, ws, the pi SDK) from their REAL path under services/ — where
-// no node_modules exists on the walk-up. Bridge services/node_modules to
-// frontend/node_modules so every resolver (tsc, bun, webpack, turbopack,
-// Node) finds the exact same dependency instances the frontend uses.
-//
-// Ran from frontend/ as part of postinstall.
-
 import { lstatSync, mkdirSync, rmSync, symlinkSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -14,17 +5,36 @@ import { fileURLToPath } from "node:url";
 const frontendDir = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const servicesDir = path.join(path.dirname(frontendDir), "services");
 const linkPath = path.join(servicesDir, "node_modules");
-const target = path.join("..", "frontend", "node_modules");
+
+const existingEntryKind = () => {
+  try {
+    const stat = lstatSync(linkPath);
+    if (stat.isSymbolicLink()) return "link";
+    return stat.isDirectory() ? "directory" : "file";
+  } catch {
+    return "missing";
+  }
+};
+
+const removeExistingEntry = () => {
+  rmSync(linkPath, { recursive: true, force: true });
+};
+
+const createLink = () => {
+  if (process.platform === "win32") {
+    symlinkSync(path.join(frontendDir, "node_modules"), linkPath, "junction");
+    return;
+  }
+  symlinkSync(path.join("..", "frontend", "node_modules"), linkPath, "dir");
+};
 
 mkdirSync(servicesDir, { recursive: true });
-try {
-  const stat = lstatSync(linkPath);
-  if (!stat.isSymbolicLink()) {
-    console.error(`[link-services-node-modules] ${linkPath} exists and is not a symlink; leaving it alone.`);
-    process.exit(0);
-  }
-  rmSync(linkPath);
-} catch {
-  // does not exist yet
+const kind = existingEntryKind();
+if (kind === "directory") {
+  console.error(
+    `[link-services-node-modules] ${linkPath} is a real directory; leaving it alone.`,
+  );
+  process.exit(0);
 }
-symlinkSync(target, linkPath, "dir");
+if (kind !== "missing") removeExistingEntry();
+createLink();

--- a/frontend/scripts/prepare-repo-hooks.mjs
+++ b/frontend/scripts/prepare-repo-hooks.mjs
@@ -1,0 +1,12 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const frontendDir = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const rootHooksScript = path.join(
+  path.dirname(frontendDir),
+  "scripts",
+  "setup-git-hooks.mjs",
+);
+
+if (existsSync(rootHooksScript)) await import(pathToFileURL(rootHooksScript).href);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "doctor": "bash scripts/doctor.sh",
     "release:notes": "node scripts/release-statement.mjs",
     "release:check-commits": "node scripts/check-conventional-commits.mjs --range origin/main..HEAD",
-    "setup:git-hooks": "git config core.hooksPath .githooks && chmod +x .githooks/*",
+    "setup:git-hooks": "node scripts/setup-git-hooks.mjs",
     "check": "npm run check:contracts && npm run check:structure && npm run check:frontend && npm run check:controller",
     "check:contracts": "node scripts/validate-shared-contracts.mjs",
     "check:structure": "node scripts/validate-barrel-dir-siblings.mjs",

--- a/scripts/setup-git-hooks.mjs
+++ b/scripts/setup-git-hooks.mjs
@@ -23,6 +23,7 @@ try {
   runGit(["rev-parse", "--git-dir"]);
   runGit(["config", "core.hooksPath", ".githooks"]);
   markHooksExecutable();
-} catch {
+} catch (error) {
+  console.error(`[setup-git-hooks] skipped: ${error}`);
   process.exit(0);
 }

--- a/scripts/setup-git-hooks.mjs
+++ b/scripts/setup-git-hooks.mjs
@@ -1,0 +1,28 @@
+import { execFileSync } from "node:child_process";
+import { chmodSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const hooksDir = path.join(repoRoot, ".githooks");
+
+const runGit = (args) =>
+  execFileSync("git", args, { cwd: repoRoot, stdio: "ignore" });
+
+const markHooksExecutable = () => {
+  for (const entry of readdirSync(hooksDir)) {
+    try {
+      chmodSync(path.join(hooksDir, entry), 0o755);
+    } catch {
+      continue;
+    }
+  }
+};
+
+try {
+  runGit(["rev-parse", "--git-dir"]);
+  runGit(["config", "core.hooksPath", ".githooks"]);
+  markHooksExecutable();
+} catch {
+  process.exit(0);
+}

--- a/services/node_modules
+++ b/services/node_modules
@@ -1,1 +1,0 @@
-../frontend/node_modules


### PR DESCRIPTION
## Summary

Fresh clones are broken on Windows in two ways: the tracked `services/node_modules` symlink checks out as a plain file under `core.symlinks=false` (and `symlinkSync(..., "dir")` needs privileges a junction doesn't), and `setup:git-hooks` shells out to `chmod`, silently skipped via `|| true`. This untracks the link (postinstall recreates it anyway), teaches `link-services-node-modules.mjs` to remove a stale checkout artifact and fall back to a junction on win32, replaces the `chmod` one-liner with a small node script (`scripts/setup-git-hooks.mjs`, invoked from frontend via `prepare-repo-hooks.mjs`), and self-heals the link before `dev`. Fixes #188.

## Validation

```bash
npm --prefix frontend install          # link created: junction on win32, symlink elsewhere
npm --prefix frontend run check:quality # lint + typecheck + desktop typecheck + cycles + ui-structure + knip + jscpd + depcheck + build — all green
node scripts/setup-git-hooks.mjs        # git config core.hooksPath -> .githooks
```

Verified live on Windows 11: fresh clone → install → typecheck green, hooks installed. Linux/macOS unchanged by construction — the symlink branch still runs first, and the node hook script performs the same two operations (`core.hooksPath` config + mark executable) the shell line did.

## UI changes

None.

## Risks / rollout notes

- `services/node_modules` leaves the git index; contributors with an existing checkout keep their working link (now gitignored). Postinstall recreates it on the next install.
- Hook files rely on git-preserved execute bits instead of `chmod +x` at install time — identical result on POSIX.
