### PR TITLE
feat: add usable Agentic Harness goal workflow

### DIFF
--- a/frontend/src/app/api/harness/[...path]/route.ts
+++ b/frontend/src/app/api/harness/[...path]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest } from "next/server";
+import { requireApiAccess } from "@/lib/auth/guard";
+import { proxyToHarness } from "@/app/api/harness/proxy-to-harness";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
+  const denied = requireApiAccess(request);
+  if (denied) return denied;
+  const { path } = await params;
+  return proxyToHarness(request, path);
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
+  const denied = requireApiAccess(request);
+  if (denied) return denied;
+  const { path } = await params;
+  return proxyToHarness(request, path);
+}

--- a/frontend/src/app/api/harness/managed/[...path]/route.ts
+++ b/frontend/src/app/api/harness/managed/[...path]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest } from "next/server";
+import { requireApiAccess } from "@/lib/auth/guard";
+import { proxyToManagedHarness } from "@/app/api/harness/proxy-to-harness";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
+  const denied = requireApiAccess(request);
+  if (denied) return denied;
+  const { path } = await params;
+  return proxyToManagedHarness(request, path);
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
+  const denied = requireApiAccess(request);
+  if (denied) return denied;
+  const { path } = await params;
+  return proxyToManagedHarness(request, path);
+}

--- a/frontend/src/app/api/harness/provider/[...path]/route.ts
+++ b/frontend/src/app/api/harness/provider/[...path]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest } from "next/server";
+import { requireApiAccess } from "@/lib/auth/guard";
+import { proxyToProviderHarness } from "@/app/api/harness/proxy-to-harness";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
+  const denied = requireApiAccess(request);
+  if (denied) return denied;
+  const { path } = await params;
+  return proxyToProviderHarness(request, path);
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
+  const denied = requireApiAccess(request);
+  if (denied) return denied;
+  const { path } = await params;
+  return proxyToProviderHarness(request, path);
+}

--- a/frontend/src/app/api/harness/proxy-to-harness.test.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.test.ts
@@ -1,12 +1,17 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
-import { harnessTargetUrl, upstreamRequestHeaders } from "./proxy-to-harness";
+import {
+  downstreamResponseHeaders,
+  harnessTargetUrl,
+  upstreamRequestHeaders,
+} from "./proxy-to-harness";
 
 describe("Local Studio Harness proxy headers", () => {
-  test("removes browser-origin metadata from the internal upstream request", () => {
+  test("forwards only protocol headers required by the Harness API", () => {
     const source = new Headers({
       accept: "application/json",
       authorization: "Bearer test-token",
+      cookie: "local_studio_token=cookie-token",
       "content-type": "application/json",
       origin: "http://127.0.0.1:4783",
       referer: "http://127.0.0.1:4783/harness",
@@ -14,23 +19,29 @@ describe("Local Studio Harness proxy headers", () => {
       "sec-fetch-mode": "cors",
       "sec-fetch-site": "same-origin",
       "sec-fetch-user": "?1",
+      "x-local-studio-csrf": "csrf-token",
+      "x-local-studio-token": "header-token",
       "x-request-id": "request-1",
     });
 
     const upstream = upstreamRequestHeaders(source);
 
     for (const name of [
+      "authorization",
+      "cookie",
       "origin",
+      "referer",
       "sec-fetch-dest",
       "sec-fetch-mode",
       "sec-fetch-site",
       "sec-fetch-user",
+      "x-local-studio-csrf",
+      "x-local-studio-token",
     ]) {
       assert.equal(upstream.get(name), null, `${name} must not cross the proxy boundary`);
     }
-    assert.equal(upstream.get("authorization"), "Bearer test-token");
+    assert.equal(upstream.get("accept"), "application/json");
     assert.equal(upstream.get("content-type"), "application/json");
-    assert.equal(upstream.get("referer"), "http://127.0.0.1:4783/harness");
     assert.equal(upstream.get("x-request-id"), "request-1");
     assert.equal(source.get("origin"), "http://127.0.0.1:4783");
   });
@@ -50,6 +61,25 @@ describe("Local Studio Harness proxy headers", () => {
       assert.equal(upstream.get(name), null, `${name} must not cross the proxy boundary`);
     }
     assert.equal(upstream.get("content-type"), "application/json");
+  });
+
+  test("does not let the Harness set Local Studio cookies", () => {
+    const downstream = downstreamResponseHeaders(
+      new Headers({
+        "content-type": "application/json",
+        "set-cookie": "local_studio_token=attacker-controlled",
+        "x-request-id": "request-2",
+      }),
+    );
+
+    assert.equal(downstream.get("set-cookie"), null);
+    assert.equal(downstream.get("content-type"), "application/json");
+    assert.equal(downstream.get("x-request-id"), "request-2");
+  });
+
+  test("rejects dot segments before URL normalization can escape the API namespace", () => {
+    assert.throws(() => harnessTargetUrl(["..", "admin"], "api"), /dot segments/);
+    assert.throws(() => harnessTargetUrl(["%2e%2e", "admin"], "api"), /dot segments/);
   });
 
   test("keeps managed goals on the explicit /api namespace", () => {

--- a/frontend/src/app/api/harness/proxy-to-harness.test.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { upstreamRequestHeaders } from "./proxy-to-harness";
+
+describe("Local Studio Harness proxy headers", () => {
+  test("removes browser-origin metadata from the internal upstream request", () => {
+    const source = new Headers({
+      accept: "application/json",
+      authorization: "Bearer test-token",
+      "content-type": "application/json",
+      origin: "http://127.0.0.1:4783",
+      referer: "http://127.0.0.1:4783/harness",
+      "sec-fetch-dest": "empty",
+      "sec-fetch-mode": "cors",
+      "sec-fetch-site": "same-origin",
+      "sec-fetch-user": "?1",
+      "x-request-id": "request-1",
+    });
+
+    const upstream = upstreamRequestHeaders(source);
+
+    for (const name of [
+      "origin",
+      "sec-fetch-dest",
+      "sec-fetch-mode",
+      "sec-fetch-site",
+      "sec-fetch-user",
+    ]) {
+      assert.equal(upstream.get(name), null, `${name} must not cross the proxy boundary`);
+    }
+    assert.equal(upstream.get("authorization"), "Bearer test-token");
+    assert.equal(upstream.get("content-type"), "application/json");
+    assert.equal(upstream.get("referer"), "http://127.0.0.1:4783/harness");
+    assert.equal(upstream.get("x-request-id"), "request-1");
+    assert.equal(source.get("origin"), "http://127.0.0.1:4783");
+  });
+});

--- a/frontend/src/app/api/harness/proxy-to-harness.test.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
-import { upstreamRequestHeaders } from "./proxy-to-harness";
+import { harnessTargetUrl, upstreamRequestHeaders } from "./proxy-to-harness";
 
 describe("Local Studio Harness proxy headers", () => {
   test("removes browser-origin metadata from the internal upstream request", () => {
@@ -33,5 +33,37 @@ describe("Local Studio Harness proxy headers", () => {
     assert.equal(upstream.get("referer"), "http://127.0.0.1:4783/harness");
     assert.equal(upstream.get("x-request-id"), "request-1");
     assert.equal(source.get("origin"), "http://127.0.0.1:4783");
+  });
+
+  test("still removes hop-by-hop transport headers", () => {
+    const source = new Headers({
+      host: "127.0.0.1:4783",
+      connection: "keep-alive",
+      "content-length": "42",
+      "accept-encoding": "gzip, br",
+      "content-type": "application/json",
+    });
+
+    const upstream = upstreamRequestHeaders(source);
+
+    for (const name of ["host", "connection", "content-length", "accept-encoding"]) {
+      assert.equal(upstream.get(name), null, `${name} must not cross the proxy boundary`);
+    }
+    assert.equal(upstream.get("content-type"), "application/json");
+  });
+
+  test("keeps managed goals on the explicit /api namespace", () => {
+    assert.equal(
+      harnessTargetUrl(["tasks", "current", "stop"], "api"),
+      "http://127.0.0.1:8771/api/tasks/current/stop",
+    );
+    assert.equal(
+      harnessTargetUrl(["tasks", "current"], "v1"),
+      "http://127.0.0.1:8771/v1/tasks/current",
+    );
+  });
+
+  test("keeps provider-neutral goals on their isolated upstream", () => {
+    assert.equal(harnessTargetUrl(["tasks"], "api", "provider"), "http://127.0.0.1:8772/api/tasks");
   });
 });

--- a/frontend/src/app/api/harness/proxy-to-harness.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.ts
@@ -1,11 +1,30 @@
 import { readRequestBytesWithinLimit } from "@shared/agent/agent-turn-body";
 
-const HOP_BY_HOP_REQUEST_HEADERS = ["host", "connection", "content-length", "accept-encoding"];
+const UPSTREAM_REQUEST_HEADERS_TO_REMOVE = [
+  "host",
+  "connection",
+  "content-length",
+  "accept-encoding",
+  // The Harness server validates browser-origin requests against its own
+  // listener. These headers describe the browser-to-Local-Studio hop and must
+  // not be replayed on the trusted Local-Studio-to-Harness hop.
+  "origin",
+  "sec-fetch-dest",
+  "sec-fetch-mode",
+  "sec-fetch-site",
+  "sec-fetch-user",
+];
 const DEFAULT_HARNESS_URL = "http://127.0.0.1:8771";
 
 export function harnessBaseUrl(): string {
   const raw = process.env.LOCAL_STUDIO_HARNESS_URL?.trim();
   return (raw || DEFAULT_HARNESS_URL).replace(/\/+$/, "");
+}
+
+export function upstreamRequestHeaders(requestHeaders: Headers): Headers {
+  const headers = new Headers(requestHeaders);
+  for (const name of UPSTREAM_REQUEST_HEADERS_TO_REMOVE) headers.delete(name);
+  return headers;
 }
 
 export async function proxyToHarness(
@@ -16,8 +35,7 @@ export async function proxyToHarness(
   const targetPath = path.map((part) => encodeURIComponent(part)).join("/");
   const sourceUrl = new URL(request.url);
   const target = `${harnessBaseUrl()}/v1/${targetPath}${sourceUrl.search}`;
-  const headers = new Headers(request.headers);
-  for (const name of HOP_BY_HOP_REQUEST_HEADERS) headers.delete(name);
+  const headers = upstreamRequestHeaders(request.headers);
 
   let body: ArrayBuffer | undefined;
   if (request.method !== "GET" && request.method !== "HEAD") {

--- a/frontend/src/app/api/harness/proxy-to-harness.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.ts
@@ -1,0 +1,59 @@
+import { readRequestBytesWithinLimit } from "@shared/agent/agent-turn-body";
+
+const HOP_BY_HOP_REQUEST_HEADERS = ["host", "connection", "content-length", "accept-encoding"];
+const DEFAULT_HARNESS_URL = "http://127.0.0.1:8771";
+
+export function harnessBaseUrl(): string {
+  const raw = process.env.LOCAL_STUDIO_HARNESS_URL?.trim();
+  return (raw || DEFAULT_HARNESS_URL).replace(/\/+$/, "");
+}
+
+export async function proxyToHarness(
+  request: Request,
+  path: string[],
+  bodyLimitBytes = 256 * 1024,
+): Promise<Response> {
+  const targetPath = path.map((part) => encodeURIComponent(part)).join("/");
+  const sourceUrl = new URL(request.url);
+  const target = `${harnessBaseUrl()}/v1/${targetPath}${sourceUrl.search}`;
+  const headers = new Headers(request.headers);
+  for (const name of HOP_BY_HOP_REQUEST_HEADERS) headers.delete(name);
+
+  let body: ArrayBuffer | undefined;
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    const bounded = await readRequestBytesWithinLimit(request, bodyLimitBytes);
+    if (!bounded.ok) return Response.json({ error: bounded.error }, { status: bounded.status });
+    body = new ArrayBuffer(bounded.value.byteLength);
+    new Uint8Array(body).set(bounded.value);
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(target, {
+      method: request.method,
+      headers,
+      body,
+      signal: request.signal,
+      cache: "no-store",
+    });
+  } catch (error) {
+    if (request.signal.aborted) throw error;
+    return Response.json(
+      {
+        error: `agentic harness unreachable at ${harnessBaseUrl()}: ${
+          error instanceof Error ? error.message : "fetch failed"
+        }`,
+      },
+      { status: 502 },
+    );
+  }
+
+  const responseHeaders = new Headers(upstream.headers);
+  responseHeaders.delete("content-length");
+  responseHeaders.delete("content-encoding");
+  responseHeaders.delete("transfer-encoding");
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: responseHeaders,
+  });
+}

--- a/frontend/src/app/api/harness/proxy-to-harness.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.ts
@@ -8,6 +8,12 @@ const UPSTREAM_REQUEST_HEADERS_TO_REMOVE = [
   // The Harness server validates browser-origin requests against its own
   // listener. These headers describe the browser-to-Local-Studio hop and must
   // not be replayed on the trusted Local-Studio-to-Harness hop.
+  // Stripping them here is safe because the browser hop is already enforced
+  // before this route runs: src/proxy.ts applies evaluateRequestBoundary
+  // (host allowlist, cross-site rejection, Origin match, CSRF double-submit;
+  // see src/lib/security/request-boundary.ts and its tests) and the route
+  // handler re-checks the access token via requireApiAccess. Do not add a
+  // second origin gate here, and do not stop stripping these headers.
   "origin",
   "sec-fetch-dest",
   "sec-fetch-mode",
@@ -15,10 +21,18 @@ const UPSTREAM_REQUEST_HEADERS_TO_REMOVE = [
   "sec-fetch-user",
 ];
 const DEFAULT_HARNESS_URL = "http://127.0.0.1:8771";
+const DEFAULT_PROVIDER_HARNESS_URL = "http://127.0.0.1:8772";
 
-export function harnessBaseUrl(): string {
-  const raw = process.env.LOCAL_STUDIO_HARNESS_URL?.trim();
-  return (raw || DEFAULT_HARNESS_URL).replace(/\/+$/, "");
+export type HarnessTarget = "managed" | "provider";
+
+export function harnessBaseUrl(target: HarnessTarget = "managed"): string {
+  const raw = (
+    target === "provider"
+      ? process.env.LOCAL_STUDIO_PROVIDER_HARNESS_URL
+      : process.env.LOCAL_STUDIO_HARNESS_URL
+  )?.trim();
+  const fallback = target === "provider" ? DEFAULT_PROVIDER_HARNESS_URL : DEFAULT_HARNESS_URL;
+  return (raw || fallback).replace(/\/+$/, "");
 }
 
 export function upstreamRequestHeaders(requestHeaders: Headers): Headers {
@@ -27,14 +41,24 @@ export function upstreamRequestHeaders(requestHeaders: Headers): Headers {
   return headers;
 }
 
-export async function proxyToHarness(
+export function harnessTargetUrl(
+  path: string[],
+  namespace: "v1" | "api" = "v1",
+  target: HarnessTarget = "managed",
+): string {
+  const targetPath = path.map((part) => encodeURIComponent(part)).join("/");
+  return `${harnessBaseUrl(target)}/${namespace}/${targetPath}`;
+}
+
+async function proxyToHarnessNamespace(
   request: Request,
   path: string[],
+  namespace: "v1" | "api",
+  target: HarnessTarget,
   bodyLimitBytes = 256 * 1024,
 ): Promise<Response> {
-  const targetPath = path.map((part) => encodeURIComponent(part)).join("/");
   const sourceUrl = new URL(request.url);
-  const target = `${harnessBaseUrl()}/v1/${targetPath}${sourceUrl.search}`;
+  const upstreamTarget = `${harnessTargetUrl(path, namespace, target)}${sourceUrl.search}`;
   const headers = upstreamRequestHeaders(request.headers);
 
   let body: ArrayBuffer | undefined;
@@ -47,7 +71,7 @@ export async function proxyToHarness(
 
   let upstream: Response;
   try {
-    upstream = await fetch(target, {
+    upstream = await fetch(upstreamTarget, {
       method: request.method,
       headers,
       body,
@@ -58,7 +82,7 @@ export async function proxyToHarness(
     if (request.signal.aborted) throw error;
     return Response.json(
       {
-        error: `agentic harness unreachable at ${harnessBaseUrl()}: ${
+        error: `agentic harness unreachable at ${harnessBaseUrl(target)}: ${
           error instanceof Error ? error.message : "fetch failed"
         }`,
       },
@@ -74,4 +98,33 @@ export async function proxyToHarness(
     status: upstream.status,
     headers: responseHeaders,
   });
+}
+
+export function proxyToHarness(
+  request: Request,
+  path: string[],
+  bodyLimitBytes = 256 * 1024,
+): Promise<Response> {
+  return proxyToHarnessNamespace(request, path, "v1", "managed", bodyLimitBytes);
+}
+
+/**
+ * Proxy the managed local-goal API separately from the read-only integration
+ * API. Keeping the namespace explicit prevents a UI caller from accidentally
+ * turning a v1 canary endpoint into a privileged durable-goal action.
+ */
+export function proxyToManagedHarness(
+  request: Request,
+  path: string[],
+  bodyLimitBytes = 256 * 1024,
+): Promise<Response> {
+  return proxyToHarnessNamespace(request, path, "api", "managed", bodyLimitBytes);
+}
+
+export function proxyToProviderHarness(
+  request: Request,
+  path: string[],
+  bodyLimitBytes = 256 * 1024,
+): Promise<Response> {
+  return proxyToHarnessNamespace(request, path, "api", "provider", bodyLimitBytes);
 }

--- a/frontend/src/app/api/harness/proxy-to-harness.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.ts
@@ -1,24 +1,20 @@
 import { readRequestBytesWithinLimit } from "@shared/agent/agent-turn-body";
 
-const UPSTREAM_REQUEST_HEADERS_TO_REMOVE = [
-  "host",
-  "connection",
-  "content-length",
-  "accept-encoding",
-  // The Harness server validates browser-origin requests against its own
-  // listener. These headers describe the browser-to-Local-Studio hop and must
-  // not be replayed on the trusted Local-Studio-to-Harness hop.
-  // Stripping them here is safe because the browser hop is already enforced
-  // before this route runs: src/proxy.ts applies evaluateRequestBoundary
-  // (host allowlist, cross-site rejection, Origin match, CSRF double-submit;
-  // see src/lib/security/request-boundary.ts and its tests) and the route
-  // handler re-checks the access token via requireApiAccess. Do not add a
-  // second origin gate here, and do not stop stripping these headers.
-  "origin",
-  "sec-fetch-dest",
-  "sec-fetch-mode",
-  "sec-fetch-site",
-  "sec-fetch-user",
+const UPSTREAM_REQUEST_HEADER_ALLOWLIST = [
+  "accept",
+  "content-type",
+  "if-match",
+  "if-none-match",
+  "last-event-id",
+  "x-request-id",
+];
+const DOWNSTREAM_RESPONSE_HEADER_ALLOWLIST = [
+  "cache-control",
+  "content-type",
+  "etag",
+  "last-modified",
+  "retry-after",
+  "x-request-id",
 ];
 const DEFAULT_HARNESS_URL = "http://127.0.0.1:8771";
 const DEFAULT_PROVIDER_HARNESS_URL = "http://127.0.0.1:8772";
@@ -36,9 +32,34 @@ export function harnessBaseUrl(target: HarnessTarget = "managed"): string {
 }
 
 export function upstreamRequestHeaders(requestHeaders: Headers): Headers {
-  const headers = new Headers(requestHeaders);
-  for (const name of UPSTREAM_REQUEST_HEADERS_TO_REMOVE) headers.delete(name);
+  const headers = new Headers();
+  for (const name of UPSTREAM_REQUEST_HEADER_ALLOWLIST) {
+    const value = requestHeaders.get(name);
+    if (value !== null) headers.set(name, value);
+  }
   return headers;
+}
+
+export function downstreamResponseHeaders(upstreamHeaders: Headers): Headers {
+  const headers = new Headers();
+  for (const name of DOWNSTREAM_RESPONSE_HEADER_ALLOWLIST) {
+    const value = upstreamHeaders.get(name);
+    if (value !== null) headers.set(name, value);
+  }
+  return headers;
+}
+
+function harnessPathSegment(part: string): string {
+  let decoded = part;
+  try {
+    decoded = decodeURIComponent(part);
+  } catch {
+    throw new TypeError("Harness path contains invalid encoding");
+  }
+  if (decoded === "." || decoded === "..") {
+    throw new TypeError("Harness path cannot contain dot segments");
+  }
+  return encodeURIComponent(part);
 }
 
 export function harnessTargetUrl(
@@ -46,7 +67,7 @@ export function harnessTargetUrl(
   namespace: "v1" | "api" = "v1",
   target: HarnessTarget = "managed",
 ): string {
-  const targetPath = path.map((part) => encodeURIComponent(part)).join("/");
+  const targetPath = path.map(harnessPathSegment).join("/");
   return `${harnessBaseUrl(target)}/${namespace}/${targetPath}`;
 }
 
@@ -58,7 +79,15 @@ async function proxyToHarnessNamespace(
   bodyLimitBytes = 256 * 1024,
 ): Promise<Response> {
   const sourceUrl = new URL(request.url);
-  const upstreamTarget = `${harnessTargetUrl(path, namespace, target)}${sourceUrl.search}`;
+  let upstreamTarget: string;
+  try {
+    upstreamTarget = `${harnessTargetUrl(path, namespace, target)}${sourceUrl.search}`;
+  } catch (error) {
+    return Response.json(
+      { error: error instanceof Error ? error.message : "Harness path is invalid" },
+      { status: 400 },
+    );
+  }
   const headers = upstreamRequestHeaders(request.headers);
 
   let body: ArrayBuffer | undefined;
@@ -90,13 +119,9 @@ async function proxyToHarnessNamespace(
     );
   }
 
-  const responseHeaders = new Headers(upstream.headers);
-  responseHeaders.delete("content-length");
-  responseHeaders.delete("content-encoding");
-  responseHeaders.delete("transfer-encoding");
   return new Response(upstream.body, {
     status: upstream.status,
-    headers: responseHeaders,
+    headers: downstreamResponseHeaders(upstream.headers),
   });
 }
 

--- a/frontend/src/app/harness/page.tsx
+++ b/frontend/src/app/harness/page.tsx
@@ -1,0 +1,5 @@
+import HarnessPage from "@/features/harness/harness-page";
+
+export default function Page() {
+  return <HarnessPage />;
+}

--- a/frontend/src/features/harness/harness-page-model.test.ts
+++ b/frontend/src/features/harness/harness-page-model.test.ts
@@ -75,7 +75,13 @@ describe("resolveTaskEnvelope", () => {
 
 describe("isTerminalTaskStatus", () => {
   test("matches the Harness durable terminal set exactly", () => {
-    assert.deepEqual([...TERMINAL_TASK_STATUSES].sort(), ["blocked", "done", "failed", "stopped"]);
+    assert.deepEqual([...TERMINAL_TASK_STATUSES].sort(), [
+      "blocked",
+      "complete",
+      "done",
+      "failed",
+      "stopped",
+    ]);
     for (const status of TERMINAL_TASK_STATUSES) {
       assert.equal(isTerminalTaskStatus(status), true);
     }

--- a/frontend/src/features/harness/harness-page-model.test.ts
+++ b/frontend/src/features/harness/harness-page-model.test.ts
@@ -1,0 +1,319 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  TERMINAL_TASK_STATUSES,
+  describeGoalOutcome,
+  goalStartBlocker,
+  isTerminalTaskStatus,
+  resolveTaskEnvelope,
+  stripGoalCommandPrefix,
+  startTaskPolling,
+} from "./harness-page-model";
+
+const runningTask = { id: "task-1", status: "working" };
+
+describe("resolveTaskEnvelope", () => {
+  test("prefers the explicit task envelope over everything else", () => {
+    const resolved = resolveTaskEnvelope({
+      task: runningTask,
+      current: { id: "task-2", status: "done" },
+      id: "envelope-id",
+      status: "working",
+    });
+    assert.equal(resolved?.id, "task-1");
+    assert.equal(resolved?.status, "working");
+  });
+
+  test("an envelope carrying both a top-level id and current resolves to current", () => {
+    // Regression: `{ id: "req-1", current: {...} }` used to be misread as the
+    // task itself because the old discriminator only checked `payload.id`.
+    const resolved = resolveTaskEnvelope({
+      id: "req-1",
+      current: runningTask,
+    });
+    assert.equal(resolved?.id, "task-1");
+    assert.equal(resolved?.status, "working");
+  });
+
+  test("current still wins even when the envelope itself is task-shaped", () => {
+    const resolved = resolveTaskEnvelope({
+      id: "req-1",
+      status: "working",
+      current: runningTask,
+    });
+    assert.equal(resolved?.id, "task-1");
+  });
+
+  test("an invalid explicit envelope value falls through instead of masking the task", () => {
+    assert.equal(resolveTaskEnvelope({ task: {}, current: runningTask })?.id, "task-1");
+    assert.equal(
+      resolveTaskEnvelope({ task: { id: "half-formed" }, current: runningTask })?.id,
+      "task-1",
+    );
+    // The idle shape: tasks/current answers { current: null, tasks: [...] }.
+    assert.equal(resolveTaskEnvelope({ current: null }), null);
+  });
+
+  test("returns null when every candidate is malformed", () => {
+    assert.equal(resolveTaskEnvelope({ task: {}, current: { id: "", status: "" } }), null);
+    assert.equal(resolveTaskEnvelope({ task: null, current: null, id: "req-9" }), null);
+  });
+
+  test("accepts a bare payload only when it has a valid task shape", () => {
+    assert.equal(resolveTaskEnvelope(runningTask)?.id, "task-1");
+    // id without status is not a task.
+    assert.equal(resolveTaskEnvelope({ id: "req-1" }), null);
+    // status without id is not a task.
+    assert.equal(resolveTaskEnvelope({ status: "working" }), null);
+    // Empty ids/statuses do not count.
+    assert.equal(resolveTaskEnvelope({ id: "", status: "" }), null);
+    // The events envelope ({ task_id, events }) has neither key.
+    assert.equal(resolveTaskEnvelope({ events: [] }), null);
+    assert.equal(resolveTaskEnvelope({}), null);
+  });
+});
+
+describe("isTerminalTaskStatus", () => {
+  test("matches the Harness durable terminal set exactly", () => {
+    assert.deepEqual([...TERMINAL_TASK_STATUSES].sort(), ["blocked", "done", "failed", "stopped"]);
+    for (const status of TERMINAL_TASK_STATUSES) {
+      assert.equal(isTerminalTaskStatus(status), true);
+    }
+  });
+
+  test("active, unknown, and missing statuses keep polling", () => {
+    for (const status of ["working", "checking", "starting", "queued", "", undefined]) {
+      assert.equal(isTerminalTaskStatus(status), false, `${String(status)} must not be terminal`);
+    }
+  });
+});
+
+describe("goal prompt and outcome helpers", () => {
+  test("accepts ordinary prose and strips only a standalone /goal prefix", () => {
+    assert.equal(
+      stripGoalCommandPrefix("  Review the provider flow  "),
+      "Review the provider flow",
+    );
+    assert.equal(stripGoalCommandPrefix("/goal  Fix the prompt flow"), "Fix the prompt flow");
+    assert.equal(stripGoalCommandPrefix("/goalkeeper review"), "/goalkeeper review");
+    assert.equal(stripGoalCommandPrefix(" /goal "), "");
+  });
+
+  test("explains why a goal cannot start instead of leaving a dead button", () => {
+    assert.match(
+      goalStartBlocker({
+        goal: "",
+        backend: "managed",
+        providerConfigured: true,
+        setupLoading: false,
+      }) ?? "",
+      /Type a goal first/,
+    );
+    assert.match(
+      goalStartBlocker({
+        goal: "Review the provider",
+        backend: "provider",
+        providerConfigured: false,
+        setupLoading: false,
+      }) ?? "",
+      /endpoint and model/,
+    );
+    assert.equal(
+      goalStartBlocker({
+        goal: "Review the provider",
+        backend: "managed",
+        providerConfigured: true,
+        setupLoading: false,
+      }),
+      null,
+    );
+  });
+
+  test("an active shared-workspace goal explains why a new goal cannot start", () => {
+    const blocker = goalStartBlocker({
+      goal: "Review the provider",
+      backend: "managed",
+      providerConfigured: true,
+      setupLoading: false,
+      activeTaskStatus: "working",
+    });
+    assert.match(String(blocker), /another goal is already running/i);
+    assert.match(String(blocker), /shared workspace/i);
+  });
+
+  test("a terminal current task does not block a new goal", () => {
+    assert.equal(
+      goalStartBlocker({
+        goal: "Review the provider",
+        backend: "managed",
+        providerConfigured: true,
+        setupLoading: false,
+        activeTaskStatus: "done",
+      }),
+      null,
+    );
+  });
+
+  test("does not call a done task verified when it has no recorded checks", () => {
+    const outcome = describeGoalOutcome({ id: "task-1", status: "done" });
+    assert.equal(outcome?.state, "unverified");
+    assert.match(outcome?.headline ?? "", /without verification/);
+  });
+
+  test("treats a provider failure as terminal and actionable", () => {
+    const outcome = describeGoalOutcome({
+      id: "task-2",
+      status: "failed",
+      summary: "Provider stopped with evidence.",
+    });
+    assert.equal(outcome?.state, "blocked");
+    assert.match(outcome?.headline ?? "", /failed/i);
+    assert.match(outcome?.detail ?? "", /Provider stopped/);
+  });
+});
+
+type Deferred = {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+};
+
+function deferred(): Deferred {
+  let resolve!: () => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function manualTimers() {
+  const pending: Array<{ id: number; fn: () => void }> = [];
+  let nextId = 1;
+  return {
+    schedule(fn: () => void, _ms: number): number {
+      const id = nextId++;
+      pending.push({ id, fn });
+      return id;
+    },
+    clearSchedule(id: number): void {
+      const index = pending.findIndex((timer) => timer.id === id);
+      if (index >= 0) pending.splice(index, 1);
+    },
+    fire(): void {
+      const next = pending.shift();
+      assert.ok(next, "expected a pending timer to fire");
+      next.fn();
+    },
+    get count(): number {
+      return pending.length;
+    },
+  };
+}
+
+const settle = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+describe("startTaskPolling", () => {
+  test("serializes polls and re-arms only after the load settles", async () => {
+    const timers = manualTimers();
+    const gate = deferred();
+    const seen: AbortSignal[] = [];
+    const stop = startTaskPolling({
+      intervalMs: 3000,
+      load: (signal) => {
+        seen.push(signal);
+        return gate.promise;
+      },
+      onError: () => assert.fail("no error expected"),
+      schedule: timers.schedule,
+      clearSchedule: timers.clearSchedule,
+    });
+
+    assert.equal(timers.count, 1, "arms an initial timer");
+    timers.fire();
+    assert.equal(seen.length, 1);
+    assert.equal(timers.count, 0, "must not re-arm while a load is in flight");
+
+    gate.resolve();
+    await settle();
+    assert.equal(timers.count, 1, "re-arms after the load settles");
+
+    stop();
+    assert.equal(timers.count, 0, "stop clears the pending timer");
+  });
+
+  test("reports transient errors and keeps polling", async () => {
+    const timers = manualTimers();
+    const errors: unknown[] = [];
+    let attempts = 0;
+    const stop = startTaskPolling({
+      intervalMs: 3000,
+      load: () => {
+        attempts += 1;
+        return Promise.reject(new Error(`boom ${attempts}`));
+      },
+      onError: (error) => errors.push(error),
+      schedule: timers.schedule,
+      clearSchedule: timers.clearSchedule,
+    });
+
+    timers.fire();
+    await settle();
+    assert.equal(errors.length, 1);
+    assert.equal(timers.count, 1, "keeps polling after an error");
+
+    timers.fire();
+    await settle();
+    assert.equal(errors.length, 2);
+
+    stop();
+    assert.equal(timers.count, 0);
+  });
+
+  test("stop aborts the in-flight load and suppresses its error", async () => {
+    const timers = manualTimers();
+    const gate = deferred();
+    const seen: AbortSignal[] = [];
+    const errors: unknown[] = [];
+    const stop = startTaskPolling({
+      intervalMs: 3000,
+      load: (signal) => {
+        seen.push(signal);
+        return gate.promise;
+      },
+      onError: (error) => errors.push(error),
+      schedule: timers.schedule,
+      clearSchedule: timers.clearSchedule,
+    });
+
+    timers.fire();
+    assert.equal(seen[0]?.aborted, false);
+
+    stop();
+    assert.equal(seen[0]?.aborted, true, "stop must abort the in-flight signal");
+
+    gate.reject(new DOMException("The operation was aborted.", "AbortError"));
+    await settle();
+    assert.deepEqual(errors, [], "aborted loads must not surface as errors");
+    assert.equal(timers.count, 0, "no re-arm after stop");
+  });
+
+  test("a load that resolves after stop cannot re-arm the poller", async () => {
+    const timers = manualTimers();
+    const gate = deferred();
+    const stop = startTaskPolling({
+      intervalMs: 3000,
+      load: () => gate.promise,
+      onError: () => assert.fail("no error expected"),
+      schedule: timers.schedule,
+      clearSchedule: timers.clearSchedule,
+    });
+
+    timers.fire();
+    stop();
+    gate.resolve();
+    await settle();
+    assert.equal(timers.count, 0, "stale completion must not restart polling");
+  });
+});

--- a/frontend/src/features/harness/harness-page-model.ts
+++ b/frontend/src/features/harness/harness-page-model.ts
@@ -1,0 +1,289 @@
+// Pure model logic for the Harness operator surface. Kept framework-free so the
+// envelope discrimination, terminal-status contract, and polling lifecycle can
+// be unit tested without React.
+
+export type HarnessTask = {
+  id?: string;
+  status?: string;
+  status_label?: string;
+  summary?: string;
+  human_title?: string;
+  artifacts?: Array<{ name?: string; path?: string }>;
+  events?: Array<{ seq?: number; summary?: string; checkpoint?: string }>;
+  metadata?: {
+    demo?: { enabled?: boolean; model_used?: boolean; workspace?: string };
+    integration?: {
+      kind?: string;
+      route_id?: string;
+      model_id?: string;
+      node?: string;
+      runtime?: string;
+      model_used?: boolean;
+      connected_workspace_mutated?: boolean;
+    };
+  };
+};
+
+// The Harness GUI server answers with three envelope shapes:
+//   tasks/current      -> { current, tasks }
+//   tasks/{id}         -> { api_version, task, owner }
+//   tasks/{id}/events  -> { api_version, task_id, events }
+// Older builds returned the bare task object. TaskResponse tolerates all of
+// them; resolveTaskEnvelope decides which one we are looking at.
+export type TaskResponse = Partial<HarnessTask> & {
+  task?: HarnessTask | null;
+  current?: HarnessTask | null;
+  events?: HarnessTask["events"];
+};
+
+export type ManagedGoalTask = HarnessTask & {
+  objective?: string;
+  mode?: string;
+  execution_profile?: string;
+  needs_human?: boolean;
+  review_status?: string;
+  changed_files?: string[];
+  verification?: string[];
+  progress?: { label?: string; percent?: number; determinate?: boolean };
+  current?: { checkpoint?: string; current_subgoal?: string; cycle?: number };
+  readiness_gate?: {
+    can_start?: boolean;
+    can_queue?: boolean;
+    state?: string;
+    label?: string;
+    next_action?: string;
+    summary?: string;
+    requires_review?: boolean;
+  };
+  advanced_details?: {
+    payload?: { events?: HarnessTask["events"] };
+    last_run?: { run_dir?: string; prompt_path?: string };
+  };
+};
+
+export type ManagedTaskResponse = Partial<ManagedGoalTask> & {
+  task?: ManagedGoalTask | null;
+  current?: ManagedGoalTask | null;
+  events?: ManagedGoalTask["events"];
+};
+
+function isTaskShaped(
+  candidate: Partial<HarnessTask>,
+): candidate is Partial<HarnessTask> & { id: string; status: string } {
+  return (
+    typeof candidate.id === "string" &&
+    candidate.id.length > 0 &&
+    typeof candidate.status === "string" &&
+    candidate.status.length > 0
+  );
+}
+
+/** Explicit `task` / `current` envelopes win, in that order, but only when the
+ *  value actually looks like a task (non-empty id AND status). Every valid
+ *  Harness response serializes both fields, so this rejects only malformed
+ *  values — `current: null` while idle, `task: {}` from a broken upstream —
+ *  and lets them fall through to the next candidate instead of masking it.
+ *  The top-level payload is checked last so an envelope that happens to carry
+ *  a top-level id (e.g. a request id next to `current`) can never shadow the
+ *  real task. */
+export function resolveTaskEnvelope(payload: TaskResponse): HarnessTask | null {
+  for (const candidate of [payload.task, payload.current, payload]) {
+    if (candidate && isTaskShaped(candidate)) return candidate;
+  }
+  return null;
+}
+
+// Task statuses come from the managed and provider Harness adapters:
+// done | stopped | blocked | failed | checking | starting | working. The
+// durable terminal set includes provider failures because a failed worker run
+// is complete evidence and must not block a fresh goal.
+// Unknown/future statuses are treated as active so we keep polling — the safe
+// default for states we have never seen.
+export const TERMINAL_TASK_STATUSES: ReadonlySet<string> = new Set([
+  "done",
+  "stopped",
+  "blocked",
+  "failed",
+]);
+
+export function isTerminalTaskStatus(status: string | undefined): boolean {
+  return status !== undefined && TERMINAL_TASK_STATUSES.has(status);
+}
+
+export type GoalBackendKind = "managed" | "provider";
+
+/** The prompt box accepts an ordinary sentence; `/goal` is an optional
+ *  Codex-style prefix. Stripping it here keeps the submit path and its tests
+ *  in agreement about what counts as an empty objective. */
+export function stripGoalCommandPrefix(raw: string): string {
+  return raw
+    .trim()
+    .replace(/^\/goal(?:\s+|$)/i, "")
+    .trim();
+}
+
+export type GoalStartInput = {
+  goal: string;
+  backend: GoalBackendKind;
+  /** `setup.configured` for the currently selected backend. Callers must pass
+   *  `false` while the setup payload is unknown so the gate fails closed. */
+  providerConfigured: boolean;
+  setupLoading: boolean;
+  /** Current task status for the selected shared workspace, when known. */
+  activeTaskStatus?: string;
+};
+
+/** Why a goal cannot start yet, phrased for a first-time user, or null when it
+ *  can. Returning a reason (instead of only disabling the button) is what makes
+ *  the empty-prompt and unconfigured-provider cases explainable rather than a
+ *  dead control. Provider copy stays generic: no host, path, or node names. */
+export function goalStartBlocker(input: GoalStartInput): string | null {
+  if (input.setupLoading) return "Loading goal setup…";
+  const objective = stripGoalCommandPrefix(input.goal);
+  if (!objective) {
+    return input.goal.trim()
+      ? "Add an objective after /goal, for example: /goal summarise the open issues."
+      : "Type a goal first. You can start it with /goal.";
+  }
+  if (input.backend === "provider" && !input.providerConfigured) {
+    return "Add an endpoint and model under Model provider, then save, before starting a goal.";
+  }
+  if (
+    input.activeTaskStatus &&
+    !isTerminalTaskStatus(input.activeTaskStatus) &&
+    input.activeTaskStatus !== "needs_review" &&
+    input.activeTaskStatus !== "ready"
+  ) {
+    return "Another goal is already running in this shared workspace. Continue or stop it before starting a new one.";
+  }
+  return null;
+}
+
+export type GoalOutcomeTone = "default" | "good" | "warning" | "danger";
+
+export type GoalOutcome = {
+  state: "running" | "needs_review" | "stopped" | "blocked" | "complete" | "unverified";
+  tone: GoalOutcomeTone;
+  headline: string;
+  detail: string;
+};
+
+/** Plain-language terminal state for the goal card.
+ *
+ *  Completion honesty: "verified" is only claimed when the Harness actually
+ *  recorded verification checks on the task. A `done` task with no checks is
+ *  reported as finished-but-unverified, never as verified, so UI prose can
+ *  never outrun the evidence contract. Check counts are described as
+ *  "recorded" because the task payload carries the checks, not their verdicts. */
+export function describeGoalOutcome(task: ManagedGoalTask | null): GoalOutcome | null {
+  if (!task?.id) return null;
+  const status = task.status ?? "";
+  const summary = task.summary?.trim();
+  const checks = task.verification?.length ?? 0;
+  const files = task.changed_files?.length ?? 0;
+
+  if (status === "done" || status === "complete") {
+    if (checks === 0) {
+      return {
+        state: "unverified",
+        tone: "warning",
+        headline: "Finished without verification evidence",
+        detail:
+          summary ??
+          "The harness recorded no verification checks for this goal, so it is not a verified completion.",
+      };
+    }
+    return {
+      state: "complete",
+      tone: "good",
+      headline: "Goal complete with recorded evidence",
+      detail: `${checks} verification check${checks === 1 ? "" : "s"} recorded · ${files} changed file${
+        files === 1 ? "" : "s"
+      }.`,
+    };
+  }
+  if (status === "stopped") {
+    return {
+      state: "stopped",
+      tone: "warning",
+      headline: "Goal stopped",
+      detail: summary ?? "This goal was stopped before it finished. Start a new goal to continue.",
+    };
+  }
+  if (status === "blocked") {
+    return {
+      state: "blocked",
+      tone: "danger",
+      headline: "Goal blocked",
+      detail:
+        summary ?? "The harness could not continue. Add feedback below and continue the goal.",
+    };
+  }
+  if (status === "failed") {
+    return {
+      state: "blocked",
+      tone: "danger",
+      headline: "Goal failed",
+      detail:
+        summary ?? "The provider could not complete this goal. Start a new goal to try again.",
+    };
+  }
+  if (status === "needs_review") {
+    return {
+      state: "needs_review",
+      tone: "warning",
+      headline: "Waiting for your review",
+      detail: summary ?? "The harness finished a cycle and needs your decision before continuing.",
+    };
+  }
+  return {
+    state: "running",
+    tone: "default",
+    headline: task.progress?.label ?? task.current?.checkpoint ?? "Working",
+    detail: summary ?? "The harness is working on this goal.",
+  };
+}
+
+export type TaskPollerOptions = {
+  intervalMs: number;
+  /** Load one refresh. Receives the poller's AbortSignal; implementations must
+   *  pass it to fetch and stop touching state once it is aborted. */
+  load: (signal: AbortSignal) => Promise<void>;
+  /** Called for load failures, except aborts caused by stopping the poller. */
+  onError: (error: unknown) => void;
+  /** Injectable timers for tests. Default to window timers in the browser. */
+  schedule?: (fn: () => void, ms: number) => number;
+  clearSchedule?: (id: number) => void;
+};
+
+/** Serialized task polling: each cycle waits for the previous load to settle
+ *  before arming the next timer, so requests never overlap; a failed load
+ *  reports the error and keeps polling. The returned stop function clears any
+ *  pending timer, aborts an in-flight load, and guarantees no re-arm and no
+ *  error report afterwards. */
+export function startTaskPolling(options: TaskPollerOptions): () => void {
+  const schedule = options.schedule ?? ((fn, ms) => window.setTimeout(fn, ms));
+  const clearSchedule = options.clearSchedule ?? ((id) => window.clearTimeout(id));
+  const controller = new AbortController();
+  let timer: number | undefined;
+  let stopped = false;
+
+  const tick = async (): Promise<void> => {
+    try {
+      await options.load(controller.signal);
+    } catch (error) {
+      if (!stopped && !controller.signal.aborted) options.onError(error);
+    }
+    if (!stopped) arm();
+  };
+  const arm = (): void => {
+    timer = schedule(() => void tick(), options.intervalMs);
+  };
+  arm();
+
+  return () => {
+    stopped = true;
+    controller.abort();
+    if (timer !== undefined) clearSchedule(timer);
+  };
+}

--- a/frontend/src/features/harness/harness-page-model.ts
+++ b/frontend/src/features/harness/harness-page-model.ts
@@ -100,6 +100,7 @@ export function resolveTaskEnvelope(payload: TaskResponse): HarnessTask | null {
 // Unknown/future statuses are treated as active so we keep polling — the safe
 // default for states we have never seen.
 export const TERMINAL_TASK_STATUSES: ReadonlySet<string> = new Set([
+  "complete",
   "done",
   "stopped",
   "blocked",

--- a/frontend/src/features/harness/harness-page.tsx
+++ b/frontend/src/features/harness/harness-page.tsx
@@ -26,7 +26,18 @@ type HarnessTask = {
   human_title?: string;
   artifacts?: Array<{ name?: string; path?: string }>;
   events?: Array<{ seq?: number; summary?: string; checkpoint?: string }>;
-  metadata?: { demo?: { enabled?: boolean; model_used?: boolean; workspace?: string } };
+  metadata?: {
+    demo?: { enabled?: boolean; model_used?: boolean; workspace?: string };
+    integration?: {
+      kind?: string;
+      route_id?: string;
+      model_id?: string;
+      node?: string;
+      runtime?: string;
+      model_used?: boolean;
+      connected_workspace_mutated?: boolean;
+    };
+  };
 };
 
 type RoutesResponse = { routes?: HarnessRoute[]; selection?: { policy?: string } };
@@ -51,9 +62,12 @@ function formatContext(tokens: number): string {
   return `${tokens} context`;
 }
 
+// The page coordinates route, task, event, and evidence state in one operator surface.
+// eslint-disable-next-line complexity
 export default function HarnessPage() {
   const [routes, setRoutes] = useState<HarnessRoute[]>([]);
   const [selectionPolicy, setSelectionPolicy] = useState("harness_decides");
+  const [selectedRoute, setSelectedRoute] = useState("auto");
   const [task, setTask] = useState<HarnessTask | null>(null);
   const [events, setEvents] = useState<HarnessTask["events"]>([]);
   const [loading, setLoading] = useState(true);
@@ -125,6 +139,31 @@ export default function HarnessPage() {
       setEvents(nextTask?.events ?? []);
     } catch (nextError) {
       setError(nextError instanceof Error ? nextError.message : "Canary could not start");
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const runAnalysis = async () => {
+    setRunning(true);
+    setError("");
+    try {
+      const payload = await readJson<TaskResponse & { task?: HarnessTask }>("/api/harness/tasks", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          kind: "read_only_analysis",
+          ...(selectedRoute === "auto" ? {} : { route_id: selectedRoute }),
+          objective:
+            "Use the selected cluster vLLM route to confirm the Harness execution boundary. " +
+            "Report the selected model and explain that this analysis is read-only; do not change files.",
+        }),
+      });
+      const nextTask = payload.task ?? null;
+      setTask(nextTask);
+      setEvents(nextTask?.events ?? []);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : "Model analysis could not start");
     } finally {
       setRunning(false);
     }
@@ -227,8 +266,39 @@ export default function HarnessPage() {
                 value="Operator UI and model/chat surface"
               />
               <div className="rounded-xl bg-(--ui-fg)/5 p-3 text-[length:var(--fs-xs)] leading-relaxed text-(--ui-muted)">
-                The canary is intentionally credential-free and isolated. It proves the client path
-                without sending work to vLLM or changing your connected project.
+                The safe canary is credential-free. Model analysis uses the selected vLLM route in a
+                temporary isolated workspace with write tools disabled.
+              </div>
+              <div className="rounded-xl border border-(--ui-border) p-3">
+                <label
+                  htmlFor="harness-route"
+                  className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)"
+                >
+                  Model route
+                </label>
+                <select
+                  id="harness-route"
+                  value={selectedRoute}
+                  onChange={(event) => setSelectedRoute(event.target.value)}
+                  className="mt-2 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
+                >
+                  <option value="auto">Auto: Node1 primary, Node2 overflow</option>
+                  {routes.map((route) => (
+                    <option key={route.id} value={route.id} disabled={route.status !== "ready"}>
+                      {route.node} · {route.model_id} ({route.status})
+                    </option>
+                  ))}
+                </select>
+                <Button
+                  className="mt-3 w-full"
+                  variant="secondary"
+                  size="sm"
+                  icon={<Play className="h-3.5 w-3.5" />}
+                  loading={running}
+                  onClick={() => void runAnalysis()}
+                >
+                  Run vLLM analysis
+                </Button>
               </div>
             </div>
           </Card>
@@ -253,6 +323,21 @@ export default function HarnessPage() {
                 <p className="mt-3 text-[length:var(--fs-sm)] text-(--ui-fg)">
                   {task.summary ?? task.human_title}
                 </p>
+                {task.metadata?.integration ? (
+                  <div className="mt-3 flex flex-wrap gap-2 text-[length:var(--fs-xs)] text-(--ui-muted)">
+                    <span>
+                      {task.metadata.integration.node} · {task.metadata.integration.model_id}
+                    </span>
+                    <span>{task.metadata.integration.runtime}</span>
+                    <span>read-only</span>
+                    <span>
+                      workspace{" "}
+                      {task.metadata.integration.connected_workspace_mutated
+                        ? "changed"
+                        : "unchanged"}
+                    </span>
+                  </div>
+                ) : null}
                 <div className="mt-4 space-y-2">
                   {(events ?? []).slice(-6).map((event, index) => (
                     <div

--- a/frontend/src/features/harness/harness-page.tsx
+++ b/frontend/src/features/harness/harness-page.tsx
@@ -51,8 +51,10 @@ type ManagedModesResponse = {
   execution_profiles?: ManagedProfile[];
 };
 type ManagedSetupResponse = {
+  allowed_api_key_envs?: string[];
   suggested_check?: string;
   verification_command?: string;
+  verification_contract?: { shell?: boolean; summary?: string };
   workspace?: string;
   worker?: { label?: string; type?: string };
   configured?: boolean;
@@ -307,6 +309,10 @@ export default function HarnessPage() {
   };
 
   const runManagedAction = async (action: "stop" | "continue" | "accept") => {
+    if (!managedTask?.id) {
+      setGoalError("The current goal changed. Refresh before trying that action again.");
+      return;
+    }
     setGoalBusy(true);
     setGoalError("");
     try {
@@ -315,7 +321,10 @@ export default function HarnessPage() {
         {
           method: "POST",
           headers: { "content-type": "application/json" },
-          body: JSON.stringify(action === "continue" ? { feedback: goalFeedback.trim() } : {}),
+          body: JSON.stringify({
+            task_id: managedTask.id,
+            ...(action === "continue" ? { feedback: goalFeedback.trim() } : {}),
+          }),
         },
       );
       const nextTask = managedTaskFromResponse(payload);
@@ -380,7 +389,15 @@ export default function HarnessPage() {
     label: "Managed goal loop",
     best_for: "Runs through the configured managed worker and keeps durable task state.",
   };
-  const providerModeOptions = managedModes.length ? managedModes : [];
+  const providerModeOptions = managedModes.length
+    ? managedModes
+    : [
+        {
+          key: goalMode || "quick",
+          label: "Standard goal loop",
+          best_for: "Plan, act, verify, and keep working until the goal reaches a terminal result.",
+        },
+      ];
   const selectedMode =
     goalBackend === "provider"
       ? (providerModeOptions.find((mode) => mode.key === goalMode) ?? providerModeOptions[0])
@@ -407,7 +424,7 @@ export default function HarnessPage() {
           objective: "Verify the Local Studio to Agentic Harness task boundary",
         }),
       });
-      const nextTask = payload.task ?? null;
+      const nextTask = resolveTaskEnvelope(payload);
       setTask(nextTask);
       setEvents(nextTask?.events ?? []);
     } catch (nextError) {
@@ -432,7 +449,7 @@ export default function HarnessPage() {
             "Report the selected model and explain that this analysis is read-only; do not change files.",
         }),
       });
-      const nextTask = payload.task ?? null;
+      const nextTask = resolveTaskEnvelope(payload);
       setTask(nextTask);
       setEvents(nextTask?.events ?? []);
     } catch (nextError) {
@@ -446,34 +463,21 @@ export default function HarnessPage() {
     <AppPage>
       <PageContainer width="lg" className="pt-6 sm:pt-8">
         <PageHeader
-          eyebrow="Agentic Harness"
-          title="Cluster execution"
-          description="Local Studio is the operator surface. Harness owns task state, routing, events, and evidence."
+          eyebrow="Goals"
+          title="What should your agent accomplish?"
+          description="Describe the result in plain language. The harness will keep working, verify the outcome, and ask only when it needs your decision."
           actions={
-            <div className="flex items-center gap-2">
-              <Button
-                variant="icon"
-                size="md"
-                aria-label="Refresh Harness"
-                title="Refresh"
-                onClick={() => void refresh()}
-              >
-                <RefreshCw className="h-4 w-4" />
-              </Button>
-              <Button
-                variant="primary"
-                size="sm"
-                icon={<Play className="h-3.5 w-3.5" />}
-                loading={running}
-                onClick={() => void runCanary()}
-              >
-                Run safe canary
-              </Button>
-            </div>
+            <Button
+              variant="icon"
+              size="md"
+              aria-label="Refresh goals"
+              title="Refresh"
+              onClick={() => void refresh()}
+            >
+              <RefreshCw className="h-4 w-4" />
+            </Button>
           }
         />
-
-        {error ? <ErrorBox className="mb-5">{error}</ErrorBox> : null}
 
         <Card
           className="mb-4"
@@ -673,15 +677,23 @@ export default function HarnessPage() {
                       />
                     </label>
                     <label className="text-[length:var(--fs-xs)] text-(--ui-muted)">
-                      API key environment variable
-                      <input
+                      Saved credential
+                      <select
                         value={providerApiKeyEnv}
                         onChange={(event) => setProviderApiKeyEnv(event.target.value)}
-                        placeholder="OPENAI_API_KEY (optional)"
-                        autoComplete="off"
                         className="mt-1 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
                         disabled={providerBusy || goalBusy}
-                      />
+                      >
+                        <option value="">No saved credential</option>
+                        {(managedSetup?.allowed_api_key_envs ?? []).map((name) => (
+                          <option key={name} value={name}>
+                            {name}
+                          </option>
+                        ))}
+                      </select>
+                      <span className="mt-1 block leading-relaxed">
+                        Only credential names approved by this installation are available.
+                      </span>
                     </label>
                     <label className="text-[length:var(--fs-xs)] text-(--ui-muted)">
                       Session API key
@@ -706,9 +718,10 @@ export default function HarnessPage() {
                       disabled={providerBusy || goalBusy}
                     />
                     <span className="mt-1 block leading-relaxed">
-                      {providerVerificationCommand.trim()
-                        ? "This is the check saved with this provider setup and used to verify provider goals."
-                        : "Saving requires a check. If this workspace already has one, it will appear here after setup loads."}
+                      {managedSetup?.verification_contract?.summary ??
+                        (providerVerificationCommand.trim()
+                          ? "This check is saved with the provider setup and verifies each goal."
+                          : "Saving requires a check. If this workspace already has one, it will appear here after setup loads.")}
                     </span>
                   </label>
                   <label className="mt-3 flex items-start gap-2 text-[length:var(--fs-xs)] text-(--ui-muted)">
@@ -967,7 +980,28 @@ export default function HarnessPage() {
           ) : null}
         </Card>
 
-        <div className="grid gap-4 lg:grid-cols-[minmax(0,1.45fr)_minmax(18rem,0.8fr)]">
+        <details className="rounded-xl border border-(--ui-border) p-4">
+          <summary className="cursor-pointer text-[length:var(--fs-sm)] font-medium text-(--ui-fg)">
+            Advanced diagnostics
+          </summary>
+          <p className="mt-2 text-[length:var(--fs-xs)] text-(--ui-muted)">
+            Inspect routes, run a credential-free boundary check, or test a read-only model route.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              icon={<Play className="h-3.5 w-3.5" />}
+              loading={running}
+              disabled={running}
+              onClick={() => void runCanary()}
+            >
+              Run safe canary
+            </Button>
+          </div>
+          {error ? <ErrorBox className="mt-3">{error}</ErrorBox> : null}
+
+          <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1.45fr)_minmax(18rem,0.8fr)]">
           <Card
             title="Live route registry"
             description={`Harness-owned live probes · selection policy: ${selectionPolicy}`}
@@ -1068,13 +1102,13 @@ export default function HarnessPage() {
               </div>
             </div>
           </Card>
-        </div>
+          </div>
 
-        <Card
-          className="mt-4"
-          title="Harness task"
-          description="The safe canary uses the real Harness lifecycle and returns task evidence through the integration API."
-        >
+          <Card
+            className="mt-4"
+            title="Diagnostic task"
+            description="Canary and read-only model checks return task evidence through the integration API."
+          >
           {!task?.id ? (
             <p className="text-[length:var(--fs-sm)] text-(--ui-muted)">No task loaded.</p>
           ) : (
@@ -1136,7 +1170,8 @@ export default function HarnessPage() {
               </div>
             </div>
           )}
-        </Card>
+          </Card>
+        </details>
       </PageContainer>
     </AppPage>
   );

--- a/frontend/src/features/harness/harness-page.tsx
+++ b/frontend/src/features/harness/harness-page.tsx
@@ -295,6 +295,7 @@ export default function HarnessPage() {
                   size="sm"
                   icon={<Play className="h-3.5 w-3.5" />}
                   loading={running}
+                  disabled={running}
                   onClick={() => void runAnalysis()}
                 >
                   Run vLLM analysis

--- a/frontend/src/features/harness/harness-page.tsx
+++ b/frontend/src/features/harness/harness-page.tsx
@@ -3,6 +3,18 @@
 import { useCallback, useState, type ReactNode } from "react";
 import { AppPage, Button, Card, ErrorBox, PageContainer, PageHeader, StatusPill } from "@/ui";
 import { useMountSubscription } from "@/hooks/use-mount-subscription";
+import {
+  describeGoalOutcome,
+  goalStartBlocker,
+  isTerminalTaskStatus,
+  resolveTaskEnvelope,
+  startTaskPolling,
+  stripGoalCommandPrefix,
+  type HarnessTask,
+  type ManagedGoalTask,
+  type ManagedTaskResponse,
+  type TaskResponse,
+} from "./harness-page-model";
 import { GitBranch, Play, RefreshCw, ShieldCheck } from "@/ui/icon-registry";
 
 type HarnessRoute = {
@@ -18,35 +30,40 @@ type HarnessRoute = {
   eligible_for: string[];
 };
 
-type HarnessTask = {
-  id?: string;
-  status?: string;
-  status_label?: string;
+type RoutesResponse = { routes?: HarnessRoute[]; selection?: { policy?: string } };
+type ManagedMode = {
+  key: string;
+  label: string;
+  best_for?: string;
+  caution?: string;
+};
+type ManagedProfile = {
+  key: string;
+  label: string;
   summary?: string;
-  human_title?: string;
-  artifacts?: Array<{ name?: string; path?: string }>;
-  events?: Array<{ seq?: number; summary?: string; checkpoint?: string }>;
-  metadata?: {
-    demo?: { enabled?: boolean; model_used?: boolean; workspace?: string };
-    integration?: {
-      kind?: string;
-      route_id?: string;
-      model_id?: string;
-      node?: string;
-      runtime?: string;
-      model_used?: boolean;
-      connected_workspace_mutated?: boolean;
-    };
+  caution?: string;
+};
+type ManagedModesResponse = {
+  kind?: string;
+  default?: string;
+  default_execution_profile?: string;
+  modes?: ManagedMode[];
+  execution_profiles?: ManagedProfile[];
+};
+type ManagedSetupResponse = {
+  suggested_check?: string;
+  verification_command?: string;
+  workspace?: string;
+  worker?: { label?: string; type?: string };
+  configured?: boolean;
+  provider?: {
+    endpoint?: string;
+    model?: string;
+    api_key_env?: string;
+    data_location?: string;
   };
 };
-
-type RoutesResponse = { routes?: HarnessRoute[]; selection?: { policy?: string } };
-type TaskResponse = Partial<HarnessTask> & {
-  task?: HarnessTask;
-  current?: HarnessTask;
-  events?: HarnessTask["events"];
-};
-
+type GoalBackend = "managed" | "provider";
 async function readJson<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, { ...init, cache: "no-store" });
   const payload = (await response.json().catch(() => ({}))) as { error?: string } & T;
@@ -56,14 +73,29 @@ async function readJson<T>(url: string, init?: RequestInit): Promise<T> {
 
 function toneForStatus(status: string): "default" | "good" | "warning" | "danger" {
   if (status === "ready" || status === "done" || status === "complete") return "good";
-  if (status === "unavailable" || status === "blocked") return "danger";
-  if (status === "degraded" || status === "needs_review") return "warning";
+  if (status === "unavailable" || status === "blocked" || status === "failed") return "danger";
+  // "stopped" is a real interruption, not a neutral resting state: showing it in
+  // the default tone made a halted goal look the same as a running one.
+  if (status === "degraded" || status === "needs_review" || status === "stopped") return "warning";
   return "default";
 }
 
 function formatContext(tokens: number): string {
   if (tokens >= 1000) return `${Math.round(tokens / 1000)}k context`;
   return `${tokens} context`;
+}
+
+function isManagedGoalTerminal(task: ManagedGoalTask | null): boolean {
+  return (
+    !task?.id ||
+    isTerminalTaskStatus(task.status) ||
+    task.status === "needs_review" ||
+    task.status === "ready"
+  );
+}
+
+function managedTaskFromResponse(payload: ManagedTaskResponse): ManagedGoalTask | null {
+  return resolveTaskEnvelope(payload as TaskResponse) as ManagedGoalTask | null;
 }
 
 // The page coordinates route, task, event, and evidence state in one operator surface.
@@ -77,6 +109,27 @@ export default function HarnessPage() {
   const [loading, setLoading] = useState(true);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState("");
+  const [goal, setGoal] = useState("");
+  const [goalBackend, setGoalBackend] = useState<GoalBackend>("managed");
+  const [goalMode, setGoalMode] = useState("local");
+  const [goalProfile, setGoalProfile] = useState("qwen-primary");
+  const [goalFeedback, setGoalFeedback] = useState("");
+  const [managedTask, setManagedTask] = useState<ManagedGoalTask | null>(null);
+  const [managedEvents, setManagedEvents] = useState<NonNullable<HarnessTask["events"]>>([]);
+  const [managedModes, setManagedModes] = useState<ManagedMode[]>([]);
+  const [managedProfiles, setManagedProfiles] = useState<ManagedProfile[]>([]);
+  const [managedSetup, setManagedSetup] = useState<ManagedSetupResponse | null>(null);
+  const [goalLoading, setGoalLoading] = useState(true);
+  const [goalBusy, setGoalBusy] = useState(false);
+  const [goalError, setGoalError] = useState("");
+  const [providerEndpoint, setProviderEndpoint] = useState("");
+  const [providerModel, setProviderModel] = useState("");
+  const [providerApiKeyEnv, setProviderApiKeyEnv] = useState("");
+  const [providerApiKey, setProviderApiKey] = useState("");
+  const [providerVerificationCommand, setProviderVerificationCommand] = useState("");
+  const [providerRemoteConfirmed, setProviderRemoteConfirmed] = useState(false);
+  const [providerBusy, setProviderBusy] = useState(false);
+  const [providerMessage, setProviderMessage] = useState("");
 
   const loadRoutes = useCallback(async () => {
     const payload = await readJson<RoutesResponse>("/api/harness/routes");
@@ -84,22 +137,87 @@ export default function HarnessPage() {
     setSelectionPolicy(payload.selection?.policy ?? "harness_decides");
   }, []);
 
-  const loadTask = useCallback(async (taskId?: string) => {
+  const loadTask = useCallback(async (taskId?: string, signal?: AbortSignal) => {
     const target = taskId
       ? `/api/harness/tasks/${encodeURIComponent(taskId)}`
       : "/api/harness/tasks/current";
-    const payload = await readJson<TaskResponse>(target);
-    const nextTask = payload.task ?? (payload.id ? payload : (payload.current ?? null));
+    const payload = await readJson<TaskResponse>(target, { signal });
+    if (signal?.aborted) return;
+    const nextTask = resolveTaskEnvelope(payload);
     setTask(nextTask);
     if (nextTask?.id) {
       const eventPayload = await readJson<TaskResponse>(
         `/api/harness/tasks/${encodeURIComponent(nextTask.id)}/events?after=0`,
+        { signal },
       );
+      if (signal?.aborted) return;
       setEvents(eventPayload.events ?? nextTask.events ?? []);
     } else {
       setEvents([]);
     }
   }, []);
+
+  /** Task + events only. This is the poll payload: `modes` and `setup` do not
+   *  change while a goal runs, so re-fetching them every interval was three
+   *  extra round trips per tick for state that never moved. */
+  const loadManagedTask = useCallback(
+    async (signal?: AbortSignal, backend: GoalBackend = goalBackend) => {
+      const prefix = backend === "provider" ? "/api/harness/provider" : "/api/harness/managed";
+      const taskPayload = await readJson<ManagedTaskResponse>(`${prefix}/tasks/current`, {
+        signal,
+      });
+      if (signal?.aborted) return;
+      const nextTask = managedTaskFromResponse(taskPayload);
+      setManagedTask(nextTask);
+      if (nextTask?.id) {
+        const eventPayload = await readJson<ManagedTaskResponse>(`${prefix}/tasks/current/events`, {
+          signal,
+        });
+        if (signal?.aborted) return;
+        setManagedEvents(eventPayload.events ?? nextTask.events ?? []);
+      } else {
+        setManagedEvents(nextTask?.events ?? []);
+      }
+    },
+    [goalBackend],
+  );
+
+  /** Full load: setup/modes plus the current task. Used on mount and whenever
+   *  the selected goal engine changes, not on the polling interval. */
+  const loadManaged = useCallback(
+    async (signal?: AbortSignal, backend: GoalBackend = goalBackend) => {
+      const prefix = backend === "provider" ? "/api/harness/provider" : "/api/harness/managed";
+      const [modesPayload, setupPayload] = await Promise.all([
+        readJson<ManagedModesResponse>(`${prefix}/modes`, { signal }),
+        readJson<ManagedSetupResponse>(`${prefix}/setup`, { signal }),
+        // Task and events stay in the same parallel batch, so first paint is no
+        // slower than before the poll payload was split out.
+        loadManagedTask(signal, backend),
+      ]);
+      if (signal?.aborted) return;
+      setManagedModes(modesPayload.modes ?? []);
+      setManagedProfiles(modesPayload.execution_profiles ?? []);
+      setManagedSetup(setupPayload);
+      const availableModes = modesPayload.modes ?? [];
+      const fallbackMode = backend === "provider" ? (modesPayload.default ?? "plan") : "local";
+      setGoalMode((current) =>
+        availableModes.some((mode) => mode.key === current) ? current : fallbackMode,
+      );
+      if (backend === "provider") {
+        // Switching into the provider lane must reflect that lane's saved
+        // setup, not stale values left in the form by a previous selection.
+        // verification_command is the effective persisted check; the
+        // detected suggestion is only the first-run fallback.
+        setProviderEndpoint(setupPayload.provider?.endpoint || "");
+        setProviderModel(setupPayload.provider?.model || "");
+        setProviderApiKeyEnv(setupPayload.provider?.api_key_env || "");
+        setProviderVerificationCommand(
+          setupPayload.verification_command || setupPayload.suggested_check || "",
+        );
+      }
+    },
+    [goalBackend, loadManagedTask],
+  );
 
   const refresh = useCallback(async () => {
     setError("");
@@ -117,25 +235,165 @@ export default function HarnessPage() {
   }, [refresh]);
 
   useMountSubscription(() => {
-    if (!task?.id || ["done", "stopped", "blocked"].includes(task.status ?? "")) return;
-    let stopped = false;
-    let timer: number | undefined;
-    const poll = () => {
-      timer = window.setTimeout(async () => {
-        try {
-          await loadTask(task.id!);
-        } catch (nextError) {
-          setError(nextError instanceof Error ? nextError.message : "Task refresh failed");
-        }
-        if (!stopped) poll();
-      }, 3000);
-    };
-    poll();
-    return () => {
-      stopped = true;
-      if (timer !== undefined) window.clearTimeout(timer);
-    };
+    void loadManaged()
+      .catch((nextError) =>
+        setGoalError(nextError instanceof Error ? nextError.message : "Managed goal unavailable"),
+      )
+      .finally(() => setGoalLoading(false));
+  }, [loadManaged]);
+
+  useMountSubscription(() => {
+    if (!task?.id || isTerminalTaskStatus(task.status)) return;
+    const taskId = task.id;
+    return startTaskPolling({
+      intervalMs: 3000,
+      load: (signal) => loadTask(taskId, signal),
+      onError: (nextError) =>
+        setError(nextError instanceof Error ? nextError.message : "Task refresh failed"),
+    });
   }, [loadTask, task?.id, task?.status]);
+
+  useMountSubscription(() => {
+    if (isManagedGoalTerminal(managedTask)) return;
+    return startTaskPolling({
+      intervalMs: 3000,
+      load: (signal) => loadManagedTask(signal),
+      onError: (nextError) =>
+        setGoalError(nextError instanceof Error ? nextError.message : "Goal refresh failed"),
+    });
+  }, [loadManagedTask, managedTask?.id, managedTask?.status]);
+
+  const goalApiPrefix =
+    goalBackend === "provider" ? "/api/harness/provider" : "/api/harness/managed";
+
+  const startGoal = async () => {
+    // Validate on submit rather than only disabling the button, so a new user is
+    // told why nothing happened instead of facing an inert control.
+    const blocker = goalStartBlocker({
+      goal,
+      backend: goalBackend,
+      providerConfigured: managedSetup?.configured === true,
+      setupLoading: goalLoading,
+      activeTaskStatus: managedTask?.status,
+    });
+    if (blocker) {
+      setGoalError(blocker);
+      return;
+    }
+    const objective = stripGoalCommandPrefix(goal);
+    setGoalBusy(true);
+    setGoalError("");
+    try {
+      const payload = await readJson<ManagedTaskResponse>(`${goalApiPrefix}/tasks`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(
+          goalBackend === "provider"
+            ? { objective, strategy: goalMode }
+            : { objective, mode: goalMode, execution_profile: goalProfile },
+        ),
+      });
+      const nextTask = managedTaskFromResponse(payload);
+      setManagedTask(nextTask);
+      setManagedEvents(nextTask?.events ?? []);
+      if (nextTask?.status === "blocked" || nextTask?.status === "needs_review") {
+        setGoalError(nextTask.summary ?? "The goal needs attention before it can continue.");
+      }
+    } catch (nextError) {
+      setGoalError(nextError instanceof Error ? nextError.message : "Goal could not start");
+    } finally {
+      setGoalBusy(false);
+    }
+  };
+
+  const runManagedAction = async (action: "stop" | "continue" | "accept") => {
+    setGoalBusy(true);
+    setGoalError("");
+    try {
+      const payload = await readJson<ManagedTaskResponse>(
+        `${goalApiPrefix}/tasks/current/${action}`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(action === "continue" ? { feedback: goalFeedback.trim() } : {}),
+        },
+      );
+      const nextTask = managedTaskFromResponse(payload);
+      setManagedTask(nextTask);
+      setManagedEvents(nextTask?.events ?? []);
+      if (action === "continue") setGoalFeedback("");
+    } catch (nextError) {
+      setGoalError(nextError instanceof Error ? nextError.message : `Goal ${action} failed`);
+    } finally {
+      setGoalBusy(false);
+    }
+  };
+
+  const configureProvider = async (testOnly: boolean) => {
+    if (!providerEndpoint.trim() || !providerModel.trim()) {
+      setProviderMessage("");
+      setGoalError(
+        "Enter both an OpenAI-compatible endpoint and a model ID before testing or saving.",
+      );
+      return;
+    }
+    setProviderBusy(true);
+    setProviderMessage("");
+    setGoalError("");
+    try {
+      const payload = {
+        execution: providerEndpoint.trim().startsWith("https://") ? "cloud_model" : "local_model",
+        endpoint: providerEndpoint.trim(),
+        model: providerModel.trim(),
+        api_key_env: providerApiKeyEnv.trim(),
+        api_key: providerApiKey.trim(),
+        verification_command: providerVerificationCommand.trim(),
+        confirm_remote_data: providerRemoteConfirmed,
+      };
+      const response = await readJson<ManagedSetupResponse>(
+        `${goalApiPrefix}/setup${testOnly ? "/test" : ""}`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(payload),
+        },
+      );
+      if (!testOnly) {
+        setManagedSetup(response);
+        setProviderApiKey("");
+      }
+      setProviderMessage(testOnly ? "Connection test passed." : "Provider saved.");
+    } catch (nextError) {
+      setProviderMessage("");
+      setGoalError(nextError instanceof Error ? nextError.message : "Provider setup failed");
+    } finally {
+      setProviderBusy(false);
+    }
+  };
+
+  const node1GoalMode: ManagedMode = {
+    ...(managedModes.find((mode) => mode.key === "local") ?? {
+      key: "local",
+      label: "Managed goal loop",
+      best_for: "A durable goal executed by the configured managed worker.",
+    }),
+    label: "Managed goal loop",
+    best_for: "Runs through the configured managed worker and keeps durable task state.",
+  };
+  const providerModeOptions = managedModes.length ? managedModes : [];
+  const selectedMode =
+    goalBackend === "provider"
+      ? (providerModeOptions.find((mode) => mode.key === goalMode) ?? providerModeOptions[0])
+      : node1GoalMode;
+
+  const startBlocker = goalStartBlocker({
+    goal,
+    backend: goalBackend,
+    providerConfigured: managedSetup?.configured === true,
+    setupLoading: goalLoading,
+    activeTaskStatus: managedTask?.status,
+  });
+  const goalOutcome = describeGoalOutcome(managedTask);
 
   const runCanary = async () => {
     setRunning(true);
@@ -216,6 +474,498 @@ export default function HarnessPage() {
         />
 
         {error ? <ErrorBox className="mb-5">{error}</ErrorBox> : null}
+
+        <Card
+          className="mb-4"
+          title="Work on a goal"
+          description="Type one objective, then let the managed harness keep working until it has evidence or needs your decision."
+        >
+          <div className="grid gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(18rem,0.65fr)]">
+            <div>
+              <label
+                htmlFor="harness-goal"
+                className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)"
+              >
+                What do you want done?
+              </label>
+              <textarea
+                id="harness-goal"
+                value={goal}
+                onChange={(event) => {
+                  setGoal(event.target.value);
+                  if (goalError) setGoalError("");
+                }}
+                onKeyDown={(event) => {
+                  if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+                    event.preventDefault();
+                    void startGoal();
+                  }
+                }}
+                rows={5}
+                placeholder="Describe the outcome in plain language, for example: Review the Local Studio integration, make a bounded improvement, and verify it end to end."
+                aria-describedby="harness-goal-hint"
+                aria-invalid={Boolean(goalError && !goal.trim())}
+                className="mt-2 block w-full resize-y rounded-xl border border-(--ui-border) bg-(--ui-bg) px-3 py-3 text-[length:var(--fs-md)] leading-relaxed text-(--ui-fg) outline-none transition focus:border-(--ui-accent) focus:ring-2 focus:ring-(--ui-accent)/20"
+                disabled={goalBusy}
+              />
+              <div
+                id="harness-goal-hint"
+                className="mt-2 flex flex-wrap items-center justify-between gap-2 text-[length:var(--fs-xs)] text-(--ui-muted)"
+              >
+                <span>Plain language is enough; /goal is optional.</span>
+                <span>⌘/Ctrl + Enter to start</span>
+              </div>
+              {managedTask?.id ? (
+                <div
+                  role="status"
+                  className="mt-3 rounded-xl border border-(--ui-border) bg-(--ui-fg)/5 p-3 text-[length:var(--fs-sm)]"
+                >
+                  <div className="font-medium text-(--ui-fg)">
+                    {isManagedGoalTerminal(managedTask)
+                      ? "Last task in this workspace"
+                      : "A goal is already running in this shared workspace"}
+                  </div>
+                  <p className="mt-1 leading-relaxed text-(--ui-muted)">
+                    {isManagedGoalTerminal(managedTask)
+                      ? "The task shown below is history. You can start a new goal."
+                      : "Continue or stop the current goal before starting another one."}
+                  </p>
+                </div>
+              ) : null}
+
+              <div className="mt-4 grid gap-3 sm:grid-cols-3">
+                <div>
+                  <label
+                    htmlFor="harness-goal-backend"
+                    className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)"
+                  >
+                    Goal engine
+                  </label>
+                  <select
+                    id="harness-goal-backend"
+                    value={goalBackend}
+                    onChange={(event) => {
+                      const nextBackend = event.target.value as GoalBackend;
+                      setGoalBackend(nextBackend);
+                      setManagedTask(null);
+                      setManagedEvents([]);
+                      setProviderMessage("");
+                      setGoalError("");
+                      // Drop the previous engine's setup so the provider gate
+                      // fails closed instead of reading the other backend's
+                      // `configured` flag until the new payload lands.
+                      // useMountSubscription diffs its deps and re-subscribes, so
+                      // changing goalBackend gives loadManaged a new identity and
+                      // re-runs that subscription; its finally() clears goalLoading.
+                      setManagedSetup(null);
+                      setGoalLoading(true);
+                    }}
+                    className="mt-2 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
+                    disabled={goalBusy || providerBusy}
+                  >
+                    <option value="managed">Configured managed worker</option>
+                    <option value="provider">Any OpenAI-compatible model</option>
+                  </select>
+                  <p className="mt-1 text-[length:var(--fs-xs)] text-(--ui-muted)">
+                    {goalBackend === "provider"
+                      ? "Use a local, LAN, or cloud endpoint configured below."
+                      : "Use the deployment's existing durable worker and route policy."}
+                  </p>
+                </div>
+                <div>
+                  <label
+                    htmlFor="harness-goal-mode"
+                    className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)"
+                  >
+                    Work mode
+                  </label>
+                  <select
+                    id="harness-goal-mode"
+                    value={goalMode}
+                    onChange={(event) => setGoalMode(event.target.value)}
+                    className="mt-2 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
+                    disabled={goalBusy}
+                  >
+                    {(goalBackend === "provider" ? providerModeOptions : [node1GoalMode]).map(
+                      (mode) => (
+                        <option key={mode.key} value={mode.key}>
+                          {mode.label}
+                        </option>
+                      ),
+                    )}
+                  </select>
+                  <p className="mt-1 text-[length:var(--fs-xs)] text-(--ui-muted)">
+                    {selectedMode?.best_for ?? "Loading work strategies..."}
+                  </p>
+                </div>
+                {goalBackend === "managed" ? (
+                  <div>
+                    <label
+                      htmlFor="harness-goal-profile"
+                      className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)"
+                    >
+                      Execution route
+                    </label>
+                    <select
+                      id="harness-goal-profile"
+                      value={goalProfile}
+                      onChange={(event) => setGoalProfile(event.target.value)}
+                      className="mt-2 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
+                      disabled={goalBusy}
+                    >
+                      {(managedProfiles.length
+                        ? managedProfiles
+                        : [{ key: goalProfile, label: "Configured model profile" }]
+                      ).map((profile) => (
+                        <option key={profile.key} value={profile.key}>
+                          {profile.label}
+                        </option>
+                      ))}
+                    </select>
+                    <p className="mt-1 text-[length:var(--fs-xs)] text-(--ui-muted)">
+                      {managedProfiles.find((profile) => profile.key === goalProfile)?.summary ??
+                        "The managed deployment chooses the endpoint and model for this profile."}
+                    </p>
+                  </div>
+                ) : (
+                  <div className="rounded-lg border border-(--ui-border) p-3 text-[length:var(--fs-xs)] text-(--ui-muted)">
+                    <div className="uppercase tracking-[0.12em]">Selected model</div>
+                    <div className="mt-2 break-words text-(--ui-fg)">
+                      {goalLoading
+                        ? "Loading provider settings…"
+                        : providerModel || "Configure a model below"}
+                    </div>
+                    <div className="mt-1 break-all">
+                      {goalLoading ? "" : providerEndpoint || "No endpoint configured"}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {goalBackend === "provider" ? (
+                <div className="mt-4 rounded-xl border border-(--ui-border) p-4">
+                  <div className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)">
+                    Model provider
+                  </div>
+                  <p className="mt-2 text-[length:var(--fs-sm)] leading-relaxed text-(--ui-muted)">
+                    Enter any OpenAI-compatible chat-completions endpoint and model ID. Keep keys in
+                    an environment variable when possible; a session key is cleared after restart.
+                  </p>
+                  <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                    <label className="text-[length:var(--fs-xs)] text-(--ui-muted)">
+                      Endpoint
+                      <input
+                        value={providerEndpoint}
+                        onChange={(event) => setProviderEndpoint(event.target.value)}
+                        placeholder="http://127.0.0.1:8000/v1/chat/completions"
+                        className="mt-1 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
+                        disabled={providerBusy || goalBusy}
+                      />
+                    </label>
+                    <label className="text-[length:var(--fs-xs)] text-(--ui-muted)">
+                      Model ID
+                      <input
+                        value={providerModel}
+                        onChange={(event) => setProviderModel(event.target.value)}
+                        placeholder="your-provider/model-name"
+                        className="mt-1 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
+                        disabled={providerBusy || goalBusy}
+                      />
+                    </label>
+                    <label className="text-[length:var(--fs-xs)] text-(--ui-muted)">
+                      API key environment variable
+                      <input
+                        value={providerApiKeyEnv}
+                        onChange={(event) => setProviderApiKeyEnv(event.target.value)}
+                        placeholder="OPENAI_API_KEY (optional)"
+                        autoComplete="off"
+                        className="mt-1 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
+                        disabled={providerBusy || goalBusy}
+                      />
+                    </label>
+                    <label className="text-[length:var(--fs-xs)] text-(--ui-muted)">
+                      Session API key
+                      <input
+                        type="password"
+                        value={providerApiKey}
+                        onChange={(event) => setProviderApiKey(event.target.value)}
+                        placeholder="Optional; never written to project state"
+                        autoComplete="new-password"
+                        className="mt-1 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
+                        disabled={providerBusy || goalBusy}
+                      />
+                    </label>
+                  </div>
+                  <label className="mt-3 block text-[length:var(--fs-xs)] text-(--ui-muted)">
+                    Independent verification command (required)
+                    <input
+                      value={providerVerificationCommand}
+                      onChange={(event) => setProviderVerificationCommand(event.target.value)}
+                      placeholder="The workspace's detected check will be used when available"
+                      className="mt-1 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
+                      disabled={providerBusy || goalBusy}
+                    />
+                    <span className="mt-1 block leading-relaxed">
+                      {providerVerificationCommand.trim()
+                        ? "This is the check saved with this provider setup and used to verify provider goals."
+                        : "Saving requires a check. If this workspace already has one, it will appear here after setup loads."}
+                    </span>
+                  </label>
+                  <label className="mt-3 flex items-start gap-2 text-[length:var(--fs-xs)] text-(--ui-muted)">
+                    <input
+                      type="checkbox"
+                      checked={providerRemoteConfirmed}
+                      onChange={(event) => setProviderRemoteConfirmed(event.target.checked)}
+                      className="mt-0.5"
+                      disabled={providerBusy || goalBusy}
+                    />
+                    I understand that a cloud endpoint may receive selected prompts, file excerpts,
+                    and tool results.
+                  </label>
+                  {providerMessage ? (
+                    <p className="mt-3 text-[length:var(--fs-sm)] text-(--ui-fg)">
+                      {providerMessage}
+                    </p>
+                  ) : null}
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      loading={providerBusy}
+                      disabled={
+                        providerBusy ||
+                        goalBusy ||
+                        goalLoading ||
+                        !providerEndpoint.trim() ||
+                        !providerModel.trim()
+                      }
+                      onClick={() => void configureProvider(true)}
+                    >
+                      Test connection
+                    </Button>
+                    <Button
+                      variant="primary"
+                      size="sm"
+                      loading={providerBusy}
+                      disabled={
+                        providerBusy ||
+                        goalBusy ||
+                        goalLoading ||
+                        !providerEndpoint.trim() ||
+                        !providerModel.trim()
+                      }
+                      onClick={() => void configureProvider(false)}
+                    >
+                      Save provider
+                    </Button>
+                  </div>
+                </div>
+              ) : null}
+
+              {goalError ? <ErrorBox className="mt-4">{goalError}</ErrorBox> : null}
+
+              {startBlocker && !goalError ? (
+                <p
+                  id="harness-goal-blocker"
+                  className="mt-4 text-[length:var(--fs-sm)] text-(--ui-muted)"
+                >
+                  {startBlocker}
+                </p>
+              ) : null}
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                <Button
+                  variant="primary"
+                  size="sm"
+                  icon={<Play className="h-3.5 w-3.5" />}
+                  loading={goalBusy}
+                  // Loading and in-flight states disable the control; other
+                  // reasons are reported by startGoal so they can be read.
+                  disabled={goalBusy || goalLoading}
+                  aria-describedby={startBlocker ? "harness-goal-blocker" : undefined}
+                  onClick={() => void startGoal()}
+                >
+                  Start goal
+                </Button>
+                {managedTask?.id && !isManagedGoalTerminal(managedTask) ? (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    loading={goalBusy}
+                    disabled={goalBusy}
+                    onClick={() => void runManagedAction("stop")}
+                  >
+                    Stop goal
+                  </Button>
+                ) : null}
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <div className="rounded-xl bg-(--ui-fg)/5 p-3">
+                <div className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)">
+                  What happens next
+                </div>
+                <div className="mt-2 space-y-2 text-[length:var(--fs-sm)] leading-relaxed text-(--ui-fg)">
+                  <p>
+                    {goalBackend === "provider"
+                      ? "The Harness owns the durable goal loop and uses the configured provider/model."
+                      : "The configured managed worker owns the durable goal loop and route policy."}
+                  </p>
+                  <p>It can plan, act, check, and continue without another prompt.</p>
+                  <p>
+                    It keeps working until complete, blocked, paused, budget-limited, or awaiting
+                    review.
+                  </p>
+                </div>
+              </div>
+              <div className="rounded-xl border border-(--ui-border) p-3 text-[length:var(--fs-xs)] text-(--ui-muted)">
+                <div className="font-medium text-(--ui-fg)">Live target</div>
+                <div className="mt-1 break-words">
+                  {/* Avoid exposing provider workspace paths in a generic
+                      provider session; managed mode may show its operator target. */}
+                  {goalBackend === "provider"
+                    ? "Configured provider workspace"
+                    : (managedSetup?.workspace ??
+                      (goalLoading ? "Loading workspace..." : "No workspace reported yet"))}
+                </div>
+                <div className="mt-1">
+                  {managedSetup?.worker?.label ??
+                    (goalBackend === "provider" ? "Provider model agent" : "Managed goal runtime")}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {managedTask?.id ? (
+            <div className="mt-5 border-t border-(--ui-border) pt-5">
+              <div className="flex flex-wrap items-center gap-2">
+                <StatusPill tone={toneForStatus(managedTask.status ?? "")} variant="badge">
+                  {managedTask.status_label ?? managedTask.status ?? "working"}
+                </StatusPill>
+                <span className="text-[length:var(--fs-xs)] text-(--ui-muted)">
+                  {managedTask.progress?.label ?? managedTask.current?.checkpoint ?? "Managed goal"}
+                </span>
+                <code className="text-[length:var(--fs-xs)] text-(--ui-muted)">
+                  {managedTask.id}
+                </code>
+              </div>
+              <p className="mt-3 text-[length:var(--fs-sm)] text-(--ui-fg)">
+                {managedTask.objective ?? managedTask.summary ?? "Goal is running."}
+              </p>
+              {goalOutcome && goalOutcome.state !== "running" ? (
+                <div
+                  role="status"
+                  className="mt-3 rounded-xl border border-(--ui-border) p-3 text-[length:var(--fs-sm)]"
+                >
+                  <div className="flex flex-wrap items-center gap-2">
+                    <StatusPill tone={goalOutcome.tone} variant="badge">
+                      {goalOutcome.headline}
+                    </StatusPill>
+                  </div>
+                  <p className="mt-2 leading-relaxed text-(--ui-muted)">{goalOutcome.detail}</p>
+                </div>
+              ) : null}
+              {managedTask.progress?.determinate ? (
+                <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-(--ui-fg)/10">
+                  <div
+                    className="h-full rounded-full bg-(--ui-accent) transition-all"
+                    style={{
+                      width: `${Math.max(0, Math.min(100, managedTask.progress.percent ?? 0))}%`,
+                    }}
+                  />
+                </div>
+              ) : null}
+              {managedTask.summary && goalOutcome?.state === "running" ? (
+                <p className="mt-3 text-[length:var(--fs-sm)] leading-relaxed text-(--ui-muted)">
+                  {managedTask.summary}
+                </p>
+              ) : null}
+              {managedTask.status === "needs_review" || managedTask.status === "blocked" ? (
+                <div className="mt-4 rounded-xl border border-(--ui-border) p-3">
+                  <label
+                    htmlFor="harness-goal-feedback"
+                    className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)"
+                  >
+                    Feedback to continue
+                  </label>
+                  <textarea
+                    id="harness-goal-feedback"
+                    value={goalFeedback}
+                    onChange={(event) => setGoalFeedback(event.target.value)}
+                    rows={3}
+                    placeholder="Tell the worker what to address next, or leave blank to continue."
+                    className="mt-2 block w-full resize-y rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
+                    disabled={goalBusy}
+                  />
+                  <Button
+                    className="mt-3"
+                    variant="secondary"
+                    size="sm"
+                    loading={goalBusy}
+                    disabled={goalBusy}
+                    onClick={() => void runManagedAction("continue")}
+                  >
+                    Continue goal
+                  </Button>
+                  {managedTask.status === "needs_review" ? (
+                    <Button
+                      className="mt-3 ml-2"
+                      variant="primary"
+                      size="sm"
+                      loading={goalBusy}
+                      disabled={goalBusy}
+                      onClick={() => void runManagedAction("accept")}
+                    >
+                      Accept result
+                    </Button>
+                  ) : null}
+                </div>
+              ) : null}
+              <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(15rem,0.55fr)]">
+                <div className="space-y-2">
+                  {(managedEvents ?? []).slice(-8).map((event, index) => (
+                    <div
+                      key={`${event.seq ?? index}-${event.checkpoint ?? "goal-event"}`}
+                      className="flex gap-2 text-[length:var(--fs-xs)] text-(--ui-muted)"
+                    >
+                      <span className="shrink-0 tabular-nums">{event.seq ?? "·"}</span>
+                      <span>{event.summary ?? event.checkpoint ?? "Goal event"}</span>
+                    </div>
+                  ))}
+                  {managedEvents.length === 0 ? (
+                    <p className="text-[length:var(--fs-xs)] text-(--ui-muted)">
+                      {goalLoading ? "Loading goal state..." : "Progress events will appear here."}
+                    </p>
+                  ) : null}
+                </div>
+                <div className="rounded-xl bg-(--ui-fg)/5 p-3">
+                  <div className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)">
+                    Evidence
+                  </div>
+                  <div className="mt-2 text-[length:var(--fs-sm)] text-(--ui-fg)">
+                    {managedTask.verification?.length ?? 0} verification checks ·{" "}
+                    {managedTask.changed_files?.length ?? 0} owned paths
+                  </div>
+                  <div className="mt-2 space-y-1">
+                    {(managedTask.artifacts ?? []).slice(0, 3).map((artifact) => (
+                      <div
+                        key={artifact.path ?? artifact.name}
+                        className="truncate text-[length:var(--fs-xs)] text-(--ui-muted)"
+                      >
+                        {artifact.name ?? artifact.path}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+          ) : goalLoading ? (
+            <p className="mt-5 border-t border-(--ui-border) pt-5 text-[length:var(--fs-sm)] text-(--ui-muted)">
+              Loading goal setup...
+            </p>
+          ) : null}
+        </Card>
 
         <div className="grid gap-4 lg:grid-cols-[minmax(0,1.45fr)_minmax(18rem,0.8fr)]">
           <Card

--- a/frontend/src/features/harness/harness-page.tsx
+++ b/frontend/src/features/harness/harness-page.tsx
@@ -41,7 +41,11 @@ type HarnessTask = {
 };
 
 type RoutesResponse = { routes?: HarnessRoute[]; selection?: { policy?: string } };
-type TaskResponse = { task?: HarnessTask; current?: HarnessTask; events?: HarnessTask["events"] };
+type TaskResponse = Partial<HarnessTask> & {
+  task?: HarnessTask;
+  current?: HarnessTask;
+  events?: HarnessTask["events"];
+};
 
 async function readJson<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, { ...init, cache: "no-store" });
@@ -85,7 +89,7 @@ export default function HarnessPage() {
       ? `/api/harness/tasks/${encodeURIComponent(taskId)}`
       : "/api/harness/tasks/current";
     const payload = await readJson<TaskResponse>(target);
-    const nextTask = payload.task ?? payload.current ?? null;
+    const nextTask = payload.task ?? (payload.id ? payload : (payload.current ?? null));
     setTask(nextTask);
     if (nextTask?.id) {
       const eventPayload = await readJson<TaskResponse>(
@@ -114,12 +118,23 @@ export default function HarnessPage() {
 
   useMountSubscription(() => {
     if (!task?.id || ["done", "stopped", "blocked"].includes(task.status ?? "")) return;
-    const timer = window.setTimeout(() => {
-      void loadTask(task.id).catch((nextError) =>
-        setError(nextError instanceof Error ? nextError.message : "Task refresh failed"),
-      );
-    }, 3000);
-    return () => window.clearTimeout(timer);
+    let stopped = false;
+    let timer: number | undefined;
+    const poll = () => {
+      timer = window.setTimeout(async () => {
+        try {
+          await loadTask(task.id!);
+        } catch (nextError) {
+          setError(nextError instanceof Error ? nextError.message : "Task refresh failed");
+        }
+        if (!stopped) poll();
+      }, 3000);
+    };
+    poll();
+    return () => {
+      stopped = true;
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
   }, [loadTask, task?.id, task?.status]);
 
   const runCanary = async () => {

--- a/frontend/src/features/harness/harness-page.tsx
+++ b/frontend/src/features/harness/harness-page.tsx
@@ -410,6 +410,7 @@ export default function HarnessPage() {
     setupLoading: goalLoading,
     activeTaskStatus: managedTask?.status,
   });
+  const showStartBlocker = Boolean(startBlocker && !goalError && !error);
   const goalOutcome = describeGoalOutcome(managedTask);
 
   const runCanary = async () => {
@@ -508,7 +509,7 @@ export default function HarnessPage() {
                 rows={5}
                 placeholder="Describe the outcome in plain language, for example: Review the Local Studio integration, make a bounded improvement, and verify it end to end."
                 aria-describedby={
-                  startBlocker
+                  showStartBlocker
                     ? "harness-goal-hint harness-goal-blocker"
                     : "harness-goal-hint"
                 }
@@ -782,7 +783,7 @@ export default function HarnessPage() {
               {goalError ? <ErrorBox className="mt-4">{goalError}</ErrorBox> : null}
               {!goalError && error ? <ErrorBox className="mt-4">{error}</ErrorBox> : null}
 
-              {startBlocker && !goalError && !error ? (
+              {showStartBlocker ? (
                 <p
                   id="harness-goal-blocker"
                   className="mt-4 text-[length:var(--fs-sm)] text-(--ui-muted)"
@@ -800,7 +801,7 @@ export default function HarnessPage() {
                   // Loading and in-flight states disable the control; other
                   // reasons are reported by startGoal so they can be read.
                   disabled={goalBusy || goalLoading}
-                  aria-describedby={startBlocker ? "harness-goal-blocker" : undefined}
+                  aria-describedby={showStartBlocker ? "harness-goal-blocker" : undefined}
                   onClick={() => void startGoal()}
                 >
                   Start goal

--- a/frontend/src/features/harness/harness-page.tsx
+++ b/frontend/src/features/harness/harness-page.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useCallback, useState, type ReactNode } from "react";
+import { AppPage, Button, Card, ErrorBox, PageContainer, PageHeader, StatusPill } from "@/ui";
+import { useMountSubscription } from "@/hooks/use-mount-subscription";
+import { GitBranch, Play, RefreshCw, ShieldCheck } from "@/ui/icon-registry";
+
+type HarnessRoute = {
+  id: string;
+  model_id: string;
+  node: string;
+  runtime: string;
+  role: string;
+  status: string;
+  status_reason?: string;
+  capabilities: string[];
+  max_context_tokens: number;
+  eligible_for: string[];
+};
+
+type HarnessTask = {
+  id?: string;
+  status?: string;
+  status_label?: string;
+  summary?: string;
+  human_title?: string;
+  artifacts?: Array<{ name?: string; path?: string }>;
+  events?: Array<{ seq?: number; summary?: string; checkpoint?: string }>;
+  metadata?: { demo?: { enabled?: boolean; model_used?: boolean; workspace?: string } };
+};
+
+type RoutesResponse = { routes?: HarnessRoute[]; selection?: { policy?: string } };
+type TaskResponse = { task?: HarnessTask; current?: HarnessTask; events?: HarnessTask["events"] };
+
+async function readJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(url, { ...init, cache: "no-store" });
+  const payload = (await response.json().catch(() => ({}))) as { error?: string } & T;
+  if (!response.ok) throw new Error(payload.error || `Harness request failed (${response.status})`);
+  return payload;
+}
+
+function toneForStatus(status: string): "default" | "good" | "warning" | "danger" {
+  if (status === "ready" || status === "done" || status === "complete") return "good";
+  if (status === "unavailable" || status === "blocked") return "danger";
+  if (status === "degraded" || status === "needs_review") return "warning";
+  return "default";
+}
+
+function formatContext(tokens: number): string {
+  if (tokens >= 1000) return `${Math.round(tokens / 1000)}k context`;
+  return `${tokens} context`;
+}
+
+export default function HarnessPage() {
+  const [routes, setRoutes] = useState<HarnessRoute[]>([]);
+  const [selectionPolicy, setSelectionPolicy] = useState("harness_decides");
+  const [task, setTask] = useState<HarnessTask | null>(null);
+  const [events, setEvents] = useState<HarnessTask["events"]>([]);
+  const [loading, setLoading] = useState(true);
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState("");
+
+  const loadRoutes = useCallback(async () => {
+    const payload = await readJson<RoutesResponse>("/api/harness/routes");
+    setRoutes(payload.routes ?? []);
+    setSelectionPolicy(payload.selection?.policy ?? "harness_decides");
+  }, []);
+
+  const loadTask = useCallback(async (taskId?: string) => {
+    const target = taskId
+      ? `/api/harness/tasks/${encodeURIComponent(taskId)}`
+      : "/api/harness/tasks/current";
+    const payload = await readJson<TaskResponse>(target);
+    const nextTask = payload.task ?? payload.current ?? null;
+    setTask(nextTask);
+    if (nextTask?.id) {
+      const eventPayload = await readJson<TaskResponse>(
+        `/api/harness/tasks/${encodeURIComponent(nextTask.id)}/events?after=0`,
+      );
+      setEvents(eventPayload.events ?? nextTask.events ?? []);
+    } else {
+      setEvents([]);
+    }
+  }, []);
+
+  const refresh = useCallback(async () => {
+    setError("");
+    try {
+      await Promise.all([loadRoutes(), loadTask()]);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : "Harness is unavailable");
+    } finally {
+      setLoading(false);
+    }
+  }, [loadRoutes, loadTask]);
+
+  useMountSubscription(() => {
+    void refresh();
+  }, [refresh]);
+
+  useMountSubscription(() => {
+    if (!task?.id || ["done", "stopped", "blocked"].includes(task.status ?? "")) return;
+    const timer = window.setTimeout(() => {
+      void loadTask(task.id).catch((nextError) =>
+        setError(nextError instanceof Error ? nextError.message : "Task refresh failed"),
+      );
+    }, 3000);
+    return () => window.clearTimeout(timer);
+  }, [loadTask, task?.id, task?.status]);
+
+  const runCanary = async () => {
+    setRunning(true);
+    setError("");
+    try {
+      const payload = await readJson<TaskResponse & { task?: HarnessTask }>("/api/harness/tasks", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          kind: "read_only_canary",
+          objective: "Verify the Local Studio to Agentic Harness task boundary",
+        }),
+      });
+      const nextTask = payload.task ?? null;
+      setTask(nextTask);
+      setEvents(nextTask?.events ?? []);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : "Canary could not start");
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <AppPage>
+      <PageContainer width="lg" className="pt-6 sm:pt-8">
+        <PageHeader
+          eyebrow="Agentic Harness"
+          title="Cluster execution"
+          description="Local Studio is the operator surface. Harness owns task state, routing, events, and evidence."
+          actions={
+            <div className="flex items-center gap-2">
+              <Button
+                variant="icon"
+                size="md"
+                aria-label="Refresh Harness"
+                title="Refresh"
+                onClick={() => void refresh()}
+              >
+                <RefreshCw className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="primary"
+                size="sm"
+                icon={<Play className="h-3.5 w-3.5" />}
+                loading={running}
+                onClick={() => void runCanary()}
+              >
+                Run safe canary
+              </Button>
+            </div>
+          }
+        />
+
+        {error ? <ErrorBox className="mb-5">{error}</ErrorBox> : null}
+
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1.45fr)_minmax(18rem,0.8fr)]">
+          <Card
+            title="Live route registry"
+            description={`Harness-owned live probes · selection policy: ${selectionPolicy}`}
+          >
+            {loading && routes.length === 0 ? (
+              <p className="text-[length:var(--fs-sm)] text-(--ui-muted)">
+                Checking Node1 and Node2...
+              </p>
+            ) : routes.length === 0 ? (
+              <p className="text-[length:var(--fs-sm)] text-(--ui-muted)">No routes reported.</p>
+            ) : (
+              <div className="divide-y divide-(--ui-border)">
+                {routes.map((route) => (
+                  <div
+                    key={route.id}
+                    className="grid gap-3 py-3 first:pt-0 last:pb-0 sm:grid-cols-[1fr_auto] sm:items-center"
+                  >
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <GitBranch className="h-4 w-4 text-(--ui-muted)" />
+                        <span className="truncate text-[length:var(--fs-md)] font-medium text-(--ui-fg)">
+                          {route.model_id}
+                        </span>
+                        <StatusPill tone={toneForStatus(route.status)} variant="badge">
+                          {route.status}
+                        </StatusPill>
+                      </div>
+                      <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[length:var(--fs-xs)] text-(--ui-muted)">
+                        <span>{route.node}</span>
+                        <span>{route.runtime}</span>
+                        <span>{route.role}</span>
+                        <span>{formatContext(route.max_context_tokens)}</span>
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap gap-1 sm:justify-end">
+                      {route.capabilities.map((capability) => (
+                        <span
+                          key={capability}
+                          className="rounded-full bg-(--ui-fg)/5 px-2 py-1 text-[length:var(--fs-xs)] text-(--ui-muted)"
+                        >
+                          {capability}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </Card>
+
+          <Card title="Ownership boundary" description="The two products have different jobs.">
+            <div className="space-y-3 text-[length:var(--fs-sm)]">
+              <BoundaryRow
+                icon={<ShieldCheck className="h-4 w-4" />}
+                label="Harness"
+                value="Executor, router, durable state, events, artifacts"
+              />
+              <BoundaryRow
+                icon={<GitBranch className="h-4 w-4" />}
+                label="Local Studio"
+                value="Operator UI and model/chat surface"
+              />
+              <div className="rounded-xl bg-(--ui-fg)/5 p-3 text-[length:var(--fs-xs)] leading-relaxed text-(--ui-muted)">
+                The canary is intentionally credential-free and isolated. It proves the client path
+                without sending work to vLLM or changing your connected project.
+              </div>
+            </div>
+          </Card>
+        </div>
+
+        <Card
+          className="mt-4"
+          title="Harness task"
+          description="The safe canary uses the real Harness lifecycle and returns task evidence through the integration API."
+        >
+          {!task?.id ? (
+            <p className="text-[length:var(--fs-sm)] text-(--ui-muted)">No task loaded.</p>
+          ) : (
+            <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_minmax(16rem,0.6fr)]">
+              <div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <StatusPill tone={toneForStatus(task.status ?? "")} variant="badge">
+                    {task.status_label ?? task.status ?? "unknown"}
+                  </StatusPill>
+                  <code className="text-[length:var(--fs-xs)] text-(--ui-muted)">{task.id}</code>
+                </div>
+                <p className="mt-3 text-[length:var(--fs-sm)] text-(--ui-fg)">
+                  {task.summary ?? task.human_title}
+                </p>
+                <div className="mt-4 space-y-2">
+                  {(events ?? []).slice(-6).map((event, index) => (
+                    <div
+                      key={`${event.seq ?? index}-${event.checkpoint ?? "event"}`}
+                      className="flex gap-2 text-[length:var(--fs-xs)] text-(--ui-muted)"
+                    >
+                      <span className="shrink-0 tabular-nums">{event.seq ?? "·"}</span>
+                      <span>{event.summary ?? event.checkpoint ?? "Harness event"}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <div className="rounded-xl bg-(--ui-fg)/5 p-3">
+                <div className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)">
+                  Evidence
+                </div>
+                <div className="mt-2 text-[length:var(--fs-sm)] text-(--ui-fg)">
+                  {task.artifacts?.length ?? 0} artifact{task.artifacts?.length === 1 ? "" : "s"}
+                </div>
+                <div className="mt-2 space-y-1">
+                  {(task.artifacts ?? []).map((artifact) => (
+                    <div
+                      key={artifact.path ?? artifact.name}
+                      className="truncate text-[length:var(--fs-xs)] text-(--ui-muted)"
+                    >
+                      {artifact.name ?? artifact.path}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+        </Card>
+      </PageContainer>
+    </AppPage>
+  );
+}
+
+function BoundaryRow({ icon, label, value }: { icon: ReactNode; label: string; value: string }) {
+  return (
+    <div className="flex items-start gap-2">
+      <span className="mt-0.5 text-(--ui-muted)">{icon}</span>
+      <div className="min-w-0">
+        <div className="text-(--ui-fg)">{label}</div>
+        <div className="mt-0.5 text-[length:var(--fs-xs)] leading-relaxed text-(--ui-muted)">
+          {value}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/harness/harness-page.tsx
+++ b/frontend/src/features/harness/harness-page.tsx
@@ -507,7 +507,11 @@ export default function HarnessPage() {
                 }}
                 rows={5}
                 placeholder="Describe the outcome in plain language, for example: Review the Local Studio integration, make a bounded improvement, and verify it end to end."
-                aria-describedby="harness-goal-hint"
+                aria-describedby={
+                  startBlocker
+                    ? "harness-goal-hint harness-goal-blocker"
+                    : "harness-goal-hint"
+                }
                 aria-invalid={Boolean(goalError && !goal.trim())}
                 className="mt-2 block w-full resize-y rounded-xl border border-(--ui-border) bg-(--ui-bg) px-3 py-3 text-[length:var(--fs-md)] leading-relaxed text-(--ui-fg) outline-none transition focus:border-(--ui-accent) focus:ring-2 focus:ring-(--ui-accent)/20"
                 disabled={goalBusy}
@@ -776,8 +780,9 @@ export default function HarnessPage() {
               ) : null}
 
               {goalError ? <ErrorBox className="mt-4">{goalError}</ErrorBox> : null}
+              {!goalError && error ? <ErrorBox className="mt-4">{error}</ErrorBox> : null}
 
-              {startBlocker && !goalError ? (
+              {startBlocker && !goalError && !error ? (
                 <p
                   id="harness-goal-blocker"
                   className="mt-4 text-[length:var(--fs-sm)] text-(--ui-muted)"
@@ -999,8 +1004,6 @@ export default function HarnessPage() {
               Run safe canary
             </Button>
           </div>
-          {error ? <ErrorBox className="mt-3">{error}</ErrorBox> : null}
-
           <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1.45fr)_minmax(18rem,0.8fr)]">
           <Card
             title="Live route registry"

--- a/frontend/src/features/shell/left-sidebar-nav.test.ts
+++ b/frontend/src/features/shell/left-sidebar-nav.test.ts
@@ -12,6 +12,7 @@ describe("left sidebar navigation", () => {
       [
         ["/", "Status"],
         ["/agent/automations", "Automations"],
+        ["/harness", "Harness"],
         ["/configure", "Configure"],
         ["/usage", "Usage"],
       ],

--- a/frontend/src/features/shell/left-sidebar-nav.tsx
+++ b/frontend/src/features/shell/left-sidebar-nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { type ComponentType } from "react";
-import { Activity, Clock, ServerCog, TrendingUp } from "@/ui/icon-registry";
+import { Activity, Clock, GitFork, ServerCog, TrendingUp } from "@/ui/icon-registry";
 
 export type IconComponent = ComponentType<{ className?: string; strokeWidth?: number }>;
 
@@ -10,6 +10,7 @@ export type IconComponent = ComponentType<{ className?: string; strokeWidth?: nu
 export const tabs = [
   { href: "/", label: "Status", icon: Activity },
   { href: "/agent/automations", label: "Automations", icon: Clock },
+  { href: "/harness", label: "Harness", icon: GitFork },
   { href: "/configure", label: "Configure", icon: ServerCog },
   { href: "/usage", label: "Usage", icon: TrendingUp },
 ];


### PR DESCRIPTION
## Summary

- add a complete `/harness` operator surface with a free-form goal composer
- support provider-neutral OpenAI-compatible endpoints and managed Harness routes
- show startup blockers, progress, review actions, evidence, files, and terminal outcomes
- add durable polling and duplicate-submission protection
- isolate provider, managed-Harness, and general Harness proxy credentials
- add beginner-oriented empty, setup, running, blocked, review, and completed states

## Why

The previous Harness pages were placeholders: a new user could not clearly enter a goal, understand which model or executor would run it, or follow the task until it was verified or blocked. Proxy boundaries also needed to prevent credentials intended for one backend from being forwarded to another.

This change turns the integration into a usable goal workflow while leaving execution and verification authority with Agentic Harness.

## User impact

A user can open Local Studio, choose any supported OpenAI-compatible model or managed Harness route, type a goal, and follow it through completion in one interface. The implementation is not tied to a private Node1 configuration; Node1 vLLM is one compatible deployment.

## Checks

- `npm run check` — passed (format, lint, type checks, unit tests, and production build)
- proxy boundary and credential-isolation tests passed
- Harness page model and beginner-state tests passed
- live end-to-end task completed through the Local Studio surface using an OpenAI-compatible Node1 vLLM route, with exact file and verification evidence
- `git diff --check`

This is intentionally a draft against `dev`. It does not merge, release, or alter the upstream deployment.
