### PR TITLE
ci: isolate desktop release signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,15 +10,14 @@ concurrency:
   group: release-main
   cancel-in-progress: false
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
-
 jobs:
-  release:
+  build:
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push'
     runs-on: macos-15
+    permissions:
+      contents: read
+    outputs:
+      release_version: ${{ steps.next-release.outputs.version }}
     env:
       RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
     steps:
@@ -57,43 +56,157 @@ jobs:
         working-directory: ./frontend
         run: npm ci --legacy-peer-deps
 
-      - name: Configure Apple notarization
+      - id: next-release
+        name: Determine release version
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -o pipefail
+          npx --yes \
+            --package semantic-release@24.2.7 \
+            --package @semantic-release/commit-analyzer@13.0.1 \
+            --package @semantic-release/release-notes-generator@14.1.0 \
+            --package @semantic-release/github@11.0.6 \
+            --package conventional-changelog-conventionalcommits@8.0.0 \
+            semantic-release --dry-run 2>&1 | tee semantic-release.log
+          version="$(sed -nE 's/.*The next release version is ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' semantic-release.log | tail -1)"
+          if [ -n "$version" ]; then
+            echo "version=$version" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build unsigned release app
+        if: steps.next-release.outputs.version != ''
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+        run: >-
+          npm --prefix frontend run desktop:pack --
+          --config.mac.identity=null
+          --config.mac.hardenedRuntime=false
+          --config.extraMetadata.version=${{ steps.next-release.outputs.version }}
+          --config.extraMetadata.localStudioCommit=${{ github.event.workflow_run.head_sha }}
+
+      - name: Archive unsigned release app
+        if: steps.next-release.outputs.version != ''
+        run: >-
+          ditto -c -k --keepParent
+          "frontend/dist-desktop/mac-arm64/Local Studio.app"
+          "local-studio-unsigned-${{ github.event.workflow_run.head_sha }}.zip"
+
+      - uses: actions/upload-artifact@v4
+        if: steps.next-release.outputs.version != ''
+        with:
+          name: local-studio-unsigned-${{ github.event.workflow_run.head_sha }}
+          path: local-studio-unsigned-${{ github.event.workflow_run.head_sha }}.zip
+          if-no-files-found: error
+          retention-days: 1
+
+  sign:
+    needs: build
+    if: needs.build.outputs.release_version != ''
+    runs-on: macos-15
+    permissions:
+      contents: read
+    env:
+      RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Select tested main revision
+        run: git checkout -B main "$RELEASE_SHA"
+
+      - name: Reject stale release revision
+        run: node scripts/assert-release-main.mjs --commit "$RELEASE_SHA"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.19.0
+
+      - name: Install signing dependencies
+        working-directory: ./frontend
+        run: npm ci --ignore-scripts --legacy-peer-deps
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: local-studio-unsigned-${{ github.event.workflow_run.head_sha }}
+          path: ${{ runner.temp }}/unsigned-release
+
+      - name: Extract unsigned release app
+        run: >-
+          ditto -x -k
+          "${{ runner.temp }}/unsigned-release/local-studio-unsigned-${{ github.event.workflow_run.head_sha }}.zip"
+          "${{ runner.temp }}/unsigned-release/app"
+
+      - name: Sign and notarize release assets
         env:
           APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           CSC_LINK: ${{ secrets.MACOS_CERTIFICATE_P12 }}
           CSC_KEY_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
-        run: |
-          for name in APPLE_API_KEY_BASE64 APPLE_API_KEY_ID APPLE_API_ISSUER CSC_LINK CSC_KEY_PASSWORD; do
-            if [ -z "$(eval "printf '%s' \"\$$name\"")" ]; then
-              echo "::error::Repo secret $name is missing — releases cannot sign or notarize without it. Run scripts/setup-release-secrets.sh once to upload all five." >&2
-              exit 1
-            fi
-          done
-          key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
-          printf '%s' "$APPLE_API_KEY_BASE64" | base64 --decode > "$key_path"
-          chmod 600 "$key_path"
-          echo "APPLE_API_KEY=$key_path" >> "$GITHUB_ENV"
+        run: >-
+          node scripts/sign-desktop-release.mjs
+          --version ${{ needs.build.outputs.release_version }}
+          --commit "$RELEASE_SHA"
+          --prepackaged "${{ runner.temp }}/unsigned-release/app/Local Studio.app"
+
+      - name: Stage signed release assets
+        run: >-
+          node scripts/stage-desktop-release.mjs
+          --version ${{ needs.build.outputs.release_version }}
+          --commit "$RELEASE_SHA"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: local-studio-release-assets-${{ github.event.workflow_run.head_sha }}
+          path: release-staging/*
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    needs: [build, sign]
+    if: needs.build.outputs.release_version != ''
+    runs-on: macos-15
+    permissions:
+      contents: write
+    env:
+      RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Select tested main revision
+        run: git checkout -B main "$RELEASE_SHA"
+
+      - name: Reject stale release revision
+        run: node scripts/assert-release-main.mjs --commit "$RELEASE_SHA"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.19.0
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: local-studio-release-assets-${{ github.event.workflow_run.head_sha }}
+          path: release-staging
 
       - name: Configure git author
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Release
+      - name: Publish release
         env:
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          CSC_LINK: ${{ secrets.MACOS_CERTIFICATE_P12 }}
-          CSC_KEY_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          npx -y \
-            -p semantic-release@24 \
-            -p @semantic-release/commit-analyzer \
-            -p @semantic-release/exec \
-            -p @semantic-release/release-notes-generator \
-            -p @semantic-release/github \
-            -p conventional-changelog-conventionalcommits@8 \
+          npx --yes \
+            --package semantic-release@24.2.7 \
+            --package @semantic-release/commit-analyzer@13.0.1 \
+            --package @semantic-release/release-notes-generator@14.1.0 \
+            --package @semantic-release/github@11.0.6 \
+            --package conventional-changelog-conventionalcommits@8.0.0 \
             semantic-release

--- a/README.md
+++ b/README.md
@@ -229,11 +229,14 @@ keeps the exact-SHA package as a GitHub Actions artifact. Conventional commits
 then trigger `release.yml`. Semantic Release chooses the next version (`feat` →
 minor, breaking → major, all other allowed commit types → patch).
 
-The release job runs on an arm64 macOS host, rebuilds the exact CI-tested
-revision, signs it with Developer ID, notarizes and staples it, rechecks that the
-revision is still `origin/main`, and only then creates the GitHub release with
-the DMG, updater files, stable website alias, checksums, and source manifest.
-There is no npm publish and tags are never created by hand.
+The release workflow builds the exact tested revision without Apple credentials,
+then passes only that unsigned app bundle to a separate signing job. The signing
+job installs the lockfile-pinned signing tooling without lifecycle scripts,
+signs, notarizes and staples the release assets, and hands them to a final
+publish job. Each stage rechecks that its revision is still `origin/main`; only
+the final stage can create the GitHub release with the DMG, updater files,
+stable website alias, checksums, and source manifest. There is no npm publish
+and tags are never created by hand.
 
 To reproduce the notarized release locally with the keychain profile:
 

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -68,6 +68,7 @@ const eslintConfig = defineConfig([
     "next-env.d.ts",
     "desktop/dist/**",
     "dist-desktop/**",
+    "dist-desktop-dev/**",
   ]),
 ]);
 

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -50,18 +50,11 @@ module.exports = {
       },
     ],
     [
-      "@semantic-release/exec",
-      {
-        prepareCmd:
-          "node scripts/build-desktop-release.mjs --version ${nextRelease.version} --commit \"$RELEASE_SHA\"",
-        publishCmd:
-          "node scripts/assert-release-main.mjs --commit \"$RELEASE_SHA\"",
-      },
-    ],
-    [
       "@semantic-release/github",
       {
         assets: [{ path: "release-staging/*" }],
+        successComment: false,
+        failComment: false,
       },
     ],
   ],

--- a/scripts/sign-desktop-release.mjs
+++ b/scripts/sign-desktop-release.mjs
@@ -1,0 +1,106 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const frontend = path.join(root, "frontend");
+
+function valueAfter(args, name) {
+  const index = args.indexOf(name);
+  return index === -1 ? undefined : args[index + 1];
+}
+
+function requireValue(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`Repo secret ${name} is missing`);
+  return value;
+}
+
+function run(command, args, options = {}) {
+  execFileSync(command, args, {
+    cwd: root,
+    env: process.env,
+    stdio: "inherit",
+    ...options,
+  });
+}
+
+export function signDesktopRelease(args = process.argv.slice(2)) {
+  const version = valueAfter(args, "--version")?.trim();
+  const commit = valueAfter(args, "--commit")?.trim().toLowerCase();
+  const prepackaged = valueAfter(args, "--prepackaged")?.trim();
+  if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
+    throw new Error("--version must be a semantic version");
+  }
+  if (!commit || !/^[0-9a-f]{40}$/.test(commit)) {
+    throw new Error("--commit must be a full Git commit SHA");
+  }
+  if (!prepackaged || !existsSync(prepackaged)) {
+    throw new Error("--prepackaged must point to an unsigned app bundle");
+  }
+
+  const apiKey = requireValue("APPLE_API_KEY_BASE64");
+  const apiKeyId = requireValue("APPLE_API_KEY_ID");
+  const apiIssuer = requireValue("APPLE_API_ISSUER");
+  requireValue("CSC_LINK");
+  requireValue("CSC_KEY_PASSWORD");
+
+  const temporary = path.join(os.tmpdir(), `local-studio-release-${process.pid}`);
+  const apiKeyPath = path.join(temporary, `AuthKey_${apiKeyId}.p8`);
+  const output = path.join(frontend, "dist-desktop");
+  const dmg = path.join(output, `Local Studio-${version}-arm64.dmg`);
+
+  try {
+    rmSync(temporary, { recursive: true, force: true });
+    mkdirSync(temporary, { recursive: true, mode: 0o700 });
+    writeFileSync(apiKeyPath, Buffer.from(apiKey, "base64"), { mode: 0o600, flag: "wx" });
+    process.env.APPLE_API_KEY = apiKeyPath;
+    process.env.APPLE_API_KEY_ID = apiKeyId;
+    process.env.APPLE_API_ISSUER = apiIssuer;
+    process.env.LOCAL_STUDIO_RELEASE_VERSION = version;
+    process.env.LOCAL_STUDIO_RELEASE_COMMIT = commit;
+
+    run(path.join(frontend, "node_modules", ".bin", "electron-builder"), [
+      "--prepackaged",
+      path.resolve(prepackaged),
+      "--config",
+      "desktop/electron-builder.yml",
+      "--config.mac.notarize=true",
+      `--config.extraMetadata.version=${version}`,
+      `--config.extraMetadata.localStudioCommit=${commit}`,
+    ], { cwd: frontend });
+    run("xcrun", [
+      "notarytool",
+      "submit",
+      dmg,
+      "--key",
+      apiKeyPath,
+      "--key-id",
+      apiKeyId,
+      "--issuer",
+      apiIssuer,
+      "--wait",
+      "--output-format",
+      "json",
+    ]);
+    run("xcrun", ["stapler", "staple", dmg]);
+    run("xcrun", ["stapler", "validate", dmg]);
+    run("codesign", ["--verify", "--verbose=4", dmg]);
+    run("spctl", [
+      "--assess",
+      "--type",
+      "open",
+      "--context",
+      "context:primary-signature",
+      "--verbose=4",
+      dmg,
+    ]);
+    console.log(`Signed and notarized Local Studio ${version} from ${commit}`);
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+signDesktopRelease();


### PR DESCRIPTION
## What\n- Split release automation into unsigned build, isolated signing/notarization, and publish jobs.\n- Pin semantic-release packages and narrow job permissions.\n- Keep generated dev desktop output out of source linting.\n\n## Testing\n- npm run check\n- signing secret preflight\n- release workflow YAML parse