### PR TITLE
fix(agent): make Pi own queued message mutations

### DIFF
--- a/frontend/src/features/agent/contracts.ts
+++ b/frontend/src/features/agent/contracts.ts
@@ -16,6 +16,7 @@ export {
 } from "@shared/agent/agent-turn";
 export type {
   ParseResult,
+  AgentQueueAction,
   AgentTurnMode,
   AgentStreamingBehavior,
   AgentTurnRequest,

--- a/frontend/src/features/agent/runtime/api.ts
+++ b/frontend/src/features/agent/runtime/api.ts
@@ -9,7 +9,11 @@ import {
   parseAgentTurnCommandResult,
   type AgentTurnCommandResult,
 } from "@/features/agent/messages";
-import type { AgentImageInput, AgentToolAccess } from "@/features/agent/contracts";
+import type {
+  AgentImageInput,
+  AgentQueueAction,
+  AgentToolAccess,
+} from "@/features/agent/contracts";
 import type { BrowserBackend } from "@/features/agent/tools/types";
 import type {
   ComposerPromptTemplateRef,
@@ -254,6 +258,8 @@ export type SubmitTurnArgs = {
   piSessionId?: string | null;
   /** Control mode for steer/follow-up; omitted for a normal prompt. */
   mode?: "steer" | "follow_up";
+  queueAction?: AgentQueueAction;
+  queueReplacement?: string;
   browserToolEnabled: boolean;
   browserSessionId?: string;
   browserBackend?: BrowserBackend;

--- a/frontend/src/features/agent/runtime/engine.ts
+++ b/frontend/src/features/agent/runtime/engine.ts
@@ -16,7 +16,11 @@ import {
 } from "@/features/agent/composer-context";
 import type { Session, SessionId, UpdateSession } from "@/features/agent/runtime/types";
 import type { BrowserBackend, ToolSelection } from "@/features/agent/tools/types";
-import type { AgentThinkingLevel, AgentToolAccess } from "@/features/agent/contracts";
+import type {
+  AgentQueueAction,
+  AgentThinkingLevel,
+  AgentToolAccess,
+} from "@/features/agent/contracts";
 import * as api from "@/features/agent/runtime/api";
 import {
   runtimeCanHydrateCanonicalSession,
@@ -52,13 +56,7 @@ export type SessionEngine = {
   /** Send a freshly-typed prompt — orchestrates optimistic update + streaming. */
   submitPrompt: (args: SubmitArgs) => Promise<void>;
   /** Send a steer/follow-up control message while a turn is in progress. */
-  sendControl: (
-    mode: "steer" | "follow_up",
-    text: string,
-    runtime: string,
-    sessionId: SessionId,
-    piSessionId?: string | null,
-  ) => Promise<{ ok: boolean; error?: string }>;
+  sendControl: (request: AgentControlRequest) => Promise<{ ok: boolean; error?: string }>;
   loadRuntimeStatus: (
     runtime: string,
     piSessionId?: string | null,
@@ -76,6 +74,16 @@ export type SessionEngine = {
     tab: { status: Session["status"]; piSessionId?: string | null },
     runtime: string,
   ) => Promise<boolean>;
+};
+
+export type AgentControlRequest = {
+  mode: "steer" | "follow_up";
+  text: string;
+  runtime: string;
+  sessionId: SessionId;
+  piSessionId?: string | null;
+  queueAction?: AgentQueueAction;
+  queueReplacement?: string;
 };
 
 export function useSessionEngine(deps: UseSessionEngineDeps): SessionEngine {
@@ -104,13 +112,9 @@ export function useSessionEngine(deps: UseSessionEngineDeps): SessionEngine {
   const loadRuntimeStatusCb = useCallback(api.loadRuntimeStatus, []);
 
   const sendControl = useCallback(
-    (
-      mode: "steer" | "follow_up",
-      text: string,
-      runtime: string,
-      sessionId: SessionId,
-      piSessionId?: string | null,
-    ): Promise<{ ok: boolean; error?: string }> => {
+    (request: AgentControlRequest): Promise<{ ok: boolean; error?: string }> => {
+      const { mode, text, runtime, sessionId, piSessionId, queueAction, queueReplacement } =
+        request;
       if (!text.trim() || !modelId) return Promise.resolve({ ok: false });
       return Effect.runPromise(
         Effect.gen(function* () {
@@ -119,6 +123,9 @@ export function useSessionEngine(deps: UseSessionEngineDeps): SessionEngine {
           const promptTemplates = selection.promptTemplates ?? EMPTY_PROMPT_TEMPLATES;
           const browserEnabledForTurn = browserToolEnabled;
           const message = selectedContextPrompt(text, skills);
+          const contextualQueueReplacement = queueReplacement
+            ? selectedContextPrompt(queueReplacement, skills)
+            : undefined;
           const result = yield* Effect.tryPromise({
             try: () =>
               api.submitTurnCommand({
@@ -130,6 +137,8 @@ export function useSessionEngine(deps: UseSessionEngineDeps): SessionEngine {
                 cwd: cwd.trim() || undefined,
                 piSessionId,
                 mode,
+                queueAction,
+                queueReplacement: contextualQueueReplacement,
                 browserToolEnabled: browserEnabledForTurn,
                 browserSessionId: runtime,
                 browserBackend,

--- a/frontend/src/features/agent/ui/chat-pane-send-flow.ts
+++ b/frontend/src/features/agent/ui/chat-pane-send-flow.ts
@@ -353,11 +353,10 @@ export function useChatPaneSendFlow({
           queueAction: "remove",
         })
         .then((result) => {
+          if (result.ok) return;
           updateTab(activeTab.id, (tab) => ({
             ...tab,
-            ...(result.ok
-              ? { queue: (tab.queue ?? []).filter((entry) => entry.id !== queueId) }
-              : { error: result.error || "Remove failed" }),
+            error: result.error || "Remove failed",
           }));
         });
     },
@@ -380,15 +379,10 @@ export function useChatPaneSendFlow({
           queueReplacement: text,
         })
         .then((result) => {
+          if (result.ok) return;
           updateTab(activeTab.id, (tab) => ({
             ...tab,
-            ...(result.ok
-              ? {
-                  queue: (tab.queue ?? []).map((entry) =>
-                    entry.id === queueId ? { ...entry, text } : entry,
-                  ),
-                }
-              : { error: result.error || "Edit failed" }),
+            error: result.error || "Edit failed",
           }));
         });
     },
@@ -415,12 +409,7 @@ export function useChatPaneSendFlow({
               }),
             catch: (error) => error,
           });
-          if (result.ok) {
-            updateTab(activeTab.id, (tab) => ({
-              ...tab,
-              queue: (tab.queue ?? []).filter((entry) => entry.id !== queueId),
-            }));
-          } else {
+          if (!result.ok) {
             updateTab(activeTab.id, (t) => ({
               ...t,
               error: result.error || "Steer failed",

--- a/frontend/src/features/agent/ui/chat-pane-send-flow.ts
+++ b/frontend/src/features/agent/ui/chat-pane-send-flow.ts
@@ -192,7 +192,14 @@ export function useChatPaneSendFlow({
       return Effect.runPromise(
         Effect.gen(function* () {
           const result = yield* Effect.tryPromise({
-            try: () => engine.sendControl(mode, text, runtime, tab.id, tab.piSessionId),
+            try: () =>
+              engine.sendControl({
+                mode,
+                text,
+                runtime,
+                sessionId: tab.id,
+                piSessionId: tab.piSessionId,
+              }),
             catch: (error) => error,
           });
           updateTab(tab.id, (t) => ({
@@ -333,26 +340,59 @@ export function useChatPaneSendFlow({
 
   const removeQueued = useCallback(
     (queueId: string) => {
-      if (!activeTab) return;
-      updateTab(activeTab.id, (tab) => ({
-        ...tab,
-        queue: (tab.queue ?? []).filter((entry) => entry.id !== queueId),
-      }));
+      if (!activeTab) return Promise.resolve();
+      const item = (activeTab.queue ?? []).find((entry) => entry.id === queueId);
+      if (!item) return Promise.resolve();
+      return engine
+        .sendControl({
+          mode: "follow_up",
+          text: item.text,
+          runtime: activeTab.id,
+          sessionId: activeTab.id,
+          piSessionId: activeTab.piSessionId,
+          queueAction: "remove",
+        })
+        .then((result) => {
+          updateTab(activeTab.id, (tab) => ({
+            ...tab,
+            ...(result.ok
+              ? { queue: (tab.queue ?? []).filter((entry) => entry.id !== queueId) }
+              : { error: result.error || "Remove failed" }),
+          }));
+        });
     },
-    [activeTab, updateTab],
+    [activeTab, engine, updateTab],
   );
 
   const editQueued = useCallback(
     (queueId: string, text: string) => {
-      if (!activeTab) return;
-      updateTab(activeTab.id, (tab) => ({
-        ...tab,
-        queue: (tab.queue ?? []).map((entry) =>
-          entry.id === queueId ? { ...entry, text } : entry,
-        ),
-      }));
+      if (!activeTab) return Promise.resolve();
+      const item = (activeTab.queue ?? []).find((entry) => entry.id === queueId);
+      if (!item) return Promise.resolve();
+      return engine
+        .sendControl({
+          mode: "follow_up",
+          text: item.text,
+          runtime: activeTab.id,
+          sessionId: activeTab.id,
+          piSessionId: activeTab.piSessionId,
+          queueAction: "replace",
+          queueReplacement: text,
+        })
+        .then((result) => {
+          updateTab(activeTab.id, (tab) => ({
+            ...tab,
+            ...(result.ok
+              ? {
+                  queue: (tab.queue ?? []).map((entry) =>
+                    entry.id === queueId ? { ...entry, text } : entry,
+                  ),
+                }
+              : { error: result.error || "Edit failed" }),
+          }));
+        });
     },
-    [activeTab, updateTab],
+    [activeTab, engine, updateTab],
   );
 
   const steerQueued = useCallback(
@@ -361,25 +401,35 @@ export function useChatPaneSendFlow({
       const item = (activeTab.queue ?? []).find((entry) => entry.id === queueId);
       if (!item) return Promise.resolve();
       const runtime = activeTab.id;
-      removeQueued(queueId);
       return Effect.runPromise(
         Effect.gen(function* () {
           const result = yield* Effect.tryPromise({
             try: () =>
-              engine.sendControl("steer", item.text, runtime, activeTab.id, activeTab.piSessionId),
+              engine.sendControl({
+                mode: "steer",
+                text: item.text,
+                runtime,
+                sessionId: activeTab.id,
+                piSessionId: activeTab.piSessionId,
+                queueAction: "promote",
+              }),
             catch: (error) => error,
           });
-          if (!result.ok) {
+          if (result.ok) {
+            updateTab(activeTab.id, (tab) => ({
+              ...tab,
+              queue: (tab.queue ?? []).filter((entry) => entry.id !== queueId),
+            }));
+          } else {
             updateTab(activeTab.id, (t) => ({
               ...t,
-              queue: [...(t.queue ?? []), item],
               error: result.error || "Steer failed",
             }));
           }
         }),
       );
     },
-    [activeTab, engine, removeQueued, updateTab],
+    [activeTab, engine, updateTab],
   );
 
   const abortTurn = useCallback(() => {

--- a/services/agent-runtime/src/http/handlers.ts
+++ b/services/agent-runtime/src/http/handlers.ts
@@ -132,6 +132,18 @@ function dispatchControlEffect(
   commandImages: AgentImageInput[] | undefined,
 ): Effect.Effect<"queued" | "rejected", unknown> {
   if (!resolved.controlTargetActive) return Effect.succeed("rejected");
+  if (turn.queueAction) {
+    return Effect.tryPromise({
+      try: () =>
+        resolved.session.mutateQueuedFollowUp(
+          turn.message,
+          turn.queueAction!,
+          turn.queueReplacement,
+          commandImages,
+        ),
+      catch: (error) => error,
+    }).pipe(Effect.map(() => "queued" as const));
+  }
   if (turn.mode === "steer") {
     return Effect.tryPromise({
       try: () => resolved.session.steer(turn.message, commandImages),

--- a/services/agent-runtime/src/pi-runtime-types.ts
+++ b/services/agent-runtime/src/pi-runtime-types.ts
@@ -1,5 +1,6 @@
 import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
 import type { AgentImageInput } from "../../../shared/agent/agent-image-input";
+import type { AgentQueueAction } from "../../../shared/agent/agent-turn";
 import type { RuntimeStartOptions } from "./pi-runtime-helpers";
 
 // Pi event surface seen by the rest of the app. Upstream consumers
@@ -78,6 +79,12 @@ export interface PiAgentSession {
     options?: PiPromptOptions,
   ): Promise<PiDurablePromptBoundary>;
   steer(message: string, images?: AgentImageInput[]): Promise<void>;
+  mutateQueuedFollowUp(
+    message: string,
+    action: AgentQueueAction,
+    replacement?: string,
+    images?: AgentImageInput[],
+  ): Promise<void>;
   followUp(message: string, images?: AgentImageInput[]): Promise<void>;
   /** Resolves with the messages that were still queued, so the caller can
    *  restore them rather than losing them to the stop. */

--- a/services/agent-runtime/src/pi-runtime.ts
+++ b/services/agent-runtime/src/pi-runtime.ts
@@ -14,6 +14,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { Effect } from "effect";
 import type { AgentImageInput } from "../../../shared/agent/agent-image-input";
+import type { AgentQueueAction } from "../../../shared/agent/agent-turn";
 import {
   applyRuntimeEnvInjections,
   buildAgentSessionOptionsSync,
@@ -40,6 +41,50 @@ import type {
 } from "./pi-runtime-types";
 
 type PiEvent = LoggedPiEvent["event"];
+
+function comparableQueuedText(text: string): string {
+  const marker = "\n\nUser prompt:\n";
+  const index = text.lastIndexOf(marker);
+  return (index === -1 ? text : text.slice(index + marker.length)).trim();
+}
+
+export function takeQueuedFollowUp(
+  followUp: readonly string[],
+  message: string,
+): { selected: string; before: string[]; after: string[] } | null {
+  const exactIndex = followUp.indexOf(message);
+  const target = comparableQueuedText(message);
+  const index =
+    exactIndex >= 0
+      ? exactIndex
+      : followUp.findIndex((candidate) => comparableQueuedText(candidate) === target);
+  if (index < 0) return null;
+  return {
+    selected: followUp[index]!,
+    before: followUp.slice(0, index),
+    after: followUp.slice(index + 1),
+  };
+}
+
+export function planQueuedFollowUpMutation(
+  followUp: readonly string[],
+  message: string,
+  action: AgentQueueAction,
+  replacement?: string,
+): { promoted: string | null; followUp: string[] } | null {
+  const selected = takeQueuedFollowUp(followUp, message);
+  if (!selected) return null;
+  if (action === "replace" && !replacement) {
+    throw new Error("Replacement text is required.");
+  }
+  return {
+    promoted: action === "promote" ? selected.selected : null,
+    followUp:
+      action === "replace"
+        ? [...selected.before, replacement!, ...selected.after]
+        : [...selected.before, ...selected.after],
+  };
+}
 
 type DurableSessionManager = Pick<
   SessionManager,
@@ -224,6 +269,8 @@ class PiSdkSession extends EventEmitter implements PiAgentSession {
   private currentModelId = "";
   private currentStartOptions: RuntimeStartOptions = {};
   private agentDir = "";
+  private queueEventBufferDepth = 0;
+  private bufferedQueueEvent: PiEvent | null = null;
   private extensionUiPending = new Map<
     string,
     { method: "select" | "confirm" | "input" | "editor"; resolve: (value: unknown) => void }
@@ -530,6 +577,51 @@ class PiSdkSession extends EventEmitter implements PiAgentSession {
     );
   }
 
+  mutateQueuedFollowUp(
+    message: string,
+    action: AgentQueueAction,
+    replacement?: string,
+    images: AgentImageInput[] = [],
+  ): Promise<void> {
+    return Effect.runPromise(
+      Effect.tryPromise({
+        try: async () => {
+          const session = this.requireSession();
+          this.queueEventBufferDepth += 1;
+          try {
+            const cleared = session.clearQueue();
+            const mutation = planQueuedFollowUpMutation(
+              cleared.followUp,
+              message,
+              action,
+              replacement,
+            );
+            if (!mutation) {
+              await Promise.all([
+                ...cleared.steering.map((queued) => session.steer(queued)),
+                ...cleared.followUp.map((queued) => session.followUp(queued)),
+              ]);
+              throw new Error("Queued follow-up is no longer pending.");
+            }
+            await Promise.all([
+              ...cleared.steering.map((queued) => session.steer(queued)),
+              ...(mutation.promoted ? [session.steer(mutation.promoted, images)] : []),
+              ...mutation.followUp.map((queued) => session.followUp(queued)),
+            ]);
+          } finally {
+            this.queueEventBufferDepth -= 1;
+            if (this.queueEventBufferDepth === 0 && this.bufferedQueueEvent) {
+              const event = this.bufferedQueueEvent;
+              this.bufferedQueueEvent = null;
+              this.recordEvent(event);
+            }
+          }
+        },
+        catch: (error) => error,
+      }),
+    );
+  }
+
   followUp(message: string, images: AgentImageInput[] = []): Promise<void> {
     return Effect.runPromise(
       Effect.tryPromise({
@@ -737,6 +829,10 @@ class PiSdkSession extends EventEmitter implements PiAgentSession {
   }
 
   private recordEvent(event: PiEvent) {
+    if (event.type === "queue_update" && this.queueEventBufferDepth > 0) {
+      this.bufferedQueueEvent = event;
+      return;
+    }
     if (event.type === "session_info_changed" && this.runtime?.session.sessionId) {
       this.currentPiSessionId = this.runtime.session.sessionId;
     }

--- a/services/agent-runtime/test/queue-promotion.test.ts
+++ b/services/agent-runtime/test/queue-promotion.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { parseAgentTurnRequest } from "../../../shared/agent/agent-turn";
+import { planQueuedFollowUpMutation, takeQueuedFollowUp } from "../src/pi-runtime";
+
+describe("takeQueuedFollowUp", () => {
+  test("removes one exact queued message and preserves order", () => {
+    expect(takeQueuedFollowUp(["first", "promote", "last"], "promote")).toEqual({
+      selected: "promote",
+      before: ["first"],
+      after: ["last"],
+    });
+  });
+
+  test("matches the visible prompt when composer context changed", () => {
+    const queued = "Composer context:\n$old\n\nUser prompt:\npromote";
+    const current = "Composer context:\n$new\n\nUser prompt:\npromote";
+    expect(takeQueuedFollowUp([queued, "last"], current)).toEqual({
+      selected: queued,
+      before: [],
+      after: ["last"],
+    });
+  });
+
+  test("removes only the first duplicate", () => {
+    expect(takeQueuedFollowUp(["same", "same"], "same")).toEqual({
+      selected: "same",
+      before: [],
+      after: ["same"],
+    });
+  });
+
+  test("returns null when the runtime queue no longer has the message", () => {
+    expect(takeQueuedFollowUp(["other"], "missing")).toBeNull();
+  });
+});
+
+describe("planQueuedFollowUpMutation", () => {
+  test("promotes one message and leaves the remaining follow-ups", () => {
+    expect(planQueuedFollowUpMutation(["first", "now", "last"], "now", "promote")).toEqual({
+      promoted: "now",
+      followUp: ["first", "last"],
+    });
+  });
+
+  test("removes one message from the runtime queue", () => {
+    expect(planQueuedFollowUpMutation(["first", "remove", "last"], "remove", "remove")).toEqual({
+      promoted: null,
+      followUp: ["first", "last"],
+    });
+  });
+
+  test("replaces in place without changing queue order", () => {
+    expect(
+      planQueuedFollowUpMutation(["first", "old", "last"], "old", "replace", "new"),
+    ).toEqual({
+      promoted: null,
+      followUp: ["first", "new", "last"],
+    });
+  });
+});
+
+describe("queued action contract", () => {
+  test("parses queue removal commands", () => {
+    const result = parseAgentTurnRequest({
+      message: "remove",
+      modelId: "model",
+      mode: "follow_up",
+      queueAction: "remove",
+    });
+    expect(result.ok).toBeTrue();
+    if (result.ok) expect(result.value.queueAction).toBe("remove");
+  });
+
+  test("requires replacement text for queue edits", () => {
+    const result = parseAgentTurnRequest({
+      message: "old",
+      modelId: "model",
+      mode: "follow_up",
+      queueAction: "replace",
+    });
+    expect(result).toEqual({
+      ok: false,
+      error: "queueReplacement is required when replacing a queued message",
+    });
+  });
+});

--- a/shared/agent/agent-turn.ts
+++ b/shared/agent/agent-turn.ts
@@ -51,6 +51,7 @@ export type AgentToolAccess = "read_only" | "full";
 
 export type AgentTurnMode = "prompt" | "steer" | "follow_up";
 export type AgentStreamingBehavior = "steer" | "followUp";
+export type AgentQueueAction = "promote" | "remove" | "replace";
 export const AGENT_THINKING_LEVELS = [
   "off",
   "minimal",
@@ -79,6 +80,8 @@ export type AgentTurnRequest = {
   skills: ReturnType<typeof sanitizeComposerSkills>;
   promptTemplates: ReturnType<typeof sanitizeComposerPromptTemplates>;
   mode: AgentTurnMode;
+  queueAction?: AgentQueueAction;
+  queueReplacement?: string;
   streamingBehavior?: AgentStreamingBehavior;
 };
 
@@ -130,6 +133,20 @@ export function parseAgentTurnRequest(input: unknown): ParseResult<AgentTurnRequ
   if (!browserSessionId.ok) return browserSessionId;
   const browserBackend = body.browserBackend === "sitegeist" ? "sitegeist" : "embedded";
   const mode = body.mode === "steer" || body.mode === "follow_up" ? body.mode : "prompt";
+  const queueAction =
+    body.queueAction === "promote" ||
+    body.queueAction === "remove" ||
+    body.queueAction === "replace"
+      ? body.queueAction
+      : undefined;
+  if (body.queueAction != null && !queueAction) {
+    return { ok: false, error: "queueAction must be promote, remove, or replace" };
+  }
+  const queueReplacement = stringField(body, "queueReplacement");
+  if (!queueReplacement.ok) return queueReplacement;
+  if (queueAction === "replace" && !queueReplacement.value) {
+    return { ok: false, error: "queueReplacement is required when replacing a queued message" };
+  }
   const streamingBehavior =
     body.streamingBehavior === "steer" || body.streamingBehavior === "followUp"
       ? body.streamingBehavior
@@ -153,6 +170,8 @@ export function parseAgentTurnRequest(input: unknown): ParseResult<AgentTurnRequ
       skills: sanitizeComposerSkills(body.skills),
       promptTemplates: sanitizeComposerPromptTemplates(body.promptTemplates),
       mode,
+      ...(queueAction ? { queueAction } : {}),
+      ...(queueReplacement.value ? { queueReplacement: queueReplacement.value } : {}),
       ...(streamingBehavior ? { streamingBehavior } : {}),
     },
   };


### PR DESCRIPTION
## Summary
- route queued Delete, Edit, and Steer through the Pi runtime instead of mutating React-only state
- use Pi's existing clearQueue, steer, followUp, and queue_update primitives to apply one exact queue mutation atomically
- preserve order and handle duplicate/context-wrapped prompts

## Validation
- npm run check
- npm run test:integration
- 9 focused queue mutation regressions