### PR TITLE
style(updates): refine sidebar update action

### DIFF
--- a/frontend/src/features/shell/profile-footer.tsx
+++ b/frontend/src/features/shell/profile-footer.tsx
@@ -23,12 +23,12 @@ function UpdateButton() {
       onClick={update.startUpdate}
       title={label}
       aria-label={label}
-      className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-(--color-primary) text-(--color-primary-foreground) transition-opacity hover:opacity-85"
+      className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[var(--sidebar-row-radius)] text-(--color-primary) transition-colors hover:bg-(--hover) hover:text-(--fg)"
     >
       {update.phase === "working" ? (
         <Spinner size="xs" />
       ) : (
-        <Download className="h-3.5 w-3.5" strokeWidth={2} />
+        <Download className="h-3.5 w-3.5" strokeWidth={1.75} />
       )}
     </button>
   );

--- a/frontend/src/features/shell/use-app-update.test.ts
+++ b/frontend/src/features/shell/use-app-update.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
-import { isNewerVersion } from "./use-app-update";
+import { isAppUpdateAvailable, isNewerVersion } from "./use-app-update";
 
 describe("isNewerVersion", () => {
   test("orders numerically per segment, not lexically", () => {
@@ -18,5 +18,18 @@ describe("isNewerVersion", () => {
     assert.equal(isNewerVersion("2.8", "2.7.3"), true);
     assert.equal(isNewerVersion("2.7", "2.7.0"), false);
     assert.equal(isNewerVersion("nonsense", "2.7.0"), false);
+  });
+});
+
+describe("isAppUpdateAvailable", () => {
+  test("shows only when the Stable feed is newer than the installed app", () => {
+    assert.equal(isAppUpdateAvailable("2.8.1", "2.8.0"), true);
+    assert.equal(isAppUpdateAvailable("2.8.1", "2.8.1"), false);
+    assert.equal(isAppUpdateAvailable("2.8.0", "2.8.1"), false);
+  });
+
+  test("stays hidden until both versions are known", () => {
+    assert.equal(isAppUpdateAvailable(null, "2.8.1"), false);
+    assert.equal(isAppUpdateAvailable("2.8.1", null), false);
   });
 });

--- a/frontend/src/features/shell/use-app-update.ts
+++ b/frontend/src/features/shell/use-app-update.ts
@@ -31,6 +31,13 @@ export function isNewerVersion(candidate: string, current: string): boolean {
   return false;
 }
 
+export function isAppUpdateAvailable(
+  latestVersion: string | null,
+  currentVersion: string | null,
+): boolean {
+  return Boolean(latestVersion && currentVersion && isNewerVersion(latestVersion, currentVersion));
+}
+
 const bridge = () => window.localStudioDesktop ?? {};
 
 function phaseForStatus(status: string): AppUpdatePhase {
@@ -91,9 +98,7 @@ export function useAppUpdate(): AppUpdate {
     };
   }, [syncDesktopPhase]);
 
-  const updateAvailable = Boolean(
-    latest.version && currentVersion && isNewerVersion(latest.version, currentVersion),
-  );
+  const updateAvailable = isAppUpdateAvailable(latest.version, currentVersion);
 
   const startUpdate = useCallback(() => {
     const desktop = bridge();


### PR DESCRIPTION
## Tasks
- keep the Stable update action visible only for a genuinely newer release
- align the update icon with the neighboring Phone and Settings controls
- preserve the existing update workflow and accessible target

## Validation
- npm run check
- live Stable v2.8.1 install and restart validation follows locally