### PR TITLE
fix(release): resolve packaged Pi runtime command

### DIFF
--- a/frontend/scripts/electron-builder-after-pack.mjs
+++ b/frontend/scripts/electron-builder-after-pack.mjs
@@ -97,6 +97,7 @@ export default async function afterPack(context) {
 
   const requiredPiLauncherMarkers = [
     "resolveElectronNodeExecutable",
+    "resolvePackagedPiCli",
     "Frameworks",
     "Helper.app",
     "ELECTRON_RUN_AS_NODE",
@@ -120,6 +121,23 @@ export default async function afterPack(context) {
     if (!existsSync(helperExecutable)) {
       throw new Error(`Packaged app is missing its Pi helper executable: ${helperExecutable}`);
     }
+  }
+
+  const packagedPiCli = path.join(
+    resourcesDir,
+    "app",
+    "frontend",
+    ".next",
+    "standalone",
+    "frontend",
+    "node_modules",
+    "@earendil-works",
+    "pi-coding-agent",
+    "dist",
+    "cli.js",
+  );
+  if (!existsSync(packagedPiCli)) {
+    throw new Error(`Packaged app is missing its Pi CLI: ${packagedPiCli}`);
   }
 
   console.log(`  afterPack: embedded frontend and agent runtime present (${electronPlatformName})`);

--- a/services/agent-runtime/src/litter-bridge-gateway.ts
+++ b/services/agent-runtime/src/litter-bridge-gateway.ts
@@ -320,23 +320,49 @@ export const resolveElectronNodeExecutable = (
   return pathExists(helperPath) ? helperPath : execPath;
 };
 
+export const resolvePackagedPiCli = (
+  resourcesPath: string | undefined,
+  pathExists: (candidate: string) => boolean = existsSync,
+): string | null => {
+  if (!resourcesPath?.trim()) return null;
+  const cli = path.join(
+    resourcesPath,
+    "app",
+    "frontend",
+    ".next",
+    "standalone",
+    "frontend",
+    "node_modules",
+    "@earendil-works",
+    "pi-coding-agent",
+    "dist",
+    "cli.js",
+  );
+  return pathExists(cli) ? cli : null;
+};
+
 const resolvePiRuntime = (): GatewayPiRuntime | null => {
+  let cli: string | null = null;
   try {
     const mainUrl = import.meta.resolve("@earendil-works/pi-coding-agent");
     const distDir = path.dirname(fileURLToPath(mainUrl));
-    const cli = path.join(distDir, "cli.js");
-    const env: Record<string, string> = {};
-    const program =
-      process.platform === "darwin" && process.versions.electron
-        ? resolveElectronNodeExecutable(process.execPath)
-        : process.execPath;
-    if (process.versions.electron) {
-      env.ELECTRON_RUN_AS_NODE = "1";
-    }
-    return { program, args: [cli], env };
+    cli = path.join(distDir, "cli.js");
   } catch {
-    return null;
+    cli = null;
   }
+  cli ??= resolvePackagedPiCli(
+    (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath,
+  );
+  if (!cli) return null;
+  const env: Record<string, string> = {};
+  const program =
+    process.platform === "darwin" && process.versions.electron
+      ? resolveElectronNodeExecutable(process.execPath)
+      : process.execPath;
+  if (process.versions.electron) {
+    env.ELECTRON_RUN_AS_NODE = "1";
+  }
+  return { program, args: [cli], env };
 };
 
 const loadControllerId = (dataDir: string): string => {

--- a/services/agent-runtime/test/litter-bridge-gateway.test.ts
+++ b/services/agent-runtime/test/litter-bridge-gateway.test.ts
@@ -25,6 +25,7 @@ import {
   litterBridgeSignaturePreimage,
   litterBridgeToolHashPreimage,
   resolveElectronNodeExecutable,
+  resolvePackagedPiCli,
   verifyLitterBridgeRequest,
 } from "../src/litter-bridge-gateway";
 
@@ -56,6 +57,25 @@ test("macOS Electron Pi launches use the background helper executable", () => {
     helper,
   );
   assert.equal(resolveElectronNodeExecutable(executable, () => false), executable);
+});
+
+test("packaged Pi runtime resolves the embedded frontend CLI", () => {
+  const resources = path.join("/Applications", "Local Studio.app", "Contents", "Resources");
+  const cli = path.join(
+    resources,
+    "app",
+    "frontend",
+    ".next",
+    "standalone",
+    "frontend",
+    "node_modules",
+    "@earendil-works",
+    "pi-coding-agent",
+    "dist",
+    "cli.js",
+  );
+  assert.equal(resolvePackagedPiCli(resources, (candidate) => candidate === cli), cli);
+  assert.equal(resolvePackagedPiCli(resources, () => false), null);
 });
 
 const keyMaterial = (): { privateKey: KeyObject; publicHex: string } => {


### PR DESCRIPTION
## Summary
- resolve the bundled Pi CLI from Electron resources when the external agent-runtime sidecar cannot use import resolution
- retain the existing background Helper executable, CLI arguments, and ELECTRON_RUN_AS_NODE environment
- fail after-pack if the bundled Pi CLI is missing

## Validation
- npm run check
- npm run test:integration (81 passing)
- focused packaged Pi path and macOS Helper tests