### PR TITLE
fix(agent): keep Pi workers out of the Dock

### DIFF
--- a/services/agent-runtime/src/litter-bridge-gateway.ts
+++ b/services/agent-runtime/src/litter-bridge-gateway.ts
@@ -303,30 +303,37 @@ const resolvePiAgentDir = (dataDir: string): string => {
   return path.resolve(path.join(dataDir, "pi-agent"));
 };
 
-/**
- * Resolve the command an external consumer should run to launch the *same*
- * `pi-coding-agent` this instance uses: this process's own executable (under
- * Electron that means `ELECTRON_RUN_AS_NODE`) plus the CLI entry.
- *
- * Resolution goes through `import.meta.resolve`, which uses the same module
- * graph that already loaded pi as a library — so it works whether the package
- * is hoisted next to the agent-runtime (dev) or in a sibling subtree of the
- * desktop bundle, where a `createRequire` walk from this module would miss it.
- * `dist/cli.js` is derived as a sibling of the package's main entry because the
- * package's `exports` map does not expose the `dist/cli.js` subpath directly.
- * Returns null on any failure so the descriptor omits `piRuntime` and consumers
- * fall back to discovery rather than getting a broken command.
- */
+export const resolveElectronNodeExecutable = (
+  execPath: string,
+  pathExists: (candidate: string) => boolean = existsSync,
+): string => {
+  const executableName = path.basename(execPath);
+  const contentsDir = path.dirname(path.dirname(execPath));
+  const helperPath = path.join(
+    contentsDir,
+    "Frameworks",
+    `${executableName} Helper.app`,
+    "Contents",
+    "MacOS",
+    `${executableName} Helper`,
+  );
+  return pathExists(helperPath) ? helperPath : execPath;
+};
+
 const resolvePiRuntime = (): GatewayPiRuntime | null => {
   try {
     const mainUrl = import.meta.resolve("@earendil-works/pi-coding-agent");
     const distDir = path.dirname(fileURLToPath(mainUrl));
     const cli = path.join(distDir, "cli.js");
     const env: Record<string, string> = {};
+    const program =
+      process.platform === "darwin" && process.versions.electron
+        ? resolveElectronNodeExecutable(process.execPath)
+        : process.execPath;
     if (process.versions.electron) {
       env.ELECTRON_RUN_AS_NODE = "1";
     }
-    return { program: process.execPath, args: [cli], env };
+    return { program, args: [cli], env };
   } catch {
     return null;
   }

--- a/services/agent-runtime/test/litter-bridge-gateway.test.ts
+++ b/services/agent-runtime/test/litter-bridge-gateway.test.ts
@@ -24,12 +24,39 @@ import {
   litterBridgeSha256Utf8,
   litterBridgeSignaturePreimage,
   litterBridgeToolHashPreimage,
+  resolveElectronNodeExecutable,
   verifyLitterBridgeRequest,
 } from "../src/litter-bridge-gateway";
 
 const NOW = new Date("2026-07-20T18:30:00.000Z");
 const SECRET = "test-secret-that-is-at-least-thirty-two-bytes-long";
 const CONTROLLER_ID = "controller-test";
+
+test("macOS Electron Pi launches use the background helper executable", () => {
+  const executable = path.join(
+    "/Applications",
+    "Local Studio Dev.app",
+    "Contents",
+    "MacOS",
+    "Local Studio Dev",
+  );
+  const helper = path.join(
+    "/Applications",
+    "Local Studio Dev.app",
+    "Contents",
+    "Frameworks",
+    "Local Studio Dev Helper.app",
+    "Contents",
+    "MacOS",
+    "Local Studio Dev Helper",
+  );
+
+  assert.equal(
+    resolveElectronNodeExecutable(executable, (candidate) => candidate === helper),
+    helper,
+  );
+  assert.equal(resolveElectronNodeExecutable(executable, () => false), executable);
+});
 
 const keyMaterial = (): { privateKey: KeyObject; publicHex: string } => {
   const { privateKey, publicKey } = generateKeyPairSync("ed25519");


### PR DESCRIPTION
## Summary
- publish the packaged macOS Electron helper as the external Pi runtime
- preserve existing Node and non-macOS executable resolution
- cover helper resolution and fallback behavior with a regression test

## Root cause
Kittylitter launched packaged Pi workers through `Local Studio.app/Contents/MacOS/Local Studio` with `ELECTRON_RUN_AS_NODE=1`. LaunchServices registered each worker as a foreground application before Node mode took over, producing one Dock tile per worker.

## Validation
- `npm run check`
- `npm run test:integration`
- packaged signed app passed `codesign --verify --deep --strict`
- packaged Pi CLI returned `0.80.8` through `Local Studio Helper`
- packaged agent runtime published the helper path as `piRuntime.program`
- live packaged helper worker: 0 visible application processes, 0 LaunchServices entries