### PR TITLE
chore(release): promote secure desktop signing to main

### DIFF
--- a/scripts/sign-desktop-release.mjs
+++ b/scripts/sign-desktop-release.mjs
@@ -1,11 +1,21 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const frontend = path.join(root, "frontend");
+const require = createRequire(import.meta.url);
 
 function valueAfter(args, name) {
   const index = args.indexOf(name);
@@ -27,7 +37,76 @@ function run(command, args, options = {}) {
   });
 }
 
-export function signDesktopRelease(args = process.argv.slice(2)) {
+function commandOutput(command, args) {
+  return execFileSync(command, args, {
+    cwd: root,
+    env: process.env,
+    encoding: "utf8",
+  }).trim();
+}
+
+function keychainList() {
+  return [...commandOutput("security", ["list-keychains", "-d", "user"]).matchAll(/"([^"]+)"/g)]
+    .map((match) => match[1]);
+}
+
+function writeCertificate(link, destination) {
+  const value = link.trim();
+  if (value.startsWith("file://")) {
+    writeFileSync(destination, readFileSync(fileURLToPath(value)), { mode: 0o600, flag: "wx" });
+    return;
+  }
+  if (existsSync(value)) {
+    writeFileSync(destination, readFileSync(value), { mode: 0o600, flag: "wx" });
+    return;
+  }
+  const encoded = value.replace(/^data:[^;]+;base64,/, "");
+  writeFileSync(destination, Buffer.from(encoded, "base64"), { mode: 0o600, flag: "wx" });
+}
+
+async function refreshUpdateMetadata(output, version) {
+  const { buildBlockMap } = require(
+    path.join(frontend, "node_modules", "app-builder-lib", "out", "targets", "blockmap", "blockmap.js"),
+  );
+  const YAML = require(path.join(frontend, "node_modules", "yaml"));
+  const zipName = `Local Studio-${version}-arm64-mac.zip`;
+  const dmgName = `Local Studio-${version}-arm64.dmg`;
+  const zipInfo = await buildBlockMap(
+    path.join(output, zipName),
+    "gzip",
+    path.join(output, `${zipName}.blockmap`),
+  );
+  const dmgInfo = await buildBlockMap(
+    path.join(output, dmgName),
+    "gzip",
+    path.join(output, `${dmgName}.blockmap`),
+  );
+  const updatePath = path.join(output, "latest-mac.yml");
+  const current = YAML.parse(readFileSync(updatePath, "utf8"));
+  writeFileSync(
+    updatePath,
+    YAML.stringify({
+      version,
+      files: [
+        {
+          url: zipName.replaceAll(" ", "-"),
+          sha512: zipInfo.sha512,
+          size: zipInfo.size,
+        },
+        {
+          url: dmgName.replaceAll(" ", "-"),
+          sha512: dmgInfo.sha512,
+          size: dmgInfo.size,
+        },
+      ],
+      path: zipName.replaceAll(" ", "-"),
+      sha512: zipInfo.sha512,
+      releaseDate: current.releaseDate,
+    }),
+  );
+}
+
+export async function signDesktopRelease(args = process.argv.slice(2)) {
   const version = valueAfter(args, "--version")?.trim();
   const commit = valueAfter(args, "--commit")?.trim().toLowerCase();
   const prepackaged = valueAfter(args, "--prepackaged")?.trim();
@@ -44,33 +123,112 @@ export function signDesktopRelease(args = process.argv.slice(2)) {
   const apiKey = requireValue("APPLE_API_KEY_BASE64");
   const apiKeyId = requireValue("APPLE_API_KEY_ID");
   const apiIssuer = requireValue("APPLE_API_ISSUER");
-  requireValue("CSC_LINK");
-  requireValue("CSC_KEY_PASSWORD");
+  const certificate = requireValue("CSC_LINK");
+  const certificatePassword = requireValue("CSC_KEY_PASSWORD");
 
   const temporary = path.join(os.tmpdir(), `local-studio-release-${process.pid}`);
   const apiKeyPath = path.join(temporary, `AuthKey_${apiKeyId}.p8`);
+  const certificatePath = path.join(temporary, "developer-id.p12");
+  const keychainPath = path.join(temporary, "release-signing.keychain-db");
+  const keychainPassword = randomBytes(32).toString("hex");
+  const originalKeychains = keychainList();
   const output = path.join(frontend, "dist-desktop");
   const dmg = path.join(output, `Local Studio-${version}-arm64.dmg`);
+  const resolvedApp = path.resolve(prepackaged);
+  const entitlements = path.join(frontend, "desktop", "resources", "entitlements.mac.plist");
 
   try {
     rmSync(temporary, { recursive: true, force: true });
     mkdirSync(temporary, { recursive: true, mode: 0o700 });
     writeFileSync(apiKeyPath, Buffer.from(apiKey, "base64"), { mode: 0o600, flag: "wx" });
+    writeCertificate(certificate, certificatePath);
+    run("security", ["create-keychain", "-p", keychainPassword, keychainPath]);
+    run("security", ["set-keychain-settings", "-lut", "21600", keychainPath]);
+    run("security", ["unlock-keychain", "-p", keychainPassword, keychainPath]);
+    run("security", [
+      "import",
+      certificatePath,
+      "-k",
+      keychainPath,
+      "-P",
+      certificatePassword,
+      "-T",
+      "/usr/bin/codesign",
+      "-T",
+      "/usr/bin/security",
+    ]);
+    run("security", [
+      "set-key-partition-list",
+      "-S",
+      "apple-tool:,apple:,codesign:",
+      "-s",
+      "-k",
+      keychainPassword,
+      keychainPath,
+    ]);
+    run("security", ["list-keychains", "-d", "user", "-s", keychainPath, ...originalKeychains]);
+    const identityOutput = commandOutput("security", [
+      "find-identity",
+      "-v",
+      "-p",
+      "codesigning",
+      keychainPath,
+    ]);
+    const identity = identityOutput.match(/"([^"]*Developer ID Application:[^"]*)"/)?.[1];
+    if (!identity) throw new Error("Imported certificate does not contain a Developer ID Application identity");
+
+    const { signAsync } = require(path.join(frontend, "node_modules", "@electron", "osx-sign"));
+    await signAsync({
+      app: resolvedApp,
+      platform: "darwin",
+      type: "distribution",
+      identity,
+      keychain: keychainPath,
+      hardenedRuntime: true,
+      preAutoEntitlements: false,
+    });
+    run("codesign", [
+      "--force",
+      "--options",
+      "runtime",
+      "--timestamp",
+      "--entitlements",
+      entitlements,
+      "--sign",
+      identity,
+      "--keychain",
+      keychainPath,
+      resolvedApp,
+    ]);
+    run("codesign", ["--verify", "--deep", "--strict", "--verbose=4", resolvedApp]);
+
     process.env.APPLE_API_KEY = apiKeyPath;
     process.env.APPLE_API_KEY_ID = apiKeyId;
     process.env.APPLE_API_ISSUER = apiIssuer;
     process.env.LOCAL_STUDIO_RELEASE_VERSION = version;
     process.env.LOCAL_STUDIO_RELEASE_COMMIT = commit;
+    process.env.CSC_IDENTITY_AUTO_DISCOVERY = "false";
 
     run(path.join(frontend, "node_modules", ".bin", "electron-builder"), [
       "--prepackaged",
-      path.resolve(prepackaged),
+      resolvedApp,
       "--config",
       "desktop/electron-builder.yml",
-      "--config.mac.notarize=true",
+      "--config.mac.identity=null",
+      "--config.mac.notarize=false",
+      "--config.dmg.sign=false",
       `--config.extraMetadata.version=${version}`,
       `--config.extraMetadata.localStudioCommit=${commit}`,
     ], { cwd: frontend });
+    run("codesign", [
+      "--force",
+      "--timestamp",
+      "--sign",
+      identity,
+      "--keychain",
+      keychainPath,
+      dmg,
+    ]);
     run("xcrun", [
       "notarytool",
       "submit",
@@ -86,6 +244,7 @@ export function signDesktopRelease(args = process.argv.slice(2)) {
       "json",
     ]);
     run("xcrun", ["stapler", "staple", dmg]);
+    await refreshUpdateMetadata(output, version);
     run("xcrun", ["stapler", "validate", dmg]);
     run("codesign", ["--verify", "--verbose=4", dmg]);
     run("spctl", [
@@ -97,10 +256,20 @@ export function signDesktopRelease(args = process.argv.slice(2)) {
       "--verbose=4",
       dmg,
     ]);
+    const packagedApp = path.join(output, "mac-arm64", "Local Studio.app");
+    mkdirSync(path.dirname(packagedApp), { recursive: true });
+    rmSync(packagedApp, { recursive: true, force: true });
+    symlinkSync(resolvedApp, packagedApp, "dir");
     console.log(`Signed and notarized Local Studio ${version} from ${commit}`);
   } finally {
+    if (originalKeychains.length > 0) {
+      run("security", ["list-keychains", "-d", "user", "-s", ...originalKeychains]);
+    }
+    if (existsSync(keychainPath)) {
+      run("security", ["delete-keychain", keychainPath]);
+    }
     rmSync(temporary, { recursive: true, force: true });
   }
 }
 
-signDesktopRelease();
+await signDesktopRelease();


### PR DESCRIPTION
## Purpose
Promote the fully green secure prepackaged desktop signing and notarization fix from `dev` to `main`.

## Included
- isolated temporary signing keychain
- explicit nested component signing
- restricted top-level entitlements
- post-sign verification
- DMG signing, notarization, stapling, and update metadata regeneration

## Verification
- PR #297: all gates green, including desktop-package
- public v2.8.1 arm64 DMG independently notarized, stapled, Gatekeeper-accepted, and served through localstudio.ai with SHA-256 `1489d9fc0a0566bd65d67e5dccb67ab2ddf45d5428e5a15d26b367a305879ac4`