### PR TITLE
feat: improve workbench readiness and runtime metrics

### DIFF
--- a/controller/contracts/observability.ts
+++ b/controller/contracts/observability.ts
@@ -33,7 +33,9 @@ export interface Metrics {
   avg_ttft_ms?: number;
   kv_cache_usage?: number;
   generation_throughput?: number;
+  generation_throughput_status?: "live" | "last" | "unavailable";
   prompt_throughput?: number;
+  prompt_throughput_status?: "live" | "last" | "unavailable";
   request_success?: number;
   generation_tokens_total?: number;
   prompt_tokens_total?: number;

--- a/controller/src/modules/system/engine-metrics-scrape.ts
+++ b/controller/src/modules/system/engine-metrics-scrape.ts
@@ -54,6 +54,11 @@ export type EngineMetricNames = {
   generationTokens: string[];
   promptThroughput: string[];
   generationThroughput: string[];
+  completedRequests: string[];
+  requestPromptTokens: string[];
+  requestGenerationTokens: string[];
+  promptDurationSeconds: string[];
+  generationDurationSeconds: string[];
   runningRequests: string[];
   pendingRequests: string[];
   kvCacheUsage: string[];
@@ -66,6 +71,14 @@ export const VLLM_METRIC_NAMES: EngineMetricNames = {
   generationTokens: ["vllm:generation_tokens_total"],
   promptThroughput: ["vllm:prompt_throughput", "vllm:prefill_throughput"],
   generationThroughput: ["vllm:gen_throughput", "vllm:generation_throughput"],
+  completedRequests: [
+    "vllm:e2e_request_latency_seconds_count",
+    "vllm:request_generation_tokens_count",
+  ],
+  requestPromptTokens: ["vllm:request_prompt_tokens_sum"],
+  requestGenerationTokens: ["vllm:request_generation_tokens_sum"],
+  promptDurationSeconds: ["vllm:request_prefill_time_seconds_sum"],
+  generationDurationSeconds: ["vllm:request_decode_time_seconds_sum"],
   runningRequests: ["vllm:num_requests_running"],
   pendingRequests: ["vllm:num_requests_waiting"],
   kvCacheUsage: ["vllm:kv_cache_usage_perc"],
@@ -82,6 +95,11 @@ export const SGLANG_METRIC_NAMES: EngineMetricNames = {
   ],
   promptThroughput: ["sglang:prompt_throughput", "sglang:prefill_throughput"],
   generationThroughput: ["sglang:gen_throughput", "sglang:generation_throughput"],
+  completedRequests: [],
+  requestPromptTokens: [],
+  requestGenerationTokens: [],
+  promptDurationSeconds: [],
+  generationDurationSeconds: [],
   runningRequests: ["sglang:num_running_reqs", "sglang:num_requests_running"],
   pendingRequests: [
     "sglang:num_queue_reqs",

--- a/controller/src/modules/system/engine-performance.test.ts
+++ b/controller/src/modules/system/engine-performance.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from "bun:test";
+import { VLLM_METRIC_NAMES } from "./engine-metrics-scrape";
+import { EnginePerformanceTracker } from "./engine-performance";
+
+const metricSample = ({
+  completedRequests,
+  decodeSeconds,
+  generationTokens,
+  prefillSeconds,
+  promptTokens,
+}: {
+  completedRequests: number;
+  decodeSeconds: number;
+  generationTokens: number;
+  prefillSeconds: number;
+  promptTokens: number;
+}): Record<string, number> => ({
+  "vllm:e2e_request_latency_seconds_count": completedRequests,
+  "vllm:generation_tokens_total": generationTokens,
+  "vllm:prompt_tokens_total": promptTokens,
+  "vllm:request_decode_time_seconds_sum": decodeSeconds,
+  "vllm:request_generation_tokens_sum": generationTokens,
+  "vllm:request_prefill_time_seconds_sum": prefillSeconds,
+  "vllm:request_prompt_tokens_sum": promptTokens,
+});
+
+describe("engine performance tracking", () => {
+  test("keeps completed-request throughput after the engine returns idle", () => {
+    const tracker = new EnginePerformanceTracker();
+    const baseline = metricSample({
+      completedRequests: 1,
+      decodeSeconds: 4,
+      generationTokens: 200,
+      prefillSeconds: 0.5,
+      promptTokens: 100,
+    });
+    const active = metricSample({
+      completedRequests: 1,
+      decodeSeconds: 4,
+      generationTokens: 350,
+      prefillSeconds: 0.5,
+      promptTokens: 500,
+    });
+    active["vllm:request_generation_tokens_sum"] = 200;
+    active["vllm:request_prompt_tokens_sum"] = 100;
+    const completed = metricSample({
+      completedRequests: 2,
+      decodeSeconds: 10,
+      generationTokens: 500,
+      prefillSeconds: 1.5,
+      promptTokens: 500,
+    });
+
+    tracker.observe({
+      key: "qwen:1",
+      metrics: baseline,
+      names: VLLM_METRIC_NAMES,
+      observedAt: 0,
+      pendingRequests: 0,
+      runningRequests: 0,
+    });
+    const live = tracker.observe({
+      key: "qwen:1",
+      metrics: active,
+      names: VLLM_METRIC_NAMES,
+      observedAt: 5_000,
+      pendingRequests: 0,
+      runningRequests: 1,
+    });
+    const finished = tracker.observe({
+      key: "qwen:1",
+      metrics: completed,
+      names: VLLM_METRIC_NAMES,
+      observedAt: 10_000,
+      pendingRequests: 0,
+      runningRequests: 0,
+    });
+    const idle = tracker.observe({
+      key: "qwen:1",
+      metrics: completed,
+      names: VLLM_METRIC_NAMES,
+      observedAt: 15_000,
+      pendingRequests: 0,
+      runningRequests: 0,
+    });
+
+    expect(live.generationThroughput).toBe(30);
+    expect(live.generationThroughputStatus).toBe("live");
+    expect(finished.promptThroughput).toBe(400);
+    expect(finished.generationThroughput).toBe(50);
+    expect(finished.completedRequests).toBe(2);
+    expect(finished.promptThroughputStatus).toBe("last");
+    expect(idle.promptThroughput).toBe(400);
+    expect(idle.generationThroughput).toBe(50);
+    expect(idle.generationThroughputStatus).toBe("last");
+  });
+
+  test("clears retained rates when engine counters reset", () => {
+    const tracker = new EnginePerformanceTracker();
+    const baseline = metricSample({
+      completedRequests: 2,
+      decodeSeconds: 10,
+      generationTokens: 500,
+      prefillSeconds: 1.5,
+      promptTokens: 500,
+    });
+    const reset = metricSample({
+      completedRequests: 0,
+      decodeSeconds: 0,
+      generationTokens: 0,
+      prefillSeconds: 0,
+      promptTokens: 0,
+    });
+
+    tracker.observe({
+      key: "qwen:1",
+      metrics: baseline,
+      names: VLLM_METRIC_NAMES,
+      observedAt: 0,
+      pendingRequests: 0,
+      runningRequests: 0,
+    });
+    const result = tracker.observe({
+      key: "qwen:1",
+      metrics: reset,
+      names: VLLM_METRIC_NAMES,
+      observedAt: 5_000,
+      pendingRequests: 0,
+      runningRequests: 0,
+    });
+
+    expect(result.promptThroughput).toBe(0);
+    expect(result.generationThroughput).toBe(0);
+    expect(result.promptThroughputStatus).toBe("unavailable");
+  });
+
+  test("retains the last measurement through a failed scrape", () => {
+    const tracker = new EnginePerformanceTracker();
+    const directMetrics = {
+      "sglang:generation_throughput": 40,
+      "sglang:prompt_throughput": 250,
+    };
+
+    tracker.observe({
+      key: "qwen:1",
+      metrics: directMetrics,
+      names: {
+        ...VLLM_METRIC_NAMES,
+        generationThroughput: ["sglang:generation_throughput"],
+        promptThroughput: ["sglang:prompt_throughput"],
+      },
+      observedAt: 0,
+      pendingRequests: 0,
+      runningRequests: 1,
+    });
+    const result = tracker.observe({
+      key: "qwen:1",
+      metrics: {},
+      names: VLLM_METRIC_NAMES,
+      observedAt: 5_000,
+      pendingRequests: 0,
+      runningRequests: 0,
+    });
+
+    expect(result.promptThroughput).toBe(250);
+    expect(result.generationThroughput).toBe(40);
+    expect(result.promptThroughputStatus).toBe("last");
+  });
+});

--- a/controller/src/modules/system/engine-performance.ts
+++ b/controller/src/modules/system/engine-performance.ts
@@ -1,0 +1,159 @@
+import type { EngineMetricNames } from "./engine-metrics-scrape";
+import { firstMetric } from "./metrics-peaks";
+
+export type ThroughputStatus = "live" | "last" | "unavailable";
+
+type EngineCounters = {
+  completedRequests: number;
+  generationDurationSeconds: number;
+  generationTokens: number;
+  promptDurationSeconds: number;
+  promptTokens: number;
+  requestGenerationTokens: number;
+  requestPromptTokens: number;
+};
+
+type TrackedEngineSample = {
+  at: number;
+  counters: EngineCounters;
+  generationThroughput: number;
+  promptThroughput: number;
+};
+
+export type EnginePerformance = {
+  completedRequests: number;
+  generationThroughput: number;
+  generationThroughputStatus: ThroughputStatus;
+  promptThroughput: number;
+  promptThroughputStatus: ThroughputStatus;
+};
+
+type ObserveEnginePerformanceInput = {
+  key: string;
+  metrics: Record<string, number>;
+  names: EngineMetricNames;
+  observedAt?: number;
+  pendingRequests: number;
+  runningRequests: number;
+};
+
+const MIN_LIVE_RATE_INTERVAL_MS = 250;
+
+const positiveRate = (tokens: number, seconds: number): number =>
+  tokens > 0 && seconds > 0 ? tokens / seconds : 0;
+
+const delta = (current: number, previous: number): number => Math.max(0, current - previous);
+
+const readCounters = (
+  metrics: Record<string, number>,
+  names: EngineMetricNames,
+): EngineCounters => ({
+  completedRequests: firstMetric(metrics, names.completedRequests),
+  generationDurationSeconds: firstMetric(metrics, names.generationDurationSeconds),
+  generationTokens: firstMetric(metrics, names.generationTokens),
+  promptDurationSeconds: firstMetric(metrics, names.promptDurationSeconds),
+  promptTokens: firstMetric(metrics, names.promptTokens),
+  requestGenerationTokens: firstMetric(metrics, names.requestGenerationTokens),
+  requestPromptTokens: firstMetric(metrics, names.requestPromptTokens),
+});
+
+const countersReset = (current: EngineCounters, previous: EngineCounters): boolean =>
+  current.completedRequests < previous.completedRequests ||
+  current.generationDurationSeconds < previous.generationDurationSeconds ||
+  current.generationTokens < previous.generationTokens ||
+  current.promptDurationSeconds < previous.promptDurationSeconds ||
+  current.promptTokens < previous.promptTokens ||
+  current.requestGenerationTokens < previous.requestGenerationTokens ||
+  current.requestPromptTokens < previous.requestPromptTokens;
+
+const statusFor = (sampled: number, retained: number, active: boolean): ThroughputStatus => {
+  if (sampled > 0 && active) return "live";
+  return retained > 0 ? "last" : "unavailable";
+};
+
+export class EnginePerformanceTracker {
+  readonly #samples = new Map<string, TrackedEngineSample>();
+
+  observe({
+    key,
+    metrics,
+    names,
+    observedAt = Date.now(),
+    pendingRequests,
+    runningRequests,
+  }: ObserveEnginePerformanceInput): EnginePerformance {
+    const previous = this.#samples.get(key);
+    if (Object.keys(metrics).length === 0) {
+      return {
+        completedRequests: previous?.counters.completedRequests ?? 0,
+        generationThroughput: previous?.generationThroughput ?? 0,
+        generationThroughputStatus: previous?.generationThroughput ? "last" : "unavailable",
+        promptThroughput: previous?.promptThroughput ?? 0,
+        promptThroughputStatus: previous?.promptThroughput ? "last" : "unavailable",
+      };
+    }
+    const counters = readCounters(metrics, names);
+    const reset = previous ? countersReset(counters, previous.counters) : false;
+    const directPromptThroughput = firstMetric(metrics, names.promptThroughput);
+    const directGenerationThroughput = firstMetric(metrics, names.generationThroughput);
+    const active = runningRequests > 0 || pendingRequests > 0;
+    let sampledPromptThroughput = directPromptThroughput;
+    let sampledGenerationThroughput = directGenerationThroughput;
+    let promptThroughput = reset ? 0 : (previous?.promptThroughput ?? 0);
+    let generationThroughput = reset ? 0 : (previous?.generationThroughput ?? 0);
+
+    if (previous && !reset) {
+      const elapsedSeconds = (observedAt - previous.at) / 1000;
+      const completedPromptThroughput = positiveRate(
+        delta(counters.requestPromptTokens, previous.counters.requestPromptTokens),
+        delta(counters.promptDurationSeconds, previous.counters.promptDurationSeconds),
+      );
+      const completedGenerationThroughput = positiveRate(
+        delta(counters.requestGenerationTokens, previous.counters.requestGenerationTokens),
+        delta(counters.generationDurationSeconds, previous.counters.generationDurationSeconds),
+      );
+      const liveGenerationThroughput =
+        elapsedSeconds >= MIN_LIVE_RATE_INTERVAL_MS / 1000
+          ? positiveRate(
+              delta(counters.generationTokens, previous.counters.generationTokens),
+              elapsedSeconds,
+            )
+          : 0;
+      sampledPromptThroughput ||= completedPromptThroughput;
+      sampledGenerationThroughput ||=
+        (active ? liveGenerationThroughput : completedGenerationThroughput) ||
+        (active ? completedGenerationThroughput : liveGenerationThroughput);
+    }
+
+    if (sampledPromptThroughput > 0) promptThroughput = sampledPromptThroughput;
+    if (sampledGenerationThroughput > 0) generationThroughput = sampledGenerationThroughput;
+
+    const shouldAdvance =
+      !previous ||
+      reset ||
+      observedAt - previous.at >= MIN_LIVE_RATE_INTERVAL_MS ||
+      counters.completedRequests !== previous.counters.completedRequests;
+    if (shouldAdvance) {
+      this.#samples.set(key, {
+        at: observedAt,
+        counters,
+        generationThroughput,
+        promptThroughput,
+      });
+    }
+
+    return {
+      completedRequests: counters.completedRequests,
+      generationThroughput,
+      generationThroughputStatus: statusFor(
+        sampledGenerationThroughput,
+        generationThroughput,
+        active,
+      ),
+      promptThroughput,
+      promptThroughputStatus: statusFor(sampledPromptThroughput, promptThroughput, active),
+    };
+  }
+}
+
+export const enginePerformanceTracker = new EnginePerformanceTracker();

--- a/controller/src/modules/system/metrics-collector.ts
+++ b/controller/src/modules/system/metrics-collector.ts
@@ -8,6 +8,7 @@ import {
   VLLM_METRIC_NAMES,
   scrapeEngineMetrics,
 } from "./engine-metrics-scrape";
+import { enginePerformanceTracker, type ThroughputStatus } from "./engine-performance";
 import { LLAMACPP_TPS_STALE_MS, scrapeLlamacppThroughput } from "./llamacpp-throughput";
 import {
   bumpBestLower,
@@ -25,7 +26,6 @@ const METRICS_LIFETIME_UPTIME_INCREMENT_SECONDS = 5;
 
 export const startMetricsCollector = (context: AppContext): Effect.Effect<never> => {
   let lastVllmMetrics: Record<string, number> = {};
-  let lastMetricsTime = 0;
   let lastRuntimeSummaryAt = 0;
   let lastLlamacppSampleAt = 0;
   let lastLlamacppSampleKey = "";
@@ -134,6 +134,9 @@ export const startMetricsCollector = (context: AppContext): Effect.Effect<never>
 
       let promptThroughput = 0;
       let generationThroughput = 0;
+      let promptThroughputStatus: ThroughputStatus = "unavailable";
+      let generationThroughputStatus: ThroughputStatus = "unavailable";
+      let completedRequests = 0;
       let runningRequests = 0;
       let pendingRequests = 0;
       let kvCacheUsage = 0;
@@ -143,34 +146,22 @@ export const startMetricsCollector = (context: AppContext): Effect.Effect<never>
 
       if (current.backend === "vllm" || current.backend === "sglang") {
         const vllmMetrics = yield* scrapeVllmMetrics(context.config.inference_port);
-        const now = Date.now() / 1000;
-        const elapsed =
-          lastMetricsTime > 0 ? now - lastMetricsTime : METRICS_LIFETIME_UPTIME_INCREMENT_SECONDS;
         const isSglang = current.backend === "sglang";
         const names = isSglang ? SGLANG_METRIC_NAMES : VLLM_METRIC_NAMES;
-        if (
-          elapsed > 0 &&
-          Object.keys(vllmMetrics).length > 0 &&
-          Object.keys(lastVllmMetrics).length > 0
-        ) {
-          const previousPromptTokens = firstMetric(lastVllmMetrics, names.promptTokens);
-          const currentPromptTokens = firstMetric(vllmMetrics, names.promptTokens);
-          const previousGenerationTokens = firstMetric(lastVllmMetrics, names.generationTokens);
-          const currentGenerationTokens = firstMetric(vllmMetrics, names.generationTokens);
-          if (currentPromptTokens > previousPromptTokens) {
-            promptThroughput = (currentPromptTokens - previousPromptTokens) / elapsed;
-          }
-          if (currentGenerationTokens > previousGenerationTokens) {
-            generationThroughput = (currentGenerationTokens - previousGenerationTokens) / elapsed;
-          }
-        }
-
-        promptThroughput = firstMetric(vllmMetrics, names.promptThroughput) || promptThroughput;
-        generationThroughput =
-          firstMetric(vllmMetrics, names.generationThroughput) || generationThroughput;
-
         runningRequests = firstMetric(vllmMetrics, names.runningRequests);
         pendingRequests = firstMetric(vllmMetrics, names.pendingRequests);
+        const performance = enginePerformanceTracker.observe({
+          key: `${modelId}:${current.pid}`,
+          metrics: vllmMetrics,
+          names,
+          pendingRequests,
+          runningRequests,
+        });
+        promptThroughput = performance.promptThroughput;
+        generationThroughput = performance.generationThroughput;
+        promptThroughputStatus = performance.promptThroughputStatus;
+        generationThroughputStatus = performance.generationThroughputStatus;
+        completedRequests = performance.completedRequests;
         kvCacheUsage = firstMetric(vllmMetrics, names.kvCacheUsage);
         promptTokensTotal = firstMetric(vllmMetrics, names.promptTokens);
         generationTokensTotal = firstMetric(vllmMetrics, names.generationTokens);
@@ -185,7 +176,6 @@ export const startMetricsCollector = (context: AppContext): Effect.Effect<never>
         }
 
         lastVllmMetrics = vllmMetrics;
-        lastMetricsTime = now;
 
         if (promptThroughput > 0 || generationThroughput > 0 || avgTtftMs > 0) {
           yield* context.stores.peakMetricsStore.updateIfBetterEffect(
@@ -197,7 +187,6 @@ export const startMetricsCollector = (context: AppContext): Effect.Effect<never>
         }
       } else if (current.backend === "llamacpp") {
         lastVllmMetrics = {};
-        lastMetricsTime = 0;
         const sample = yield* scrapeLlamacppThroughput(context, current);
         const isNewSample = Boolean(sample && sample.sampleKey !== lastLlamacppSampleKey);
         if (sample && isNewSample) {
@@ -221,9 +210,10 @@ export const startMetricsCollector = (context: AppContext): Effect.Effect<never>
         const isFresh = Date.now() - lastLlamacppSampleAt <= LLAMACPP_TPS_STALE_MS;
         promptThroughput = isFresh ? lastLlamacppPromptThroughput : 0;
         generationThroughput = isFresh ? lastLlamacppGenerationThroughput : 0;
+        promptThroughputStatus = isFresh ? "last" : "unavailable";
+        generationThroughputStatus = isFresh ? "last" : "unavailable";
       } else {
         lastVllmMetrics = {};
-        lastMetricsTime = 0;
         lastLlamacppSampleAt = 0;
         lastLlamacppSampleKey = "";
         lastLlamacppPromptThroughput = 0;
@@ -277,9 +267,13 @@ export const startMetricsCollector = (context: AppContext): Effect.Effect<never>
         prompt_tokens_total: promptTokensDisplay,
         generation_tokens_total: generationTokensDisplay,
         total_tokens: positiveOrUndefined(usageTotals?.total_tokens),
-        total_requests: positiveOrUndefined(usageTotals?.total_requests),
+        total_requests:
+          positiveOrUndefined(completedRequests) ??
+          positiveOrUndefined(usageTotals?.total_requests),
         prompt_throughput: Math.round(promptThroughput * 10) / 10,
+        prompt_throughput_status: promptThroughputStatus,
         generation_throughput: Math.round(generationThroughput * 10) / 10,
+        generation_throughput_status: generationThroughputStatus,
         avg_ttft_ms: avgTtftDisplay,
         latency_avg: usageLatencyAvg,
         vram_used_gb: Math.round(totalVramUsedGb * 10) / 10,

--- a/controller/src/modules/system/metrics-routes.ts
+++ b/controller/src/modules/system/metrics-routes.ts
@@ -13,13 +13,9 @@ import {
   VLLM_METRIC_NAMES,
   scrapeEngineMetrics,
 } from "./engine-metrics-scrape";
+import { enginePerformanceTracker } from "./engine-performance";
 import { firstMetric, positiveOrUndefined } from "./metrics-peaks";
 
-const throughputSamples = new Map<
-  string,
-  { promptTokens: number; genTokens: number; ts: number; promptTps: number; genTps: number }
->();
-const MIN_RATE_INTERVAL_MS = 1500;
 const BenchmarkQuerySchema = Schema.Struct({
   prompt_tokens: Schema.optionalKey(
     Schema.FiniteFromString.pipe(
@@ -95,42 +91,15 @@ const buildCurrentMetrics = (
     const usageTotals = usageAggregate?.totals;
     const promptTokensTotal = firstMetric(prometheus, names.promptTokens);
     const generationTokensTotal = firstMetric(prometheus, names.generationTokens);
-
-    let promptThroughput = isSglang ? firstMetric(prometheus, names.promptThroughput) : 0;
-    let generationThroughput = isSglang ? firstMetric(prometheus, names.generationThroughput) : 0;
-    if (!isSglang) {
-      const nowMs = Date.now();
-      const previous = throughputSamples.get(modelId);
-      if (previous && nowMs - previous.ts >= MIN_RATE_INTERVAL_MS) {
-        const elapsedSeconds = (nowMs - previous.ts) / 1000;
-        promptThroughput = Math.max(
-          0,
-          (promptTokensTotal - previous.promptTokens) / elapsedSeconds,
-        );
-        generationThroughput = Math.max(
-          0,
-          (generationTokensTotal - previous.genTokens) / elapsedSeconds,
-        );
-        throughputSamples.set(modelId, {
-          promptTokens: promptTokensTotal,
-          genTokens: generationTokensTotal,
-          ts: nowMs,
-          promptTps: promptThroughput,
-          genTps: generationThroughput,
-        });
-      } else if (previous) {
-        promptThroughput = previous.promptTps;
-        generationThroughput = previous.genTps;
-      } else {
-        throughputSamples.set(modelId, {
-          promptTokens: promptTokensTotal,
-          genTokens: generationTokensTotal,
-          ts: nowMs,
-          promptTps: 0,
-          genTps: 0,
-        });
-      }
-    }
+    const runningRequests = firstMetric(prometheus, names.runningRequests);
+    const pendingRequests = firstMetric(prometheus, names.pendingRequests);
+    const performance = enginePerformanceTracker.observe({
+      key: `${modelId}:${current?.pid ?? "observed"}`,
+      metrics: prometheus,
+      names,
+      pendingRequests,
+      runningRequests,
+    });
     const ttftCount = prometheus[names.ttftCount] ?? 0;
     const avgTtftMs = ttftCount > 0 ? ((prometheus[names.ttftSum] ?? 0) / ttftCount) * 1000 : 0;
     const peakData = yield* context.stores.peakMetricsStore.getEffect(modelId);
@@ -142,8 +111,8 @@ const buildCurrentMetrics = (
       model_id: modelId,
       model_path: current?.model_path ?? null,
       served_model_name: current?.served_model_name ?? scrape.modelName ?? null,
-      running_requests: firstMetric(prometheus, names.runningRequests),
-      pending_requests: firstMetric(prometheus, names.pendingRequests),
+      running_requests: runningRequests,
+      pending_requests: pendingRequests,
       kv_cache_usage: firstMetric(prometheus, names.kvCacheUsage),
       prompt_tokens_total:
         positiveOrUndefined(promptTokensTotal) ?? positiveOrUndefined(usageTotals?.prompt_tokens),
@@ -151,9 +120,13 @@ const buildCurrentMetrics = (
         positiveOrUndefined(generationTokensTotal) ??
         positiveOrUndefined(usageTotals?.completion_tokens),
       total_tokens: positiveOrUndefined(usageTotals?.total_tokens),
-      total_requests: positiveOrUndefined(usageTotals?.total_requests),
-      prompt_throughput: promptThroughput,
-      generation_throughput: generationThroughput,
+      total_requests:
+        positiveOrUndefined(performance.completedRequests) ??
+        positiveOrUndefined(usageTotals?.total_requests),
+      prompt_throughput: performance.promptThroughput,
+      prompt_throughput_status: performance.promptThroughputStatus,
+      generation_throughput: performance.generationThroughput,
+      generation_throughput_status: performance.generationThroughputStatus,
       avg_ttft_ms: avgTtftMs > 0 ? Math.round(avgTtftMs * 10) / 10 : usageAggregate?.ttft?.avg_ms,
       latency_avg: positiveOrUndefined(usageAggregate?.latency?.avg_ms),
       best_session_peak_id: bestSessionPeakData?.["session_id"] ?? null,

--- a/frontend/src/features/agent/ui/agent-browser-panel.tsx
+++ b/frontend/src/features/agent/ui/agent-browser-panel.tsx
@@ -57,6 +57,7 @@ type AgentBrowserPanelHandles = Pick<
   | "compactFocusedSession"
   | "updateDetachedSession"
   | "removeDetachedSession"
+  | "reloadModels"
 >;
 
 type AgentBrowserPanelProps = {
@@ -299,6 +300,7 @@ export function AgentBrowserPanel({
         onNavigateBrowser={navigateBrowser}
         onOpenSideChat={openSideChat}
         onOpenTerminal={openTerminalForFocusedSession}
+        onReloadModels={handles.reloadModels}
         onRenameSideChat={renameSideChat}
         onUpdateSideChatTabs={updateSideChatTabs}
         sessions={sessions}

--- a/frontend/src/features/agent/ui/agent-composer-actions.tsx
+++ b/frontend/src/features/agent/ui/agent-composer-actions.tsx
@@ -24,6 +24,7 @@ export function AgentComposerActions({
   onAbortTurn,
   onTranscript,
   modelSelector,
+  modelReady,
 }: {
   fileInputRef: RefObject<HTMLInputElement | null>;
   onAttachFiles: (files: FileList | null) => void;
@@ -41,6 +42,7 @@ export function AgentComposerActions({
   onAbortTurn: () => void;
   onTranscript: (text: string) => void;
   modelSelector?: ReactNode;
+  modelReady: boolean;
 }) {
   const inputHasText = Boolean(input.trim());
   const starting = status === "starting";
@@ -157,10 +159,12 @@ export function AgentComposerActions({
         ) : (
           <button
             type="submit"
-            disabled={(!inputHasText && attachmentsCount === 0) || readingAttachments}
+            disabled={
+              !modelReady || (!inputHasText && attachmentsCount === 0) || readingAttachments
+            }
             className="inline-flex !h-[30px] !min-h-[30px] !w-[30px] !min-w-[30px] shrink-0 items-center justify-center rounded-full bg-(--fg) text-(--bg) transition-opacity hover:opacity-85 disabled:bg-(--hl3) disabled:opacity-100"
             aria-label="Send"
-            title="Send (Enter) · Queue (Tab)"
+            title={modelReady ? "Send (Enter) · Queue (Tab)" : "Start a model to send"}
           >
             {starting ? <Spinner size="sm" /> : <ArrowUp className="h-4 w-4 stroke-[2.25]" />}
           </button>

--- a/frontend/src/features/agent/ui/agent-composer-frame.tsx
+++ b/frontend/src/features/agent/ui/agent-composer-frame.tsx
@@ -50,6 +50,7 @@ export type AgentComposerFrameProps = {
   mentionIndex: number;
   mentionRows: MentionRow[];
   modelSupportsVision: boolean;
+  modelReady: boolean;
   modelSelector?: ReactNode;
   onAbortTurn: () => void;
   onAttachFiles: (files: FileList | null) => void;
@@ -107,6 +108,7 @@ export function AgentComposerFrame({
   mentionIndex,
   mentionRows,
   modelSupportsVision,
+  modelReady,
   modelSelector,
   onAbortTurn,
   onAttachFiles,
@@ -232,6 +234,7 @@ export function AgentComposerFrame({
           onAbortTurn={onAbortTurn}
           onTranscript={onTranscript}
           modelSelector={modelSelector}
+          modelReady={modelReady}
         />
       </div>
       {showStatusBar ? (

--- a/frontend/src/features/agent/ui/agent-model-picker.tsx
+++ b/frontend/src/features/agent/ui/agent-model-picker.tsx
@@ -78,7 +78,8 @@ export function AgentModelPicker({
     : (reasoningLevels.at(-1) ?? "off");
   const reasoningLabel = REASONING_LABELS[effectiveReasoning];
   const triggerLabel = supportsReasoning ? `${modelLabel} ${reasoningLabel}` : modelLabel;
-  const selectedModelNotRunning = !loading && Boolean(active && active.active === false);
+  const selectedModelNotRunning =
+    !loading && Boolean(active?.controllerUrl && active.active === false);
   const close = useCallback(() => {
     setOpen(false);
     setView("root");
@@ -304,7 +305,7 @@ function ModelList({
                 : "No chat models are available."}
             </p>
             <Link
-              href="/models"
+              href="/configure?section=models&tab=serves#models"
               onClick={onClose}
               className="mt-2 inline-flex h-7 items-center rounded-lg bg-(--active) px-2.5 text-(--fg) hover:bg-(--hover)"
             >
@@ -469,6 +470,15 @@ function ModelOption({
         onClick={() => onSelect(model.id)}
         className="flex min-h-8 min-w-0 flex-1 items-center gap-2 rounded-[10px] pl-2.5 text-left focus-visible:outline-none active:translate-y-px"
       >
+        {model.controllerUrl ? (
+          <span
+            className={cx(
+              "h-1.5 w-1.5 shrink-0 rounded-full",
+              model.active ? "bg-(--ok)" : "bg-(--warn)",
+            )}
+            title={model.active ? "Running" : "Stopped"}
+          />
+        ) : null}
         <span className="min-w-0 flex-1 truncate" title={label}>
           {label}
         </span>

--- a/frontend/src/features/agent/ui/chat-pane-send-flow.ts
+++ b/frontend/src/features/agent/ui/chat-pane-send-flow.ts
@@ -30,6 +30,7 @@ type UseChatPaneSendFlowOptions = {
   cwd: string;
   engine: SessionEngine;
   modelId: string;
+  modelReady: boolean;
   modelSupportsVision: boolean;
   readingAttachments: boolean;
   resetComposerHeight: () => void;
@@ -48,6 +49,7 @@ export function useChatPaneSendFlow({
   cwd,
   engine,
   modelId,
+  modelReady,
   modelSupportsVision,
   readingAttachments,
   resetComposerHeight,
@@ -119,7 +121,12 @@ export function useChatPaneSendFlow({
     (rawText: string, targetTabId?: string) => {
       const targetId = targetTabId ?? activeTab?.id;
       if (!targetId) return Promise.resolve();
-      if ((!rawText.trim() && attachments.length === 0) || !modelId || readingAttachments) {
+      if (
+        (!rawText.trim() && attachments.length === 0) ||
+        !modelId ||
+        !modelReady ||
+        readingAttachments
+      ) {
         return Promise.resolve();
       }
       const args = buildPromptArgs(targetId, rawText, browserToolEnabled);
@@ -140,6 +147,7 @@ export function useChatPaneSendFlow({
       clearAttachments,
       engine,
       modelId,
+      modelReady,
       readingAttachments,
       resetComposerHeight,
       setStickToBottom,
@@ -231,6 +239,10 @@ export function useChatPaneSendFlow({
         updateTab(activeTab.id, (t) => ({ ...t, error: "Select a model to send." }));
         return Promise.resolve();
       }
+      if (!modelReady) {
+        updateTab(activeTab.id, (t) => ({ ...t, error: "Start this model before sending." }));
+        return Promise.resolve();
+      }
       return Effect.runPromise(
         Effect.gen(function* () {
           const acceptsControl = yield* Effect.tryPromise({
@@ -263,6 +275,7 @@ export function useChatPaneSendFlow({
       attachments.length,
       engine,
       modelId,
+      modelReady,
       queueAndSendControl,
       readingAttachments,
       runGuardedSubmit,
@@ -277,6 +290,10 @@ export function useChatPaneSendFlow({
     if (!text || isPlaceholderSessionTitle(text)) return Promise.resolve();
     if (!modelId) {
       updateTab(activeTab.id, (t) => ({ ...t, error: "Select a model to send." }));
+      return Promise.resolve();
+    }
+    if (!modelReady) {
+      updateTab(activeTab.id, (t) => ({ ...t, error: "Start this model before sending." }));
       return Promise.resolve();
     }
     const runtime = activeTab.id;
@@ -310,6 +327,7 @@ export function useChatPaneSendFlow({
     cwd,
     engine,
     modelId,
+    modelReady,
     queueAndSendControl,
     runGuardedSubmit,
     submitPrompt,

--- a/frontend/src/features/agent/ui/chat-pane.tsx
+++ b/frontend/src/features/agent/ui/chat-pane.tsx
@@ -101,6 +101,12 @@ import {
 import { PersistentTerminals } from "@/features/agent/ui/persistent-terminals";
 import { cx } from "@/ui/utils";
 import { ExtensionUiDialog } from "@/features/agent/ui/extension-ui-dialog";
+import { WorkbenchReadinessPanel } from "@/features/agent/ui/workbench-readiness-panel";
+import {
+  workbenchModelReady,
+  type WorkbenchReadiness,
+  type WorkbenchReadinessAction,
+} from "@/features/agent/ui/workbench-readiness";
 import {
   clearSessionGoal,
   respondExtensionUi,
@@ -126,16 +132,17 @@ function downloadTextFile(filename: string, content: string): void {
   URL.revokeObjectURL(url);
 }
 
-function EmptyPromptTimeline() {
+function EmptyPromptTimeline({
+  readiness,
+  onAction,
+}: {
+  readiness: WorkbenchReadiness;
+  onAction: (action: WorkbenchReadinessAction) => void;
+}) {
   return (
     <div className="flex min-h-0 flex-1 overflow-y-auto bg-(--agent-bg) px-6 pb-10 pt-2">
       <div className="agent-thread-shell mx-auto flex flex-1">
-        <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center">
-          <p className="max-w-[24ch] text-[clamp(1.45rem,2.6vw,2.1rem)] font-semibold leading-[1.22] tracking-[-0.02em] text-(--fg)/90">
-            A dream is something you build for yourself.
-          </p>
-          <p className="text-[length:var(--fs-xl)] text-(--dim)">Just talk to it.</p>
-        </div>
+        <WorkbenchReadinessPanel readiness={readiness} onAction={onAction} />
       </div>
     </div>
   );
@@ -162,6 +169,8 @@ function ChatTranscript({
   stickToBottom,
   setStickToBottom,
   running,
+  readiness,
+  onReadinessAction,
   onForkSession,
   loadEarlierHistory,
 }: {
@@ -172,6 +181,8 @@ function ChatTranscript({
   stickToBottom: boolean;
   setStickToBottom: (value: boolean) => void;
   running: boolean;
+  readiness: WorkbenchReadiness;
+  onReadinessAction: (action: WorkbenchReadinessAction) => void;
   onForkSession?: () => void;
   loadEarlierHistory: () => Promise<void>;
 }) {
@@ -181,7 +192,7 @@ function ChatTranscript({
   return (
     <div className={terminalView ? "hidden" : "flex min-h-0 min-w-0 flex-1"}>
       {showEmptyPrompt ? (
-        <EmptyPromptTimeline />
+        <EmptyPromptTimeline readiness={readiness} onAction={onReadinessAction} />
       ) : (
         <Timeline
           key={activeTab?.id ?? "empty"}
@@ -206,7 +217,8 @@ type Props = {
   modelName: string | null;
   modelSupportsVision: boolean;
   modelThinkingLevels: readonly AgentThinkingLevel[];
-  modelsLoading: boolean;
+  readiness: WorkbenchReadiness;
+  onRetryModels: () => void;
   contextWindow: number;
   cwd: string;
   projectName: string | null;
@@ -257,7 +269,8 @@ export function ChatPane({
   modelName,
   modelSupportsVision,
   modelThinkingLevels,
-  modelsLoading,
+  readiness,
+  onRetryModels,
   contextWindow,
   cwd,
   projectName,
@@ -289,6 +302,7 @@ export function ChatPane({
   composerOnly = false,
 }: Props) {
   const router = useRouter();
+  const modelReady = workbenchModelReady(readiness);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const lastAppliedComposerHeightRef = useRef(0);
@@ -439,6 +453,24 @@ export function ChatPane({
     tools.setComputerTab("status");
     tools.setComputerOpen(true);
   }, [tools]);
+  const handleReadinessAction = useCallback(
+    (action: WorkbenchReadinessAction) => {
+      if (action === "retry") {
+        onRetryModels();
+        return;
+      }
+      if (action === "settings") {
+        router.push("/settings");
+        return;
+      }
+      if (action === "models") {
+        router.push("/configure?section=models&tab=serves#models");
+        return;
+      }
+      router.push("/");
+    },
+    [onRetryModels, router],
+  );
   const [diffDrawerOpen, setDiffDrawerOpen] = useState(false);
   const openDiffDrawer = useCallback(() => setDiffDrawerOpen(true), []);
   const closeDiffDrawer = useCallback(() => setDiffDrawerOpen(false), []);
@@ -589,6 +621,7 @@ export function ChatPane({
       cwd,
       engine,
       modelId,
+      modelReady,
       modelSupportsVision,
       readingAttachments,
       resetComposerHeight,
@@ -711,6 +744,8 @@ export function ChatPane({
         stickToBottom={stickToBottom}
         setStickToBottom={setStickToBottom}
         running={Boolean(running)}
+        readiness={readiness}
+        onReadinessAction={handleReadinessAction}
         onForkSession={onForkSession}
         loadEarlierHistory={loadEarlierHistory}
       />
@@ -740,6 +775,7 @@ export function ChatPane({
           mentionIndex={mentionIndex}
           mentionRows={mentionRows}
           modelSupportsVision={modelSupportsVision}
+          modelReady={modelReady}
           modelSelector={composerModelSelector}
           onAbortTurn={() => void abortTurn()}
           onAttachFiles={(files) => void attachFiles(files)}
@@ -764,7 +800,7 @@ export function ChatPane({
           onToggleBrowserBackend={onToggleBrowserBackend}
           onToggleBrowserTool={onToggleBrowserTool}
           onToggleCanvas={onToggleCanvas}
-          placeholder={composerVisual.placeholder}
+          placeholder={modelReady ? composerVisual.placeholder : readiness.placeholder}
           drawer={
             <ComposerProjectDrawer
               key={`${activeTabId}:${activePiSessionId ?? "new"}`}

--- a/frontend/src/features/agent/ui/computer-tab-panel.tsx
+++ b/frontend/src/features/agent/ui/computer-tab-panel.tsx
@@ -17,6 +17,7 @@ import type { Session, UpdateSession } from "@/features/agent/runtime/types";
 import type { AgentModel } from "@/features/agent/workspace/types";
 import { AgentModelPicker } from "@/features/agent/ui/agent-model-picker";
 import { ChatPane } from "@/features/agent/ui/chat-pane";
+import { deriveWorkbenchReadiness } from "@/features/agent/ui/workbench-readiness";
 
 const LazyAgentBrowser = lazy(() =>
   import("@/features/agent/ui/agent-browser").then(({ AgentBrowser }) => ({
@@ -75,6 +76,7 @@ type ComputerTabPanelProps = {
   onNavigateBrowser: (value: string) => void;
   onOpenSideChat: (draft?: SideChatDraft) => void;
   onOpenTerminal: () => void;
+  onReloadModels: () => void;
   onRenameSideChat: (tabId: string, title: string) => void;
   onUpdateSideChatTabs: (nextTabsOrUpdater: SideChatTabsUpdater) => void;
   sessions: Session[];
@@ -142,6 +144,7 @@ function SideChatTab({
   models,
   modelsLoading,
   onCloseSideChat,
+  onReloadModels,
   onRenameSideChat,
   onUpdateSideChatTabs,
   sideChatSession,
@@ -149,6 +152,13 @@ function SideChatTab({
 }: ComputerTabPanelProps) {
   const modelId = sideChatSession.modelId ?? focusedSession?.modelId ?? activeModelId;
   const selectedModel = models.find((model) => model.id === modelId) ?? activeModel;
+  const readiness = deriveWorkbenchReadiness({
+    models,
+    selectedModelId: modelId,
+    loading: modelsLoading,
+    error: "",
+    controllerStatus: null,
+  });
   const cwd = sideChatSession.cwd ?? focusedSession?.cwd ?? activeProject?.path ?? "";
   const updateSession = useCallback<UpdateSession>(
     (sessionId, patch) =>
@@ -163,7 +173,8 @@ function SideChatTab({
         modelName={selectedModel?.name ?? modelId}
         modelSupportsVision={selectedModel?.vision ?? false}
         modelThinkingLevels={selectedModel?.thinkingLevels ?? ["off"]}
-        modelsLoading={modelsLoading}
+        readiness={readiness}
+        onRetryModels={onReloadModels}
         contextWindow={selectedModel?.contextWindow ?? 0}
         cwd={cwd}
         projectName={activeProject?.name ?? null}

--- a/frontend/src/features/agent/ui/render-workspace-pane.tsx
+++ b/frontend/src/features/agent/ui/render-workspace-pane.tsx
@@ -17,6 +17,7 @@ import { activeSession } from "@/features/agent/runtime/selectors";
 import { terminalOwnerFor } from "@/features/agent/terminal-owners";
 import { collectLeaves } from "@/features/agent/workspace/layout";
 import type { WorkspaceHandles } from "@/features/agent/ui/use-workspace";
+import { deriveWorkbenchReadiness } from "@/features/agent/ui/workbench-readiness";
 
 export type WorkspacePaneRenderContext = {
   paneId: PaneId;
@@ -128,6 +129,8 @@ type WorkspacePaneProps = {
   view: WorkspacePaneView;
   models: AgentModel[];
   modelsLoading: boolean;
+  modelError: string;
+  controllerStatus: WorkspaceState["controllerStatus"];
   defaultModel: string;
   tools: ReturnType<typeof useTools>;
   dispatch: WorkspaceDispatch;
@@ -141,6 +144,8 @@ function sameWorkspacePaneProps(previous: WorkspacePaneProps, next: WorkspacePan
     sameWorkspacePaneView(previous.view, next.view) &&
     previous.models === next.models &&
     previous.modelsLoading === next.modelsLoading &&
+    previous.modelError === next.modelError &&
+    previous.controllerStatus === next.controllerStatus &&
     previous.defaultModel === next.defaultModel &&
     previous.tools.browser.enabled === next.tools.browser.enabled &&
     previous.tools.browser.backend === next.tools.browser.backend &&
@@ -163,6 +168,8 @@ const WorkspacePane = memo(function WorkspacePane({
   view,
   models,
   modelsLoading,
+  modelError,
+  controllerStatus,
   defaultModel,
   tools,
   dispatch,
@@ -171,6 +178,13 @@ const WorkspacePane = memo(function WorkspacePane({
   composerOnly,
 }: WorkspacePaneProps) {
   const sessions = view.session ? [view.session] : [];
+  const readiness = deriveWorkbenchReadiness({
+    models,
+    selectedModelId: view.modelId,
+    loading: modelsLoading,
+    error: modelError,
+    controllerStatus,
+  });
   return (
     <ChatPane
       paneId={view.paneId}
@@ -178,7 +192,8 @@ const WorkspacePane = memo(function WorkspacePane({
       modelName={view.model?.name ?? view.modelId ?? null}
       modelSupportsVision={view.model?.vision ?? false}
       modelThinkingLevels={view.model?.thinkingLevels ?? ["off"]}
-      modelsLoading={modelsLoading}
+      readiness={readiness}
+      onRetryModels={handles.reloadModels}
       contextWindow={view.model?.contextWindow ?? 0}
       cwd={view.cwd}
       projectName={view.project?.name ?? null}
@@ -249,6 +264,8 @@ export function renderWorkspacePane({
       view={view}
       models={state.models}
       modelsLoading={state.modelsLoading}
+      modelError={state.error}
+      controllerStatus={state.controllerStatus}
       defaultModel={state.selectedModel}
       tools={tools}
       dispatch={dispatch}

--- a/frontend/src/features/agent/ui/use-workspace.ts
+++ b/frontend/src/features/agent/ui/use-workspace.ts
@@ -20,6 +20,7 @@ import type {
   AgentModel,
   PaneId,
   WorkspaceAction,
+  WorkspaceControllerStatus,
   WorkspaceState,
 } from "@/features/agent/workspace/types";
 import { useProjects } from "@/features/agent/projects/context";
@@ -62,6 +63,7 @@ export type WorkspaceHandles = {
   ) => void;
   selectPaneModel: (paneId: PaneId, modelId: string) => void;
   setDefaultModel: (modelId: string) => void;
+  reloadModels: () => void;
   notifySessionsChanged: () => void;
   startComputerResize: (event: ReactMouseEvent<HTMLDivElement>) => void;
   initGitForActiveProject: () => Promise<void>;
@@ -128,14 +130,44 @@ async function loadAgentModelsPayload(): Promise<{ models?: AgentModel[]; error?
   return payload;
 }
 
-function api(): WorkspaceEffectDeps["api"] {
+async function loadControllerStatus(): Promise<WorkspaceControllerStatus | null> {
+  const response = await fetch("/api/proxy/status", { cache: "no-store" });
+  if (!response.ok) return null;
+  const payload = await safeJson<{
+    running?: boolean;
+    launching?: string | null;
+  }>(response);
+  return {
+    running: payload.running === true,
+    launching:
+      typeof payload.launching === "string" && payload.launching.trim() ? payload.launching : null,
+  };
+}
+
+async function loadWorkbenchModelsPayload(): Promise<{
+  models?: AgentModel[];
+  error?: string;
+  controllerStatus?: WorkspaceControllerStatus | null;
+}> {
+  const [modelsResult, statusResult] = await Promise.allSettled([
+    loadAgentModelsPayload(),
+    loadControllerStatus(),
+  ]);
+  if (modelsResult.status === "rejected") throw modelsResult.reason;
+  return {
+    ...modelsResult.value,
+    controllerStatus: statusResult.status === "fulfilled" ? statusResult.value : null,
+  };
+}
+
+function workspaceApi(): WorkspaceEffectDeps["api"] {
   return {
     loadSetupChecks: async () => {
       const response = await fetch("/api/agent/setup-checks", { cache: "no-store" });
       return safeJson<{ checks?: Array<{ id: string; ok: boolean; guidance?: string }> }>(response);
     },
     loadModels: async () => {
-      return loadAgentModelsPayload();
+      return loadWorkbenchModelsPayload();
     },
   };
 }
@@ -173,7 +205,7 @@ export function useWorkspace({ ephemeral = false }: UseWorkspaceOptions = {}): U
       return {
         storage: ephemeralStorage ?? window.localStorage,
         window: createWorkspaceWindow(window),
-        api: api(),
+        api: workspaceApi(),
         dispatch: workspaceDispatch,
         queueReplay: queueSessionReplay,
         selectionFor: (id) => toolsRef.current.selectionFor(id),
@@ -194,47 +226,56 @@ export function useWorkspace({ ephemeral = false }: UseWorkspaceOptions = {}): U
 
   const { dispatch } = controller;
 
+  const reloadModels = useCallback(() => {
+    dispatch({ type: "setModelsLoading", loading: true });
+    dispatch({ type: "setError", error: "" });
+    void loadWorkbenchModelsPayload()
+      .then((payload) => {
+        dispatch({
+          type: "setModels",
+          models: payload.models ?? [],
+          preferredModelId: readDefaultAgentModel(window.localStorage),
+          controllerStatus: payload.controllerStatus,
+        });
+      })
+      .catch((error) => {
+        dispatch({
+          type: "setError",
+          error: error instanceof Error ? error.message : String(error),
+        });
+        dispatch({ type: "setModelsLoading", loading: false });
+      });
+  }, [dispatch]);
+
   useMountSubscription(() => {
     if (typeof window === "undefined") return;
-    const reload = () => {
-      dispatch({ type: "setModelsLoading", loading: true });
-      dispatch({ type: "setError", error: "" });
-      void loadAgentModelsPayload()
-        .then((models) => {
-          dispatch({
-            type: "setModels",
-            models: models.models ?? [],
-            preferredModelId: readDefaultAgentModel(window.localStorage),
-          });
-        })
-        .catch((error) => {
-          dispatch({
-            type: "setError",
-            error: error instanceof Error ? error.message : String(error),
-          });
-          dispatch({ type: "setModels", models: [] });
-        })
-        .finally(() => dispatch({ type: "setModelsLoading", loading: false }));
-    };
     const onStorage = (event: StorageEvent | Event) => {
       const key = (event as StorageEvent).key;
       if (key && key !== BACKEND_URL_STORAGE_KEY && key !== CONTROLLERS_STORAGE_KEY) return;
-      reload();
+      reloadModels();
     };
-    const recoverIfEmpty = () => {
-      if (stateRef.current.models.length === 0 && !stateRef.current.modelsLoading) reload();
+    const recoverIfUnavailable = () => {
+      const current = stateRef.current;
+      const hasReadyModel = current.models.some((model) => !model.controllerUrl || model.active);
+      if (!hasReadyModel && !current.modelsLoading) reloadModels();
     };
-    const retryTimers = [900, 2500, 6000].map((ms) => window.setTimeout(recoverIfEmpty, ms));
+    const retryTimers = [900, 2500, 6000].map((ms) => window.setTimeout(recoverIfUnavailable, ms));
     window.addEventListener("storage", onStorage);
-    window.addEventListener("focus", recoverIfEmpty);
-    window.addEventListener("online", recoverIfEmpty);
+    window.addEventListener("focus", recoverIfUnavailable);
+    window.addEventListener("online", recoverIfUnavailable);
     return () => {
       for (const t of retryTimers) window.clearTimeout(t);
       window.removeEventListener("storage", onStorage);
-      window.removeEventListener("focus", recoverIfEmpty);
-      window.removeEventListener("online", recoverIfEmpty);
+      window.removeEventListener("focus", recoverIfUnavailable);
+      window.removeEventListener("online", recoverIfUnavailable);
     };
-  }, [dispatch]);
+  }, [reloadModels]);
+
+  useMountSubscription(() => {
+    if (!state.controllerStatus?.launching || state.modelsLoading) return;
+    const timer = window.setTimeout(reloadModels, 3_000);
+    return () => window.clearTimeout(timer);
+  }, [reloadModels, state.controllerStatus?.launching, state.modelsLoading]);
 
   const handles = useMemo<WorkspaceHandles>(
     () => ({
@@ -293,6 +334,7 @@ export function useWorkspace({ ephemeral = false }: UseWorkspaceOptions = {}): U
         writeDefaultAgentModel(ephemeral ? createMemoryStorage() : window.localStorage, modelId);
         dispatch({ type: "setSelectedModel", modelId });
       },
+      reloadModels,
       notifySessionsChanged: () => dispatch({ type: "notifySessionsChanged" }),
       startComputerResize: (event: ReactMouseEvent<HTMLDivElement>) => {
         if (typeof window === "undefined") return;
@@ -343,7 +385,7 @@ export function useWorkspace({ ephemeral = false }: UseWorkspaceOptions = {}): U
         }
       },
     }),
-    [dispatch, ephemeral, getReplayQueue],
+    [dispatch, ephemeral, getReplayQueue, reloadModels],
   );
 
   useWorkspaceHydrationEffects({ dispatch, toolsRef, skipRestore: ephemeral });

--- a/frontend/src/features/agent/ui/workbench-readiness-panel.tsx
+++ b/frontend/src/features/agent/ui/workbench-readiness-panel.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Button, Spinner } from "@/ui";
+import type {
+  WorkbenchReadiness,
+  WorkbenchReadinessAction,
+} from "@/features/agent/ui/workbench-readiness";
+
+const ACTION_LABELS: Record<WorkbenchReadinessAction, string> = {
+  retry: "Try again",
+  settings: "Open settings",
+  models: "Open Models",
+  status: "View startup",
+};
+
+export function WorkbenchReadinessPanel({
+  readiness,
+  onAction,
+}: {
+  readiness: WorkbenchReadiness;
+  onAction: (action: WorkbenchReadinessAction) => void;
+}) {
+  const primaryAction = readiness.primaryAction;
+  const secondaryAction = readiness.secondaryAction;
+  if (readiness.kind === "ready") {
+    return (
+      <div
+        className="flex flex-1 flex-col items-center justify-center gap-3 text-center"
+        data-workbench-readiness="ready"
+      >
+        <div className="inline-flex items-center gap-2 rounded-full border border-(--border) bg-(--fg)/[0.025] px-3 py-1.5 text-[length:var(--fs-sm)] text-(--dim)">
+          <span className="h-2 w-2 rounded-full bg-(--ok)" />
+          {readiness.title}
+        </div>
+        <p className="max-w-[24ch] text-[clamp(1.45rem,2.6vw,2.1rem)] font-semibold leading-[1.22] tracking-[-0.02em] text-(--fg)/90">
+          A dream is something you build for yourself.
+        </p>
+        <p className="text-[length:var(--fs-xl)] text-(--dim)">Just talk to it.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex flex-1 flex-col items-center justify-center px-4 text-center"
+      data-workbench-readiness={readiness.kind}
+      role="status"
+    >
+      <div className="w-full max-w-md rounded-3xl border border-(--border) bg-(--composer)/70 px-7 py-7 shadow-[var(--shadow-lg)] backdrop-blur-xl">
+        <div className="mx-auto mb-4 flex h-9 w-9 items-center justify-center rounded-full bg-(--fg)/5">
+          {readiness.kind === "connecting" || readiness.kind === "starting" ? (
+            <Spinner size="sm" />
+          ) : (
+            <span className="h-2.5 w-2.5 rounded-full bg-(--warn)" />
+          )}
+        </div>
+        <h2 className="text-[length:var(--fs-xl)] font-semibold text-(--fg)">{readiness.title}</h2>
+        <p className="mx-auto mt-2 max-w-sm text-[length:var(--fs-base)] leading-5 text-(--dim)">
+          {readiness.detail}
+        </p>
+        {primaryAction ? (
+          <div className="mt-5 flex flex-wrap items-center justify-center gap-2">
+            <Button size="sm" onClick={() => onAction(primaryAction)}>
+              {ACTION_LABELS[primaryAction]}
+            </Button>
+            {secondaryAction ? (
+              <Button size="sm" variant="secondary" onClick={() => onAction(secondaryAction)}>
+                {ACTION_LABELS[secondaryAction]}
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/agent/ui/workbench-readiness.test.ts
+++ b/frontend/src/features/agent/ui/workbench-readiness.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { AgentModel } from "@/features/agent/workspace/types";
+import { deriveWorkbenchReadiness } from "./workbench-readiness";
+
+function controllerModel(id: string, active: boolean): AgentModel {
+  return {
+    id,
+    name: id,
+    provider: "local-studio",
+    controllerUrl: "http://controller.local:8080",
+    contextWindow: 128_000,
+    maxTokens: 32_000,
+    reasoning: true,
+    vision: false,
+    active,
+  };
+}
+
+function readiness(overrides: Partial<Parameters<typeof deriveWorkbenchReadiness>[0]> = {}) {
+  return deriveWorkbenchReadiness({
+    models: [],
+    selectedModelId: "",
+    loading: false,
+    error: "",
+    controllerStatus: null,
+    ...overrides,
+  });
+}
+
+test("ready controller model enables the first-message state", () => {
+  const model = controllerModel("qwen", true);
+  const result = readiness({ models: [model], selectedModelId: model.id });
+
+  assert.equal(result.kind, "ready");
+  assert.equal(result.model, model);
+  assert.match(result.title, /qwen is ready/);
+});
+
+test("initial model loading presents a connecting state", () => {
+  assert.equal(readiness({ loading: true }).kind, "connecting");
+});
+
+test("controller launch presents a startup state", () => {
+  const model = controllerModel("qwen", false);
+  const result = readiness({
+    models: [model],
+    selectedModelId: model.id,
+    controllerStatus: { running: true, launching: "qwen-serve" },
+  });
+
+  assert.equal(result.kind, "starting");
+  assert.equal(result.primaryAction, "status");
+});
+
+test("authentication and connectivity errors have distinct recovery actions", () => {
+  const authentication = readiness({ error: "HTTP 401 Unauthorized" });
+  const offline = readiness({ error: "fetch failed: ECONNREFUSED" });
+
+  assert.equal(authentication.kind, "authentication");
+  assert.equal(authentication.primaryAction, "settings");
+  assert.equal(offline.kind, "offline");
+  assert.equal(offline.primaryAction, "retry");
+});
+
+test("empty and stopped controllers direct the user to Models", () => {
+  const empty = readiness();
+  const model = controllerModel("qwen", false);
+  const stopped = readiness({ models: [model], selectedModelId: model.id });
+
+  assert.equal(empty.kind, "empty");
+  assert.equal(empty.primaryAction, "models");
+  assert.equal(stopped.kind, "stopped");
+  assert.equal(stopped.primaryAction, "models");
+});
+
+test("non-controller provider models remain available without controller active state", () => {
+  const model: AgentModel = {
+    ...controllerModel("cloud-model", false),
+    controllerUrl: undefined,
+  };
+  assert.equal(readiness({ models: [model], selectedModelId: model.id }).kind, "ready");
+});

--- a/frontend/src/features/agent/ui/workbench-readiness.ts
+++ b/frontend/src/features/agent/ui/workbench-readiness.ts
@@ -1,0 +1,157 @@
+import type { AgentModel, WorkspaceControllerStatus } from "@/features/agent/workspace/types";
+
+export type WorkbenchReadinessKind =
+  | "connecting"
+  | "authentication"
+  | "offline"
+  | "error"
+  | "empty"
+  | "starting"
+  | "stopped"
+  | "ready";
+
+export type WorkbenchReadinessAction = "retry" | "settings" | "models" | "status";
+
+export type WorkbenchReadiness = {
+  kind: WorkbenchReadinessKind;
+  title: string;
+  detail: string;
+  placeholder: string;
+  model: AgentModel | null;
+  primaryAction?: WorkbenchReadinessAction;
+  secondaryAction?: WorkbenchReadinessAction;
+};
+
+type WorkbenchReadinessInput = {
+  models: AgentModel[];
+  selectedModelId: string;
+  loading: boolean;
+  error: string;
+  controllerStatus: WorkspaceControllerStatus | null;
+};
+
+function modelLabel(model: AgentModel): string {
+  return model.rawId || model.name || model.id;
+}
+
+function modelCanChat(model: AgentModel): boolean {
+  return !model.controllerUrl || model.active;
+}
+
+function connectionErrorReadiness(error: string): WorkbenchReadiness {
+  const normalized = error.toLowerCase();
+  if (normalized.includes("unauthorized") || normalized.includes("401")) {
+    return {
+      kind: "authentication",
+      title: "Controller authentication failed",
+      detail: "Workbench could not authenticate with the active controller.",
+      placeholder: "Update the controller connection to continue",
+      model: null,
+      primaryAction: "settings",
+      secondaryAction: "retry",
+    };
+  }
+  if (
+    normalized.includes("fetch failed") ||
+    normalized.includes("failed to fetch") ||
+    normalized.includes("network") ||
+    normalized.includes("econnrefused") ||
+    normalized.includes("socket") ||
+    normalized.includes("timeout") ||
+    normalized.includes("timed out") ||
+    normalized.includes("unreachable")
+  ) {
+    return {
+      kind: "offline",
+      title: "Controller unavailable",
+      detail: "Workbench cannot reach the active controller yet.",
+      placeholder: "Reconnect to the controller to continue",
+      model: null,
+      primaryAction: "retry",
+      secondaryAction: "settings",
+    };
+  }
+  return {
+    kind: "error",
+    title: "Workbench needs attention",
+    detail: error || "The model list could not be loaded.",
+    placeholder: "Resolve the controller issue to continue",
+    model: null,
+    primaryAction: "retry",
+    secondaryAction: "settings",
+  };
+}
+
+export function deriveWorkbenchReadiness({
+  models,
+  selectedModelId,
+  loading,
+  error,
+  controllerStatus,
+}: WorkbenchReadinessInput): WorkbenchReadiness {
+  const selected = models.find((model) => model.id === selectedModelId) ?? null;
+  if (selected && modelCanChat(selected)) {
+    return {
+      kind: "ready",
+      title: `${modelLabel(selected)} is ready`,
+      detail: "Connected to the active controller and ready for your first message.",
+      placeholder: "Do anything",
+      model: selected,
+    };
+  }
+  if (controllerStatus?.launching || (controllerStatus?.running && !models.some(modelCanChat))) {
+    return {
+      kind: "starting",
+      title: "Your model is starting",
+      detail: "Local model startup can take several minutes on the first run.",
+      placeholder: "Wait for the model to finish starting",
+      model: selected,
+      primaryAction: "status",
+      secondaryAction: "retry",
+    };
+  }
+  if (loading && models.length === 0) {
+    return {
+      kind: "connecting",
+      title: "Connecting to your controller",
+      detail: "Checking for a chat model that is ready to use.",
+      placeholder: "Connecting to your controller…",
+      model: null,
+    };
+  }
+  if (error) return connectionErrorReadiness(error);
+  if (models.length === 0) {
+    return {
+      kind: "empty",
+      title: "No chat models yet",
+      detail: "Download or configure a Serve, then launch it to start chatting.",
+      placeholder: "Set up a model to start chatting",
+      model: null,
+      primaryAction: "models",
+      secondaryAction: "retry",
+    };
+  }
+  const activeModel = models.find(modelCanChat) ?? null;
+  if (activeModel) {
+    return {
+      kind: "ready",
+      title: `${modelLabel(activeModel)} is ready`,
+      detail: "Connected to the active controller and ready for your first message.",
+      placeholder: "Do anything",
+      model: activeModel,
+    };
+  }
+  return {
+    kind: "stopped",
+    title: selected ? `${modelLabel(selected)} is not running` : "No model is running",
+    detail: "Launch a saved Serve, then return to Workbench to start chatting.",
+    placeholder: selected ? `Start ${modelLabel(selected)} to chat` : "Start a model to chat",
+    model: selected,
+    primaryAction: "models",
+    secondaryAction: "retry",
+  };
+}
+
+export function workbenchModelReady(readiness: WorkbenchReadiness): boolean {
+  return readiness.kind === "ready";
+}

--- a/frontend/src/features/agent/workspace/effects.ts
+++ b/frontend/src/features/agent/workspace/effects.ts
@@ -13,6 +13,7 @@ import type {
   AgentModel,
   PaneId,
   WorkspaceAction,
+  WorkspaceControllerStatus,
   WorkspaceState,
 } from "@/features/agent/workspace/types";
 import {
@@ -35,7 +36,14 @@ type SetupCheck = { id: string; ok: boolean; guidance?: string };
 
 export type WorkspaceApi = {
   loadSetupChecks?: () => Promise<{ checks?: SetupCheck[] }>;
-  loadModels?: () => Promise<{ models?: AgentModel[]; error?: string } | AgentModel[]>;
+  loadModels?: () => Promise<
+    | {
+        models?: AgentModel[];
+        error?: string;
+        controllerStatus?: WorkspaceControllerStatus | null;
+      }
+    | AgentModel[]
+  >;
 };
 
 export type WorkspaceWindow = {
@@ -98,11 +106,25 @@ function scheduleSessionsRefresh(deps: WorkspaceEffectDeps): void {
 }
 
 function normalizeModelsPayload(
-  payload: { models?: AgentModel[]; error?: string } | AgentModel[],
-): { models: AgentModel[]; error?: string } {
+  payload:
+    | {
+        models?: AgentModel[];
+        error?: string;
+        controllerStatus?: WorkspaceControllerStatus | null;
+      }
+    | AgentModel[],
+): {
+  models: AgentModel[];
+  error?: string;
+  controllerStatus?: WorkspaceControllerStatus | null;
+} {
   return Array.isArray(payload)
     ? { models: payload }
-    : { models: payload.models ?? [], error: payload.error };
+    : {
+        models: payload.models ?? [],
+        error: payload.error,
+        controllerStatus: payload.controllerStatus,
+      };
 }
 
 function runInitialApiEffects(state: WorkspaceState, deps: WorkspaceEffectDeps): void {
@@ -133,6 +155,7 @@ function runInitialApiEffects(state: WorkspaceState, deps: WorkspaceEffectDeps):
             type: "setModels",
             models: normalized.models,
             preferredModelId: readDefaultAgentModel(deps.storage),
+            controllerStatus: normalized.controllerStatus,
           });
           if (normalized.models.length > 0) {
             deps.dispatch?.({ type: "setSetupWarning", warning: "" });

--- a/frontend/src/features/agent/workspace/reducer.test.ts
+++ b/frontend/src/features/agent/workspace/reducer.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { AgentModel } from "@/features/agent/workspace/types";
+import { createInitialState, reducer } from "./store";
+
+function model(id: string, active: boolean): AgentModel {
+  return {
+    id,
+    name: id,
+    provider: "local-studio",
+    controllerUrl: "http://controller.local:8080",
+    contextWindow: 128_000,
+    maxTokens: 32_000,
+    reasoning: false,
+    vision: false,
+    active,
+  };
+}
+
+test("running model wins over stale current and preferred selections", () => {
+  const stopped = model("stopped", false);
+  const running = model("running", true);
+  const initial = { ...createInitialState(), selectedModel: stopped.id };
+  const next = reducer(initial, {
+    type: "setModels",
+    models: [stopped, running],
+    preferredModelId: stopped.id,
+  });
+
+  assert.equal(next.selectedModel, running.id);
+});
+
+test("ready preferred model remains selected", () => {
+  const first = model("first", true);
+  const preferred = model("preferred", true);
+  const next = reducer(createInitialState(), {
+    type: "setModels",
+    models: [first, preferred],
+    preferredModelId: preferred.id,
+    controllerStatus: { running: true, launching: null },
+  });
+
+  assert.equal(next.selectedModel, preferred.id);
+  assert.deepEqual(next.controllerStatus, { running: true, launching: null });
+});

--- a/frontend/src/features/agent/workspace/reducer.ts
+++ b/frontend/src/features/agent/workspace/reducer.ts
@@ -25,13 +25,22 @@ function chooseModelId(
   currentModelId: string,
   preferredModelId?: string,
 ): string {
+  const ready = (model: AgentModel) => !model.controllerUrl || model.active;
+  if (preferredModelId && models.some((model) => model.id === preferredModelId && ready(model))) {
+    return preferredModelId;
+  }
+  if (currentModelId && models.some((model) => model.id === currentModelId && ready(model))) {
+    return currentModelId;
+  }
+  const firstReady = models.find(ready)?.id;
+  if (firstReady) return firstReady;
   if (preferredModelId && models.some((model) => model.id === preferredModelId)) {
     return preferredModelId;
   }
   if (currentModelId && models.some((model) => model.id === currentModelId)) {
     return currentModelId;
   }
-  return models.find((model) => model.active)?.id || models[0]?.id || "";
+  return models[0]?.id || "";
 }
 
 function reduceWorkspaceStatus(
@@ -53,6 +62,8 @@ function reduceWorkspaceStatus(
         models: action.models,
         selectedModel: chooseModelId(action.models, state.selectedModel, action.preferredModelId),
         modelsLoading: false,
+        controllerStatus:
+          action.controllerStatus === undefined ? state.controllerStatus : action.controllerStatus,
       };
     case "setSelectedModel":
       return { ...state, selectedModel: action.modelId };

--- a/frontend/src/features/agent/workspace/store.ts
+++ b/frontend/src/features/agent/workspace/store.ts
@@ -46,6 +46,7 @@ export function createInitialState(): WorkspaceState {
     models: [],
     selectedModel: "",
     modelsLoading: true,
+    controllerStatus: null,
     layout: { kind: "leaf", paneId: "p-init" },
     panesById: new Map([["p-init", { sessionId: session.id }]]),
     focusedPaneId: "p-init",

--- a/frontend/src/features/agent/workspace/types.ts
+++ b/frontend/src/features/agent/workspace/types.ts
@@ -10,6 +10,11 @@ export type { AgentModel } from "@/features/agent/models";
 
 export type WorkspaceLayout = Layout;
 
+export type WorkspaceControllerStatus = {
+  running: boolean;
+  launching: string | null;
+};
+
 export type { GitSummary } from "@/features/agent/projects/types";
 
 export type ChatPaneState = {
@@ -25,6 +30,7 @@ export type WorkspaceState = {
   models: AgentModel[];
   selectedModel: string;
   modelsLoading: boolean;
+  controllerStatus: WorkspaceControllerStatus | null;
   layout: WorkspaceLayout;
   panesById: ReadonlyMap<PaneId, PaneState>;
   focusedPaneId: PaneId;
@@ -49,7 +55,12 @@ export type WorkspaceHydration = Partial<WorkspaceState>;
 export type WorkspaceAction =
   | { type: "hydrate"; state: WorkspaceHydration; hydrated?: boolean }
   | { type: "setModelsLoading"; loading: boolean }
-  | { type: "setModels"; models: AgentModel[]; preferredModelId?: string }
+  | {
+      type: "setModels";
+      models: AgentModel[];
+      preferredModelId?: string;
+      controllerStatus?: WorkspaceControllerStatus | null;
+    }
   | { type: "setSelectedModel"; modelId: string }
   | { type: "setSetupWarning"; warning: string }
   | { type: "setError"; error: string }

--- a/frontend/src/features/dashboard/control-panel/status-section-parts.tsx
+++ b/frontend/src/features/dashboard/control-panel/status-section-parts.tsx
@@ -230,14 +230,20 @@ export function StatusMetricStrip({
         <MetricCell
           key={metric.label}
           label={metric.label}
-          value={metric.value ?? "0"}
+          value={metric.value ?? "—"}
           unit={metric.value ? metric.unit : undefined}
           detail={metric.detail ?? undefined}
           detailTitle={metric.detailTitle ?? undefined}
         />
       ))}
       {compactMetrics.map((metric) => (
-        <MetricCell key={metric.label} label={metric.label} value={metric.value ?? "—"} />
+        <MetricCell
+          key={metric.label}
+          label={metric.label}
+          value={metric.value ?? "—"}
+          detail={metric.detail}
+          detailTitle={metric.detailTitle}
+        />
       ))}
     </dl>
   );

--- a/frontend/src/features/dashboard/control-panel/status-section-view.test.ts
+++ b/frontend/src/features/dashboard/control-panel/status-section-view.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { Metrics, ProcessInfo } from "@/lib/types";
+import { resolveStatusSectionView } from "./status-section-view";
+
+const process: ProcessInfo = {
+  backend: "vllm",
+  model_path: "/models/qwen",
+  pid: 42,
+  port: 8000,
+  served_model_name: "qwen",
+};
+
+function view(metrics: Metrics) {
+  return resolveStatusSectionView({
+    currentProcess: process,
+    currentRecipe: null,
+    gpus: [],
+    metrics,
+  });
+}
+
+test("recorded throughput remains visible when the engine is idle", () => {
+  const result = view({
+    generation_throughput: 0,
+    peak_generation_tps: 67.5,
+    peak_prefill_tps: 469.5,
+    prompt_throughput: 0,
+    running_requests: 0,
+    pending_requests: 0,
+    total_requests: 9,
+  });
+
+  assert.deepEqual(
+    result.metricColumns.map(({ label, value, detail }) => ({ label, value, detail })),
+    [
+      { label: "Decode", value: "67.5", detail: "recorded peak" },
+      { label: "TTFT", value: null, detail: undefined },
+      { label: "Prefill", value: "469.5", detail: "recorded peak" },
+    ],
+  );
+  assert.deepEqual(result.compactMetrics[0], {
+    label: "Requests",
+    value: "9",
+    detail: "0 active · 0 queued",
+    detailTitle: "9 completed · 0 active · 0 queued",
+  });
+});
+
+test("live throughput and request concurrency are labeled explicitly", () => {
+  const result = view({
+    generation_throughput: 67.4,
+    generation_throughput_status: "live",
+    peak_generation_tps: 70,
+    prompt_throughput: 480.2,
+    prompt_throughput_status: "live",
+    peak_prefill_tps: 500,
+    running_requests: 1,
+    pending_requests: 2,
+    total_requests: 9,
+  });
+
+  assert.equal(result.metricColumns[0]?.value, "67.4");
+  assert.equal(result.metricColumns[0]?.detail, "live · max 70.0");
+  assert.equal(result.metricColumns[2]?.value, "480.2");
+  assert.equal(result.metricColumns[2]?.detail, "live · max 500.0");
+  assert.equal(result.compactMetrics[0]?.value, "9");
+  assert.equal(result.compactMetrics[0]?.detail, "1 active · 2 queued");
+  assert.equal(result.sampleInput.requests, 3);
+});
+
+test("unmeasured throughput renders as unavailable instead of zero", () => {
+  const result = view({ total_requests: 0 });
+
+  assert.equal(result.metricColumns[0]?.value, null);
+  assert.equal(result.metricColumns[2]?.value, null);
+  assert.equal(result.compactMetrics[0]?.value, "0");
+});

--- a/frontend/src/features/dashboard/control-panel/status-section-view.ts
+++ b/frontend/src/features/dashboard/control-panel/status-section-view.ts
@@ -25,10 +25,13 @@ export type MetricColumnView = {
 export type CompactMetricView = {
   label: string;
   value: string | null;
+  detail?: string;
+  detailTitle?: string;
 };
 
 type PeakKind = "generation" | "prefill" | "ttft";
 type PeakTier = "session" | "bestSession" | "all";
+type ThroughputSource = "live" | "last" | "peak" | "unavailable";
 
 const PEAK_FIELDS: Record<PeakKind, Record<PeakTier, readonly (keyof Metrics)[]>> = {
   generation: {
@@ -87,14 +90,14 @@ export function resolveStatusSectionView({
     modelName: resolveModelName(currentProcess, currentRecipe),
     sampleInput: {
       key: resolveModelSampleKey(currentProcess, currentRecipe),
-      generation: perf.genTps ?? 0,
+      generation: perf.genSample,
       generationPeak: peakFor(metrics, "generation") ?? perf.genTps ?? 0,
-      prefill: perf.prefillTps ?? 0,
+      prefill: perf.prefillSample,
       prefillPeak: peakFor(metrics, "prefill") ?? perf.prefillTps ?? 0,
       ttft: perf.ttftMs ?? 0,
       ttftPeak: peakFor(metrics, "ttft") ?? perf.ttftMs ?? 0,
-      requests: perf.sessions,
-      requestPeak: perf.peakReq || perf.sessions,
+      requests: perf.activeRequests + perf.queuedRequests,
+      requestPeak: perf.peakReq || perf.activeRequests + perf.queuedRequests,
       active: isRunning,
     },
   };
@@ -123,17 +126,49 @@ function resolveModelSampleKey(
 
 function resolvePerformanceMetrics(metrics: Metrics | null, gpus: GPU[]) {
   const gpuTotals = resolveGpuTotals(gpus);
+  const generation = resolveThroughput(metrics, "generation");
+  const prefill = resolveThroughput(metrics, "prefill");
   return {
-    genTps: firstPositive(metrics?.generation_throughput, metrics?.session_avg_generation),
-    prefillTps: firstPositive(metrics?.prompt_throughput, metrics?.session_avg_prefill),
+    genTps: generation.value,
+    genSample: generation.source === "peak" ? 0 : (generation.value ?? 0),
+    genSource: generation.source,
+    prefillTps: prefill.value,
+    prefillSample: prefill.source === "peak" ? 0 : (prefill.value ?? 0),
+    prefillSource: prefill.source,
     ttftMs: firstPositive(metrics?.avg_ttft_ms),
-    sessions: metrics?.running_requests ?? 0,
+    activeRequests: finiteCount(metrics?.running_requests),
+    queuedRequests: finiteCount(metrics?.pending_requests),
+    totalRequests: firstFiniteCount(metrics?.total_requests, metrics?.requests_total),
     peakReq: metrics?.session_peak_running_requests ?? 0,
     totalMemUsed: firstPositive(gpuTotals.memUsed, metrics?.vram_used_gb),
     vramCapacity: firstPositive(gpuTotals.memCapacity, metrics?.vram_capacity_gb),
     totalPower: firstPositive(gpuTotals.power, metrics?.current_power_watts),
     powerLimit: firstPositive(gpuTotals.powerLimit, metrics?.power_limit_watts),
   };
+}
+
+function resolveThroughput(
+  metrics: Metrics | null,
+  kind: Exclude<PeakKind, "ttft">,
+): { source: ThroughputSource; value: number | null } {
+  const current =
+    kind === "generation"
+      ? firstPositive(metrics?.generation_throughput, metrics?.session_avg_generation)
+      : firstPositive(metrics?.prompt_throughput, metrics?.session_avg_prefill);
+  const reportedStatus =
+    kind === "generation"
+      ? metrics?.generation_throughput_status
+      : metrics?.prompt_throughput_status;
+  if (current) {
+    const active =
+      finiteCount(metrics?.running_requests) + finiteCount(metrics?.pending_requests) > 0;
+    return {
+      source: reportedStatus === "live" || (reportedStatus !== "last" && active) ? "live" : "last",
+      value: current,
+    };
+  }
+  const peak = peakFor(metrics, kind);
+  return peak ? { source: "peak", value: peak } : { source: "unavailable", value: null };
 }
 
 function resolveGpuTotals(gpus: GPU[]) {
@@ -157,7 +192,7 @@ function metricColumnViews(
       label: "Decode",
       value: metricValue(perf.genTps, 1),
       unit: "tok/s",
-      ...peakDetailFor(metrics, "generation"),
+      ...throughputDetailFor(metrics, "generation", perf.genSource),
     },
     {
       label: "TTFT",
@@ -169,7 +204,7 @@ function metricColumnViews(
       label: "Prefill",
       value: metricValue(perf.prefillTps, 1),
       unit: "t/s",
-      ...peakDetailFor(metrics, "prefill"),
+      ...throughputDetailFor(metrics, "prefill", perf.prefillSource),
     },
   ];
 }
@@ -178,10 +213,33 @@ function compactMetricViews(
   perf: ReturnType<typeof resolvePerformanceMetrics>,
 ): CompactMetricView[] {
   return [
-    { label: "Requests", value: `${perf.sessions}/${perf.peakReq || perf.sessions}` },
+    {
+      label: "Requests",
+      value: perf.totalRequests === null ? null : perf.totalRequests.toLocaleString(),
+      detail: `${perf.activeRequests} active · ${perf.queuedRequests} queued`,
+      detailTitle:
+        perf.totalRequests === null
+          ? undefined
+          : `${perf.totalRequests.toLocaleString()} completed · ${perf.activeRequests} active · ${perf.queuedRequests} queued`,
+    },
     { label: "VRAM", value: ratioMetric(perf.totalMemUsed, perf.vramCapacity, "G", 1) },
     { label: "Power", value: ratioMetric(perf.totalPower, perf.powerLimit, "W") },
   ];
+}
+
+function throughputDetailFor(
+  metrics: Metrics | null,
+  kind: Exclude<PeakKind, "ttft">,
+  source: ThroughputSource,
+): { detail?: string; detailTitle?: string } {
+  const peak = peakDetailFor(metrics, kind);
+  if (source === "unavailable") return peak;
+  const sourceLabel =
+    source === "live" ? "live" : source === "last" ? "last measured" : "recorded peak";
+  return {
+    detail: source === "peak" || !peak.detail ? sourceLabel : `${sourceLabel} · ${peak.detail}`,
+    detailTitle: peak.detailTitle,
+  };
 }
 
 function readField(metrics: Metrics | null, field: keyof Metrics): number | null {
@@ -216,7 +274,7 @@ function peakDetailFor(metrics: Metrics | null, kind: PeakKind) {
 function metricValue(value: number | null, digits: number): string | null {
   return typeof value === "number" && Number.isFinite(value) && value > 0
     ? value.toFixed(digits)
-    : (0).toFixed(digits);
+    : null;
 }
 
 function ratioMetric(
@@ -277,6 +335,19 @@ function gpuMemoryTotal(gpu: GPU): number {
 function firstPositive(...values: Array<number | null | undefined>): number | null {
   for (const v of values) {
     if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+  }
+  return null;
+}
+
+function finiteCount(value: number | null | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? Math.round(value) : 0;
+}
+
+function firstFiniteCount(...values: Array<number | null | undefined>): number | null {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+      return Math.round(value);
+    }
   }
   return null;
 }

--- a/frontend/src/features/settings/controller-sync.test.ts
+++ b/frontend/src/features/settings/controller-sync.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { includeSavedController } from "@/lib/api/controllers";
+
+test("active controller is added to an empty saved list", () => {
+  assert.deepEqual(includeSavedController([], { url: "http://spark.local:8080/" }), [
+    { url: "http://spark.local:8080" },
+  ]);
+});
+
+test("active controller does not replace saved metadata", () => {
+  const saved = [
+    {
+      url: "http://spark.local:8080",
+      name: "Spark",
+      apiKey: "saved-key",
+    },
+  ];
+
+  assert.equal(
+    includeSavedController(saved, {
+      url: "http://spark.local:8080/",
+      apiKey: "different-key",
+    }),
+    saved,
+  );
+});

--- a/frontend/src/features/settings/use-settings.ts
+++ b/frontend/src/features/settings/use-settings.ts
@@ -13,7 +13,12 @@ import {
   setApiKey,
   setStoredBackendUrl,
 } from "@/lib/api/connection";
-import { normalizeControllerUrl } from "@/lib/api/controllers";
+import {
+  includeSavedController,
+  loadSavedControllers,
+  normalizeControllerUrl,
+  saveSavedControllers,
+} from "@/lib/api/controllers";
 import { readPageCache, writePageCache } from "@/lib/page-data-cache";
 import { scheduleDurableUiPreferencesSave } from "@/lib/desktop-ui-preferences";
 import type { CompatibilityReport, ConfigData } from "@/lib/types";
@@ -42,6 +47,17 @@ const mergeApiSettings = (server?: Partial<ApiConnectionSettings>): ApiConnectio
     hasApiKey: Boolean(localApiKey) || Boolean(server?.hasApiKey),
   };
 };
+
+function syncActiveController(settings: ApiConnectionSettings): void {
+  const saved = loadSavedControllers();
+  const next = includeSavedController(saved, {
+    url: settings.backendUrl,
+    apiKey: getApiKey() || undefined,
+  });
+  if (next === saved) return;
+  saveSavedControllers(next);
+  scheduleDurableUiPreferencesSave();
+}
 
 export function useSettings() {
   // Stale-while-revalidate: seed from the last-loaded config so navigating to
@@ -74,7 +90,9 @@ export function useSettings() {
       const res = await fetch("/api/settings");
       if (res.ok) {
         const settings = (await res.json()) as Partial<ApiConnectionSettings>;
-        setApiSettings(mergeApiSettings(settings));
+        const merged = mergeApiSettings(settings);
+        setApiSettings(merged);
+        syncActiveController(merged);
         return;
       }
     } catch (e) {

--- a/frontend/src/lib/api/controllers.ts
+++ b/frontend/src/lib/api/controllers.ts
@@ -89,6 +89,27 @@ export function saveSavedControllers(controllers: SavedController[]): SavedContr
   return next;
 }
 
+export function includeSavedController(
+  controllers: SavedController[],
+  controller: SavedController,
+): SavedController[] {
+  const url = normalizeControllerUrl(controller.url);
+  if (!url) return controllers;
+  if (controllers.some((entry) => normalizeControllerUrl(entry.url) === url)) {
+    return controllers;
+  }
+  const apiKey = controller.apiKey?.trim();
+  const name = controller.name?.trim();
+  return [
+    ...controllers,
+    {
+      url,
+      ...(apiKey ? { apiKey } : {}),
+      ...(name ? { name } : {}),
+    },
+  ];
+}
+
 export function getControllerApiKey(url: string): string {
   const normalized = normalizeControllerUrl(url);
   if (!normalized) return "";

--- a/services/agent-runtime/src/pi-runtime-models.ts
+++ b/services/agent-runtime/src/pi-runtime-models.ts
@@ -172,19 +172,24 @@ function normalizeControllerInput(input: PiControllerModelsRequest): PiControlle
   };
 }
 
-function mergeControllers(
+export function mergePiControllers(
   settings: ApiSettings,
   requested: PiControllerModelsRequest[] = [],
 ): PiControllerConfig[] {
   const requestedController = requested
     .map(normalizeControllerInput)
     .find((controller): controller is PiControllerConfig => controller !== null);
-  if (requestedController) return [requestedController];
   const primary = normalizeControllerInput({
     url: settings.backendUrl,
     apiKey: settings.apiKey,
     name: "primary",
   });
+  if (requestedController) {
+    if (!requestedController.apiKey && primary?.url === requestedController.url) {
+      return [{ ...requestedController, apiKey: primary.apiKey }];
+    }
+    return [requestedController];
+  }
   return primary ? [primary] : [];
 }
 
@@ -355,7 +360,7 @@ export async function refreshPiModels(
     requestedControllers && requestedControllers.length > 0
       ? requestedControllers
       : await loadPersistedControllers(agentDir);
-  const controllers = mergeControllers(settings, persisted);
+  const controllers = mergePiControllers(settings, persisted);
   await savePersistedControllers(agentDir, controllers);
   // A dead controller must not hide signed-in cloud providers: collect the
   // failure and only surface it when nothing else can serve models.

--- a/services/agent-runtime/test/pi-runtime-models.test.ts
+++ b/services/agent-runtime/test/pi-runtime-models.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ApiSettings } from "../src/settings-service";
+import { mergePiControllers } from "../src/pi-runtime-models";
+
+const settings: ApiSettings = {
+  backendUrl: "http://spark.local:8080/",
+  apiKey: "server-key",
+  voiceUrl: "",
+  voiceModel: "whisper-large-v3-turbo",
+};
+
+test("matching browser controller inherits the saved server API key", () => {
+  assert.deepEqual(
+    mergePiControllers(settings, [{ url: "http://spark.local:8080", name: "spark" }]),
+    [{ url: "http://spark.local:8080", apiKey: "server-key", name: "spark" }],
+  );
+});
+
+test("explicit browser API key remains authoritative", () => {
+  assert.deepEqual(
+    mergePiControllers(settings, [
+      { url: "http://spark.local:8080", apiKey: "browser-key", name: "spark" },
+    ]),
+    [{ url: "http://spark.local:8080", apiKey: "browser-key", name: "spark" }],
+  );
+});
+
+test("saved server API key is not copied to a different controller", () => {
+  assert.deepEqual(
+    mergePiControllers(settings, [{ url: "http://other.local:8080", name: "other" }]),
+    [{ url: "http://other.local:8080", apiKey: "", name: "other" }],
+  );
+});


### PR DESCRIPTION
## Summary

- reuse the saved controller API key when the active browser controller matches a configured server
- add explicit Workbench readiness states and recovery actions for connecting, authentication, offline, starting, stopped, and empty-model conditions
- preserve completed-request Decode and Prefill measurements from vLLM metrics and distinguish live, last-measured, peak, active, queued, and completed request data on Status

## Why

Controller-backed models could appear unavailable even when a matching saved controller already held the required key. The Workbench also collapsed several materially different startup and connectivity states into ambiguous empty UI. On Status, five-second sampling allowed short prefill activity and completed decode activity to be replaced by idle zeros, while Requests displayed active/session-peak concurrency instead of useful completed, active, and queued counts.

## User impact

The Workbench now explains what is blocking chat and offers the relevant recovery path. Status keeps meaningful throughput visible after generation ends, labels live versus historical values honestly, and exposes request activity in understandable terms.

## Validation

- `npm --prefix frontend run check:quality`
- `npm run check`
- `npm --prefix frontend run test` — 64 passing
- `npm run test:integration` — 60 passing
- controller performance tests — 3 passing
- Status view tests — 3 passing
- `npm run desktop:dist`
- production browser QA against the Spark controller with no console errors or blocked interactions
- installed `/Applications/Local Studio.app` QA: live Decode reached 67.9 tok/s, Requests showed 1 active / 0 queued, completed Requests advanced from 6 to 7, and `/api/desktop-health` returned HTTP 200

The local desktop package completed and ran successfully; code signing was skipped because the configured signing identity was unavailable on the build machine.
