### PR TITLE
fix(agent): preserve the controller active model

### DIFF
--- a/services/agent-runtime/src/pi-runtime-models.ts
+++ b/services/agent-runtime/src/pi-runtime-models.ts
@@ -28,6 +28,7 @@ function userPiModelsPath(): string {
 type PiProviderModel = {
   id: string;
   name?: string;
+  active?: boolean;
   reasoning?: boolean;
   input?: string[];
   contextWindow?: number;
@@ -465,6 +466,7 @@ export function modelsToPiModels(models: AgentModel[]) {
     return {
       id: model.rawId ?? model.id,
       name: model.name,
+      active: model.active,
       reasoning: model.reasoning,
       input: model.vision ? ["text", "image"] : ["text"],
       contextWindow: model.contextWindow,

--- a/services/agent-runtime/test/pi-runtime-litter.test.ts
+++ b/services/agent-runtime/test/pi-runtime-litter.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import type { AgentModel } from "../../../shared/agent/models";
+import { modelsToPiModels } from "../src/pi-runtime-models";
 import {
   persistLitterPromptBoundary,
   resolvePiRuntimeStartOptions,
@@ -93,6 +94,22 @@ test("Pi model resolution requires provider qualification when raw IDs collide",
   ];
   assert.equal(selectPiRuntimeModel(models, "local-studio-b/shared")?.providerId, "local-studio-b");
   assert.throws(() => selectPiRuntimeModel(models, "shared"), /ambiguous/i);
+});
+
+test("Pi model catalog preserves the controller's active model", () => {
+  const model: AgentModel = {
+    id: "model-active",
+    rawId: "model-active",
+    providerId: "local-studio",
+    name: "Active model",
+    provider: "local-studio",
+    contextWindow: 128_000,
+    maxTokens: 16_000,
+    reasoning: true,
+    vision: false,
+    active: true,
+  };
+  assert.equal(modelsToPiModels([model])[0]?.active, true);
 });
 
 test("Pi preserves reasoning, skills, templates, and tools when restart options are omitted", () => {


### PR DESCRIPTION
## What

Preserve the controller `active` flag when Local Studio writes Pi’s `models.json`. Alleycat consumes that flag to mark the running model as the default mobile selection.

## Why

Fresh Litter sessions were defaulting to the first alphabetical controller model. When another model was actually loaded, the first turn failed with `model_not_running`.

## Verification

- `npm run check`
- `npm run test:integration`
- agent-runtime regression test for the active flag
- Litter live iroh/JSON-RPC acceptance: 20/20, including streaming, tools, file creation, reconnect, session handoff, compaction, and post-compaction hydration