### PR TITLE
fix(agent): preserve session metadata across reloads

### DIFF
--- a/frontend/src/features/agent/workspace/persistence.test.ts
+++ b/frontend/src/features/agent/workspace/persistence.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { loadInitialFromStorage } from "./persistence";
+import { PANE_STATE_KEY, type WorkspaceStorage } from "./store";
+import { TRANSCRIPT_CACHE_PREFIX } from "./transcript-cache";
+
+function storage(entries: Record<string, string>): WorkspaceStorage {
+  const values = new Map(Object.entries(entries));
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+    removeItem: (key) => values.delete(key),
+  };
+}
+
+test("restored transcript cache preserves the canonical session title", () => {
+  const sessionId = "tab-1";
+  const piSessionId = "019f6f7a-6068-754a-a1c9-b2972a5f26e4";
+  const loaded = loadInitialFromStorage(
+    storage({
+      [PANE_STATE_KEY]: JSON.stringify({
+        version: 1,
+        layout: { kind: "leaf", paneId: "p-init" },
+        focusedPaneId: "p-init",
+        panes: {
+          "p-init": {
+            activeTabId: sessionId,
+            tabs: [
+              {
+                id: sessionId,
+                piSessionId,
+                projectId: "project-1",
+                cwd: "/tmp/project-1",
+                title: "New session",
+              },
+            ],
+          },
+        },
+      }),
+      [`${TRANSCRIPT_CACHE_PREFIX}${piSessionId}`]: JSON.stringify({
+        version: 2,
+        updatedAt: 1,
+        title: "Recovered session title",
+        messages: [{ id: "message-1", role: "user", text: "hello" }],
+      }),
+    }),
+  );
+  const restored = loaded.workspace.sessions?.get(sessionId);
+  assert.equal(restored?.title, "Recovered session title");
+  assert.equal(restored?.messages.length, 1);
+});

--- a/frontend/src/features/agent/workspace/persistence.ts
+++ b/frontend/src/features/agent/workspace/persistence.ts
@@ -22,7 +22,7 @@ import {
   restoreSessionDrafts,
   sessionDraftsWithSessions,
 } from "@/features/agent/workspace/session-drafts";
-import { readTranscriptSnapshot } from "@/features/agent/workspace/transcript-cache";
+import { readTranscriptSnapshotEntry } from "@/features/agent/workspace/transcript-cache";
 
 const SESSIONS_COLLAPSED_KEY = "local-studio.agent.sessionsCollapsed";
 const SESSIONS_COLLAPSED_CLEANED_KEY = "local-studio.agent.sessionsCollapsedCleaned";
@@ -139,10 +139,14 @@ function seedCachedTranscripts(
   let next: Map<SessionId, Session> | null = null;
   for (const [id, session] of sessions) {
     if (!session.piSessionId) continue;
-    const cached = readTranscriptSnapshot(session.piSessionId, storage);
-    if (!cached || cached.length === 0) continue;
+    const cached = readTranscriptSnapshotEntry(session.piSessionId, storage);
+    if (!cached || cached.messages.length === 0) continue;
     next ??= new Map(sessions);
-    next.set(id, { ...session, messages: cached });
+    next.set(id, {
+      ...session,
+      ...(cached.title ? { title: cached.title } : {}),
+      messages: cached.messages,
+    });
   }
   return next ?? sessions;
 }

--- a/frontend/src/features/agent/workspace/transcript-cache.ts
+++ b/frontend/src/features/agent/workspace/transcript-cache.ts
@@ -128,10 +128,17 @@ export function readTranscriptSnapshot(
   piSessionId: string | null | undefined,
   storage: TranscriptStorage | null = defaultStorage(),
 ): ChatMessage[] | null {
+  const entry = readTranscriptSnapshotEntry(piSessionId, storage);
+  return entry && entry.messages.length > 0 ? entry.messages : null;
+}
+
+export function readTranscriptSnapshotEntry(
+  piSessionId: string | null | undefined,
+  storage: TranscriptStorage | null = defaultStorage(),
+): CachedTranscript | null {
   if (!storage || !piSessionId) return null;
   try {
-    const entry = parseCachedTranscript(storage.getItem(sessionKey(piSessionId)));
-    return entry && entry.messages.length > 0 ? entry.messages : null;
+    return parseCachedTranscript(storage.getItem(sessionKey(piSessionId)));
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- restore cached Pi transcript titles when hydrating persisted workbench tabs
- keep existing transcript cache API behavior unchanged
- add regression coverage for reload hydration

## Validation
- npm --prefix frontend run check:quality
- npm run check
- npm run test:integration
- packaged and reinstalled `/Applications/Local Studio.app`; `/api/desktop-health` returned 200
- live persisted-session reload rendered the canonical title and transcript

No UI layout or styling changes.