### PR TITLE
feat(harness): add verified goals to Local Studio

### DIFF
--- a/frontend/src/app/api/harness/[...path]/route.ts
+++ b/frontend/src/app/api/harness/[...path]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest } from "next/server";
+import { requireApiAccess } from "@/lib/auth/guard";
+import { proxyToHarness } from "@/app/api/harness/proxy-to-harness";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
+  const denied = requireApiAccess(request);
+  if (denied) return denied;
+  const { path } = await params;
+  return proxyToHarness(request, path);
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
+  const denied = requireApiAccess(request);
+  if (denied) return denied;
+  const { path } = await params;
+  return proxyToHarness(request, path);
+}

--- a/frontend/src/app/api/harness/managed/[...path]/route.ts
+++ b/frontend/src/app/api/harness/managed/[...path]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest } from "next/server";
+import { requireApiAccess } from "@/lib/auth/guard";
+import { proxyToManagedHarness } from "@/app/api/harness/proxy-to-harness";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
+  const denied = requireApiAccess(request);
+  if (denied) return denied;
+  const { path } = await params;
+  return proxyToManagedHarness(request, path);
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
+  const denied = requireApiAccess(request);
+  if (denied) return denied;
+  const { path } = await params;
+  return proxyToManagedHarness(request, path);
+}

--- a/frontend/src/app/api/harness/provider/[...path]/route.ts
+++ b/frontend/src/app/api/harness/provider/[...path]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest } from "next/server";
+import { requireApiAccess } from "@/lib/auth/guard";
+import { proxyToProviderHarness } from "@/app/api/harness/proxy-to-harness";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
+  const denied = requireApiAccess(request);
+  if (denied) return denied;
+  const { path } = await params;
+  return proxyToProviderHarness(request, path);
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
+  const denied = requireApiAccess(request);
+  if (denied) return denied;
+  const { path } = await params;
+  return proxyToProviderHarness(request, path);
+}

--- a/frontend/src/app/api/harness/proxy-to-harness.test.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.test.ts
@@ -1,12 +1,17 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
-import { harnessTargetUrl, upstreamRequestHeaders } from "./proxy-to-harness";
+import {
+  downstreamResponseHeaders,
+  harnessTargetUrl,
+  upstreamRequestHeaders,
+} from "./proxy-to-harness";
 
 describe("Local Studio Harness proxy headers", () => {
-  test("removes browser-origin metadata from the internal upstream request", () => {
+  test("forwards only protocol headers required by the Harness API", () => {
     const source = new Headers({
       accept: "application/json",
       authorization: "Bearer test-token",
+      cookie: "local_studio_token=cookie-token",
       "content-type": "application/json",
       origin: "http://127.0.0.1:4783",
       referer: "http://127.0.0.1:4783/harness",
@@ -14,23 +19,29 @@ describe("Local Studio Harness proxy headers", () => {
       "sec-fetch-mode": "cors",
       "sec-fetch-site": "same-origin",
       "sec-fetch-user": "?1",
+      "x-local-studio-csrf": "csrf-token",
+      "x-local-studio-token": "header-token",
       "x-request-id": "request-1",
     });
 
     const upstream = upstreamRequestHeaders(source);
 
     for (const name of [
+      "authorization",
+      "cookie",
       "origin",
+      "referer",
       "sec-fetch-dest",
       "sec-fetch-mode",
       "sec-fetch-site",
       "sec-fetch-user",
+      "x-local-studio-csrf",
+      "x-local-studio-token",
     ]) {
       assert.equal(upstream.get(name), null, `${name} must not cross the proxy boundary`);
     }
-    assert.equal(upstream.get("authorization"), "Bearer test-token");
+    assert.equal(upstream.get("accept"), "application/json");
     assert.equal(upstream.get("content-type"), "application/json");
-    assert.equal(upstream.get("referer"), "http://127.0.0.1:4783/harness");
     assert.equal(upstream.get("x-request-id"), "request-1");
     assert.equal(source.get("origin"), "http://127.0.0.1:4783");
   });
@@ -50,6 +61,25 @@ describe("Local Studio Harness proxy headers", () => {
       assert.equal(upstream.get(name), null, `${name} must not cross the proxy boundary`);
     }
     assert.equal(upstream.get("content-type"), "application/json");
+  });
+
+  test("does not let the Harness set Local Studio cookies", () => {
+    const downstream = downstreamResponseHeaders(
+      new Headers({
+        "content-type": "application/json",
+        "set-cookie": "local_studio_token=attacker-controlled",
+        "x-request-id": "request-2",
+      }),
+    );
+
+    assert.equal(downstream.get("set-cookie"), null);
+    assert.equal(downstream.get("content-type"), "application/json");
+    assert.equal(downstream.get("x-request-id"), "request-2");
+  });
+
+  test("rejects dot segments before URL normalization can escape the API namespace", () => {
+    assert.throws(() => harnessTargetUrl(["..", "admin"], "api"), /dot segments/);
+    assert.throws(() => harnessTargetUrl(["%2e%2e", "admin"], "api"), /dot segments/);
   });
 
   test("keeps managed goals on the explicit /api namespace", () => {

--- a/frontend/src/app/api/harness/proxy-to-harness.test.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { upstreamRequestHeaders } from "./proxy-to-harness";
+
+describe("Local Studio Harness proxy headers", () => {
+  test("removes browser-origin metadata from the internal upstream request", () => {
+    const source = new Headers({
+      accept: "application/json",
+      authorization: "Bearer test-token",
+      "content-type": "application/json",
+      origin: "http://127.0.0.1:4783",
+      referer: "http://127.0.0.1:4783/harness",
+      "sec-fetch-dest": "empty",
+      "sec-fetch-mode": "cors",
+      "sec-fetch-site": "same-origin",
+      "sec-fetch-user": "?1",
+      "x-request-id": "request-1",
+    });
+
+    const upstream = upstreamRequestHeaders(source);
+
+    for (const name of [
+      "origin",
+      "sec-fetch-dest",
+      "sec-fetch-mode",
+      "sec-fetch-site",
+      "sec-fetch-user",
+    ]) {
+      assert.equal(upstream.get(name), null, `${name} must not cross the proxy boundary`);
+    }
+    assert.equal(upstream.get("authorization"), "Bearer test-token");
+    assert.equal(upstream.get("content-type"), "application/json");
+    assert.equal(upstream.get("referer"), "http://127.0.0.1:4783/harness");
+    assert.equal(upstream.get("x-request-id"), "request-1");
+    assert.equal(source.get("origin"), "http://127.0.0.1:4783");
+  });
+});

--- a/frontend/src/app/api/harness/proxy-to-harness.test.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
-import { upstreamRequestHeaders } from "./proxy-to-harness";
+import { harnessTargetUrl, upstreamRequestHeaders } from "./proxy-to-harness";
 
 describe("Local Studio Harness proxy headers", () => {
   test("removes browser-origin metadata from the internal upstream request", () => {
@@ -33,5 +33,37 @@ describe("Local Studio Harness proxy headers", () => {
     assert.equal(upstream.get("referer"), "http://127.0.0.1:4783/harness");
     assert.equal(upstream.get("x-request-id"), "request-1");
     assert.equal(source.get("origin"), "http://127.0.0.1:4783");
+  });
+
+  test("still removes hop-by-hop transport headers", () => {
+    const source = new Headers({
+      host: "127.0.0.1:4783",
+      connection: "keep-alive",
+      "content-length": "42",
+      "accept-encoding": "gzip, br",
+      "content-type": "application/json",
+    });
+
+    const upstream = upstreamRequestHeaders(source);
+
+    for (const name of ["host", "connection", "content-length", "accept-encoding"]) {
+      assert.equal(upstream.get(name), null, `${name} must not cross the proxy boundary`);
+    }
+    assert.equal(upstream.get("content-type"), "application/json");
+  });
+
+  test("keeps managed goals on the explicit /api namespace", () => {
+    assert.equal(
+      harnessTargetUrl(["tasks", "current", "stop"], "api"),
+      "http://127.0.0.1:8771/api/tasks/current/stop",
+    );
+    assert.equal(
+      harnessTargetUrl(["tasks", "current"], "v1"),
+      "http://127.0.0.1:8771/v1/tasks/current",
+    );
+  });
+
+  test("keeps provider-neutral goals on their isolated upstream", () => {
+    assert.equal(harnessTargetUrl(["tasks"], "api", "provider"), "http://127.0.0.1:8772/api/tasks");
   });
 });

--- a/frontend/src/app/api/harness/proxy-to-harness.test.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.test.ts
@@ -281,6 +281,33 @@ describe("Local Studio Harness proxy headers", () => {
     assert.equal(task.verification?.[0]?.source, "legacy");
   });
 
+  test("keeps a bare task distinct from its nested current checkpoint", () => {
+    const projected = projectHarnessPayload(
+      {
+        id: "task-1",
+        status: "needs_review",
+        current: {
+          checkpoint: "Review",
+          current_subgoal: "Preparing the result for review",
+          cycle: 14,
+        },
+        changed_files: [],
+        verification: [],
+      },
+      "api",
+      ["tasks", "current"],
+      "managed",
+    );
+
+    assert.equal(projected?.id, "task-1");
+    assert.equal(projected?.status, "needs_review");
+    assert.deepEqual(projected?.current, {
+      checkpoint: "Review",
+      current_subgoal: "Preparing the result for review",
+      cycle: 14,
+    });
+  });
+
   test("does not relay raw output from rejected upstream responses", async () => {
     const previousFetch = globalThis.fetch;
     const previousToken = process.env.LOCAL_STUDIO_HARNESS_TOKEN;

--- a/frontend/src/app/api/harness/proxy-to-harness.test.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 import {
   downstreamResponseHeaders,
+  harnessToken,
   harnessTargetUrl,
+  isHarnessRouteAllowed,
+  proxyToProviderHarness,
   upstreamRequestHeaders,
 } from "./proxy-to-harness";
 
@@ -95,5 +98,73 @@ describe("Local Studio Harness proxy headers", () => {
 
   test("keeps provider-neutral goals on their isolated upstream", () => {
     assert.equal(harnessTargetUrl(["tasks"], "api", "provider"), "http://127.0.0.1:8772/api/tasks");
+  });
+
+  test("allows only the Harness routes used by the product UI", () => {
+    assert.equal(isHarnessRouteAllowed("GET", ["routes"], "v1", "managed"), true);
+    assert.equal(isHarnessRouteAllowed("POST", ["tasks"], "v1", "managed"), true);
+    assert.equal(
+      isHarnessRouteAllowed("GET", ["tasks", "goal-1", "events"], "v1", "managed"),
+      true,
+    );
+    assert.equal(
+      isHarnessRouteAllowed("POST", ["tasks", "current", "continue"], "api", "managed"),
+      true,
+    );
+    assert.equal(isHarnessRouteAllowed("POST", ["setup", "test"], "api", "provider"), true);
+    assert.equal(isHarnessRouteAllowed("POST", ["setup"], "api", "managed"), false);
+    assert.equal(
+      isHarnessRouteAllowed("GET", ["tasks", "current", "file"], "api", "managed"),
+      false,
+    );
+    assert.equal(isHarnessRouteAllowed("POST", ["tasks", "bulk"], "api", "managed"), false);
+  });
+
+  test("reads a dedicated server-side token for each Harness target", () => {
+    const previousManaged = process.env.LOCAL_STUDIO_HARNESS_TOKEN;
+    const previousProvider = process.env.LOCAL_STUDIO_PROVIDER_HARNESS_TOKEN;
+    process.env.LOCAL_STUDIO_HARNESS_TOKEN = "managed-token";
+    process.env.LOCAL_STUDIO_PROVIDER_HARNESS_TOKEN = "provider-token";
+    try {
+      assert.equal(harnessToken("managed"), "managed-token");
+      assert.equal(harnessToken("provider"), "provider-token");
+    } finally {
+      if (previousManaged === undefined) delete process.env.LOCAL_STUDIO_HARNESS_TOKEN;
+      else process.env.LOCAL_STUDIO_HARNESS_TOKEN = previousManaged;
+      if (previousProvider === undefined) delete process.env.LOCAL_STUDIO_PROVIDER_HARNESS_TOKEN;
+      else process.env.LOCAL_STUDIO_PROVIDER_HARNESS_TOKEN = previousProvider;
+    }
+  });
+
+  test("always marks browser traffic through Local Studio as remote", async () => {
+    const previousToken = process.env.LOCAL_STUDIO_PROVIDER_HARNESS_TOKEN;
+    const previousFetch = globalThis.fetch;
+    let forwardedHeaders: Headers | undefined;
+    process.env.LOCAL_STUDIO_PROVIDER_HARNESS_TOKEN = "provider-token";
+    globalThis.fetch = (async (_input, init) => {
+      forwardedHeaders = new Headers(init?.headers);
+      return Response.json({ ok: true });
+    }) as typeof fetch;
+    try {
+      const response = await proxyToProviderHarness(
+        new Request("https://studio.example/api/harness/provider/setup", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-forwarded-host": "127.0.0.1",
+          },
+          body: "{}",
+        }),
+        ["setup"],
+      );
+
+      assert.equal(response.status, 200);
+      assert.equal(forwardedHeaders?.get("authorization"), "Bearer provider-token");
+      assert.equal(forwardedHeaders?.get("x-agentic-harness-client-scope"), "remote");
+    } finally {
+      globalThis.fetch = previousFetch;
+      if (previousToken === undefined) delete process.env.LOCAL_STUDIO_PROVIDER_HARNESS_TOKEN;
+      else process.env.LOCAL_STUDIO_PROVIDER_HARNESS_TOKEN = previousToken;
+    }
   });
 });

--- a/frontend/src/app/api/harness/proxy-to-harness.test.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.test.ts
@@ -11,6 +11,7 @@ import {
   harnessToken,
   harnessTargetUrl,
   isHarnessRouteAllowed,
+  projectHarnessPayload,
   proxyToManagedHarness,
   proxyToProviderHarness,
   upstreamRequestHeaders,
@@ -237,5 +238,46 @@ describe("Local Studio Harness proxy headers", () => {
       if (previousToken === undefined) delete process.env.LOCAL_STUDIO_HARNESS_TOKEN;
       else process.env.LOCAL_STUDIO_HARNESS_TOKEN = previousToken;
     }
+  });
+
+  test("projects task responses without raw worker output or unknown fields", () => {
+    const projected = projectHarnessPayload(
+      {
+        task: {
+          id: "task-1",
+          status: "done",
+          summary: "Safe result summary",
+          advanced_details: { stdout: "raw-secret-value" },
+          events: [
+            {
+              seq: 4,
+              checkpoint: "verification_complete",
+              summary: "raw-secret-value",
+              output: "raw-secret-value",
+            },
+          ],
+          verification: ["raw-secret-value"],
+          metadata: {
+            observed_at: "2026-08-04T12:00:00Z",
+            "raw-secret-value": true,
+          },
+        },
+        "raw-secret-value": { leaked: true },
+      },
+      "api",
+      ["tasks", "current"],
+      "managed",
+    );
+    const serialized = JSON.stringify(projected);
+    const task = projected?.task as {
+      events?: Array<Record<string, unknown>>;
+      verification?: Array<Record<string, unknown>>;
+    };
+
+    assert.ok(projected);
+    assert.equal(serialized.includes("raw-secret-value"), false);
+    assert.deepEqual(task.events, [{ seq: 4, checkpoint: "verification_complete" }]);
+    assert.equal(task.verification?.[0]?.passed, false);
+    assert.equal(task.verification?.[0]?.source, "legacy");
   });
 });

--- a/frontend/src/app/api/harness/proxy-to-harness.test.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.test.ts
@@ -280,4 +280,52 @@ describe("Local Studio Harness proxy headers", () => {
     assert.equal(task.verification?.[0]?.passed, false);
     assert.equal(task.verification?.[0]?.source, "legacy");
   });
+
+  test("does not relay raw output from rejected upstream responses", async () => {
+    const previousFetch = globalThis.fetch;
+    const previousToken = process.env.LOCAL_STUDIO_HARNESS_TOKEN;
+    process.env.LOCAL_STUDIO_HARNESS_TOKEN = "managed-token";
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          error: "raw-secret-value",
+          stdout: "raw-secret-value",
+          details: { token: "raw-secret-value" },
+        }),
+        {
+          status: 422,
+          headers: {
+            "content-type": "application/json",
+            etag: '"unsafe-upstream-body"',
+          },
+        },
+      );
+
+    try {
+      const response = await proxyToManagedHarness(
+        new Request("http://127.0.0.1/api/harness/managed/tasks", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            [HARNESS_REMOTE_DATA_CONSENT_HEADER]: HARNESS_REMOTE_DATA_CONSENT_VERSION,
+          },
+          body: JSON.stringify({ objective: "Safe test objective" }),
+        }),
+        ["tasks"],
+      );
+      const body = await response.text();
+
+      assert.equal(response.status, 422);
+      assert.equal(response.headers.get("etag"), null);
+      assert.equal(body.includes("raw-secret-value"), false);
+      assert.deepEqual(JSON.parse(body), {
+        error: "The externally managed Harness rejected the request.",
+        upstream_status: 422,
+      });
+    } finally {
+      globalThis.fetch = previousFetch;
+      if (previousToken === undefined) delete process.env.LOCAL_STUDIO_HARNESS_TOKEN;
+      else process.env.LOCAL_STUDIO_HARNESS_TOKEN = previousToken;
+    }
+  });
 });

--- a/frontend/src/app/api/harness/proxy-to-harness.test.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.test.ts
@@ -1,10 +1,17 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 import {
+  HARNESS_INTEGRATION_CONTRACT_VERSION,
+  HARNESS_REMOTE_DATA_CONSENT_HEADER,
+  HARNESS_REMOTE_DATA_CONSENT_VERSION,
+} from "@shared/agent/harness";
+import {
   downstreamResponseHeaders,
+  harnessIntegrationContract,
   harnessToken,
   harnessTargetUrl,
   isHarnessRouteAllowed,
+  proxyToManagedHarness,
   proxyToProviderHarness,
   upstreamRequestHeaders,
 } from "./proxy-to-harness";
@@ -151,6 +158,7 @@ describe("Local Studio Harness proxy headers", () => {
           method: "POST",
           headers: {
             "content-type": "application/json",
+            [HARNESS_REMOTE_DATA_CONSENT_HEADER]: HARNESS_REMOTE_DATA_CONSENT_VERSION,
             "x-forwarded-host": "127.0.0.1",
           },
           body: "{}",
@@ -165,6 +173,69 @@ describe("Local Studio Harness proxy headers", () => {
       globalThis.fetch = previousFetch;
       if (previousToken === undefined) delete process.env.LOCAL_STUDIO_PROVIDER_HARNESS_TOKEN;
       else process.env.LOCAL_STUDIO_PROVIDER_HARNESS_TOKEN = previousToken;
+    }
+  });
+
+  test("blocks every mutation without the current remote-data consent contract", async () => {
+    const previousToken = process.env.LOCAL_STUDIO_PROVIDER_HARNESS_TOKEN;
+    const previousFetch = globalThis.fetch;
+    let fetchCalls = 0;
+    process.env.LOCAL_STUDIO_PROVIDER_HARNESS_TOKEN = "provider-token";
+    globalThis.fetch = (async () => {
+      fetchCalls += 1;
+      return Response.json({ ok: true });
+    }) as typeof fetch;
+    try {
+      const response = await proxyToProviderHarness(
+        new Request("https://studio.example/api/harness/provider/tasks", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ objective: "Do not forward me" }),
+        }),
+        ["tasks"],
+      );
+      const payload = (await response.json()) as { code?: string; consent_version?: string };
+
+      assert.equal(response.status, 428);
+      assert.equal(payload.code, "harness_remote_data_consent_required");
+      assert.equal(payload.consent_version, HARNESS_REMOTE_DATA_CONSENT_VERSION);
+      assert.equal(fetchCalls, 0);
+    } finally {
+      globalThis.fetch = previousFetch;
+      if (previousToken === undefined) delete process.env.LOCAL_STUDIO_PROVIDER_HARNESS_TOKEN;
+      else process.env.LOCAL_STUDIO_PROVIDER_HARNESS_TOKEN = previousToken;
+    }
+  });
+
+  test("publishes external ownership and lifecycle limits on setup", async () => {
+    const previousToken = process.env.LOCAL_STUDIO_HARNESS_TOKEN;
+    const previousFetch = globalThis.fetch;
+    process.env.LOCAL_STUDIO_HARNESS_TOKEN = "managed-token";
+    globalThis.fetch = (async () => Response.json({ configured: true })) as typeof fetch;
+    try {
+      const response = await proxyToManagedHarness(
+        new Request("https://studio.example/api/harness/managed/setup"),
+        ["setup"],
+      );
+      const payload = (await response.json()) as {
+        configured?: boolean;
+        integration?: ReturnType<typeof harnessIntegrationContract>;
+      };
+
+      assert.equal(response.status, 200);
+      assert.equal(payload.configured, true);
+      assert.equal(payload.integration?.contract, HARNESS_INTEGRATION_CONTRACT_VERSION);
+      assert.equal(payload.integration?.ownership, "external");
+      assert.deepEqual(payload.integration?.lifecycle, {
+        state: "reachable",
+        install: "external",
+        start: "external",
+        stop: "external",
+      });
+    } finally {
+      globalThis.fetch = previousFetch;
+      if (previousToken === undefined) delete process.env.LOCAL_STUDIO_HARNESS_TOKEN;
+      else process.env.LOCAL_STUDIO_HARNESS_TOKEN = previousToken;
     }
   });
 });

--- a/frontend/src/app/api/harness/proxy-to-harness.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.ts
@@ -1,11 +1,30 @@
 import { readRequestBytesWithinLimit } from "@shared/agent/agent-turn-body";
 
-const HOP_BY_HOP_REQUEST_HEADERS = ["host", "connection", "content-length", "accept-encoding"];
+const UPSTREAM_REQUEST_HEADERS_TO_REMOVE = [
+  "host",
+  "connection",
+  "content-length",
+  "accept-encoding",
+  // The Harness server validates browser-origin requests against its own
+  // listener. These headers describe the browser-to-Local-Studio hop and must
+  // not be replayed on the trusted Local-Studio-to-Harness hop.
+  "origin",
+  "sec-fetch-dest",
+  "sec-fetch-mode",
+  "sec-fetch-site",
+  "sec-fetch-user",
+];
 const DEFAULT_HARNESS_URL = "http://127.0.0.1:8771";
 
 export function harnessBaseUrl(): string {
   const raw = process.env.LOCAL_STUDIO_HARNESS_URL?.trim();
   return (raw || DEFAULT_HARNESS_URL).replace(/\/+$/, "");
+}
+
+export function upstreamRequestHeaders(requestHeaders: Headers): Headers {
+  const headers = new Headers(requestHeaders);
+  for (const name of UPSTREAM_REQUEST_HEADERS_TO_REMOVE) headers.delete(name);
+  return headers;
 }
 
 export async function proxyToHarness(
@@ -16,8 +35,7 @@ export async function proxyToHarness(
   const targetPath = path.map((part) => encodeURIComponent(part)).join("/");
   const sourceUrl = new URL(request.url);
   const target = `${harnessBaseUrl()}/v1/${targetPath}${sourceUrl.search}`;
-  const headers = new Headers(request.headers);
-  for (const name of HOP_BY_HOP_REQUEST_HEADERS) headers.delete(name);
+  const headers = upstreamRequestHeaders(request.headers);
 
   let body: ArrayBuffer | undefined;
   if (request.method !== "GET" && request.method !== "HEAD") {

--- a/frontend/src/app/api/harness/proxy-to-harness.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.ts
@@ -3,6 +3,7 @@ import {
   HARNESS_INTEGRATION_CONTRACT_VERSION,
   HARNESS_REMOTE_DATA_CONSENT_HEADER,
   HARNESS_REMOTE_DATA_CONSENT_VERSION,
+  decodeHarnessVerificationCheck,
   type HarnessIntegrationContract,
 } from "@shared/agent/harness";
 
@@ -120,6 +121,206 @@ export function downstreamResponseHeaders(upstreamHeaders: Headers): Headers {
   return headers;
 }
 
+type JsonRecord = Record<string, unknown>;
+
+function jsonRecord(value: unknown): JsonRecord | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : null;
+}
+
+function projectedStrings(value: unknown, limit = 100): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string").slice(0, limit)
+    : [];
+}
+
+function projectedRecord(value: unknown, keys: readonly string[]): JsonRecord {
+  const source = jsonRecord(value);
+  if (!source) return {};
+  return Object.fromEntries(
+    keys.flatMap((key) => {
+      const item = source[key];
+      return typeof item === "string" || typeof item === "number" || typeof item === "boolean"
+        ? [[key, item]]
+        : [];
+    }),
+  );
+}
+
+function projectedVerification(value: unknown): JsonRecord[] {
+  if (!Array.isArray(value)) return [];
+  return value.slice(0, 100).map((item) => {
+    const check = decodeHarnessVerificationCheck(item);
+    return check
+      ? { ...check }
+      : {
+          name: "Legacy verification entry",
+          passed: false,
+          message: "The upstream Harness did not return a structured verification receipt.",
+          independent: false,
+          source: "legacy",
+        };
+  });
+}
+
+function projectedEvents(value: unknown): JsonRecord[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .slice(-100)
+    .map((item) => projectedRecord(item, ["seq", "checkpoint", "status", "at"]));
+}
+
+function projectedTask(value: unknown): JsonRecord | null {
+  const source = jsonRecord(value);
+  if (!source) return null;
+  const task = projectedRecord(source, [
+    "id",
+    "status",
+    "status_label",
+    "summary",
+    "human_title",
+    "objective",
+    "mode",
+    "execution_profile",
+    "needs_human",
+    "review_status",
+    "result_category",
+  ]);
+  task.changed_files = projectedStrings(source.changed_files);
+  task.artifacts = Array.isArray(source.artifacts)
+    ? source.artifacts.slice(0, 100).map((item) => projectedRecord(item, ["name", "path"]))
+    : [];
+  task.events = projectedEvents(source.events);
+  task.verification = projectedVerification(source.verification);
+  task.progress = projectedRecord(source.progress, ["label", "percent", "determinate"]);
+  task.current = projectedRecord(source.current, [
+    "checkpoint",
+    "current_subgoal",
+    "cycle",
+    "last_event_at",
+  ]);
+  task.readiness_gate = projectedRecord(source.readiness_gate, [
+    "can_start",
+    "can_queue",
+    "state",
+    "label",
+    "next_action",
+    "summary",
+    "requires_review",
+  ]);
+  const metadata = jsonRecord(source.metadata);
+  task.metadata = {
+    ...projectedRecord(metadata, ["observed_at", "updated_at"]),
+    route_receipt: projectedRecord(metadata?.route_receipt, [
+      "contract",
+      "actual",
+      "evidence",
+      "status",
+      "reviewer",
+      "observed_at",
+    ]),
+    integration: projectedRecord(metadata?.integration, [
+      "kind",
+      "route_id",
+      "model_id",
+      "node",
+      "runtime",
+      "model_used",
+      "connected_workspace_mutated",
+    ]),
+    demo: projectedRecord(metadata?.demo, ["enabled", "model_used", "workspace"]),
+  };
+  task.final_result = projectedRecord(source.final_result, ["accepted"]);
+  return task;
+}
+
+function projectedSetup(value: unknown, target: HarnessTarget): JsonRecord | null {
+  const source = jsonRecord(value);
+  if (!source) return null;
+  return {
+    ...projectedRecord(source, [
+      "configured",
+      "editable",
+      "suggested_check",
+      "verification_command",
+      "workspace",
+      "execution_summary",
+      "assurance_mode",
+    ]),
+    allowed_api_key_envs: projectedStrings(source.allowed_api_key_envs),
+    worker: projectedRecord(source.worker, ["label", "type", "data_location"]),
+    provider: projectedRecord(source.provider, [
+      "endpoint",
+      "model",
+      "api_key_env",
+      "data_location",
+    ]),
+    verification_contract: projectedRecord(source.verification_contract, ["shell", "summary"]),
+    integration: harnessIntegrationContract(target),
+  };
+}
+
+export function projectHarnessPayload(
+  value: unknown,
+  namespace: "v1" | "api",
+  path: string[],
+  target: HarnessTarget,
+): JsonRecord | null {
+  const source = jsonRecord(value);
+  if (!source) return null;
+  const route = path.join("/");
+  if (namespace === "api" && route === "setup") return projectedSetup(source, target);
+  if (route === "routes") {
+    return {
+      routes: Array.isArray(source.routes)
+        ? source.routes.slice(0, 100).map((item) => ({
+            ...projectedRecord(item, [
+              "id",
+              "model_id",
+              "node",
+              "runtime",
+              "role",
+              "status",
+              "status_reason",
+              "max_context_tokens",
+            ]),
+            capabilities: projectedStrings(jsonRecord(item)?.capabilities),
+            eligible_for: projectedStrings(jsonRecord(item)?.eligible_for),
+          }))
+        : [],
+      selection: projectedRecord(source.selection, ["policy"]),
+    };
+  }
+  if (route === "modes") {
+    return {
+      ...projectedRecord(source, ["kind", "default", "default_execution_profile"]),
+      modes: Array.isArray(source.modes)
+        ? source.modes
+            .slice(0, 100)
+            .map((item) => projectedRecord(item, ["key", "label", "best_for", "caution"]))
+        : [],
+      execution_profiles: Array.isArray(source.execution_profiles)
+        ? source.execution_profiles
+            .slice(0, 100)
+            .map((item) => projectedRecord(item, ["key", "label", "summary", "caution"]))
+        : [],
+    };
+  }
+  if (route.endsWith("events")) {
+    return {
+      ...projectedRecord(source, ["api_version", "task_id"]),
+      events: projectedEvents(source.events),
+    };
+  }
+  const envelope = projectedRecord(source, ["api_version"]);
+  if ("task" in source) envelope.task = projectedTask(source.task);
+  if ("current" in source) envelope.current = projectedTask(source.current);
+  if (Array.isArray(source.tasks)) envelope.tasks = source.tasks.map(projectedTask).filter(Boolean);
+  if (Object.keys(envelope).length > 0) return envelope;
+  return projectedTask(source);
+}
+
 function harnessPathSegment(part: string): string {
   let decoded = part;
   try {
@@ -139,7 +340,7 @@ async function downstreamHarnessResponse(
   path: string[],
   target: HarnessTarget,
 ): Promise<Response> {
-  if (namespace !== "api" || path.join("/") !== "setup" || !upstream.ok) {
+  if (!upstream.ok) {
     return new Response(upstream.body, {
       status: upstream.status,
       headers: downstreamResponseHeaders(upstream.headers),
@@ -151,17 +352,18 @@ async function downstreamHarnessResponse(
   } catch {
     return Response.json({ error: "Harness setup returned invalid JSON" }, { status: 502 });
   }
-  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
-    return Response.json({ error: "Harness setup returned an invalid contract" }, { status: 502 });
+  const projected = projectHarnessPayload(payload, namespace, path, target);
+  if (!projected) {
+    return Response.json(
+      { error: "Harness returned an invalid response contract" },
+      { status: 502 },
+    );
   }
   const headers = downstreamResponseHeaders(upstream.headers);
   headers.delete("etag");
   headers.delete("last-modified");
   headers.set("content-type", "application/json");
-  return new Response(
-    JSON.stringify({ ...payload, integration: harnessIntegrationContract(target) }),
-    { status: upstream.status, headers },
-  );
+  return new Response(JSON.stringify(projected), { status: upstream.status, headers });
 }
 
 export function harnessTargetUrl(

--- a/frontend/src/app/api/harness/proxy-to-harness.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.ts
@@ -341,10 +341,20 @@ async function downstreamHarnessResponse(
   target: HarnessTarget,
 ): Promise<Response> {
   if (!upstream.ok) {
-    return new Response(upstream.body, {
-      status: upstream.status,
-      headers: downstreamResponseHeaders(upstream.headers),
-    });
+    const headers = downstreamResponseHeaders(upstream.headers);
+    headers.delete("etag");
+    headers.delete("last-modified");
+    headers.set("content-type", "application/json");
+    return new Response(
+      JSON.stringify({
+        error: "The externally managed Harness rejected the request.",
+        upstream_status: upstream.status,
+      }),
+      {
+        status: upstream.status,
+        headers,
+      },
+    );
   }
   let payload: unknown;
   try {

--- a/frontend/src/app/api/harness/proxy-to-harness.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.ts
@@ -1,0 +1,59 @@
+import { readRequestBytesWithinLimit } from "@shared/agent/agent-turn-body";
+
+const HOP_BY_HOP_REQUEST_HEADERS = ["host", "connection", "content-length", "accept-encoding"];
+const DEFAULT_HARNESS_URL = "http://127.0.0.1:8771";
+
+export function harnessBaseUrl(): string {
+  const raw = process.env.LOCAL_STUDIO_HARNESS_URL?.trim();
+  return (raw || DEFAULT_HARNESS_URL).replace(/\/+$/, "");
+}
+
+export async function proxyToHarness(
+  request: Request,
+  path: string[],
+  bodyLimitBytes = 256 * 1024,
+): Promise<Response> {
+  const targetPath = path.map((part) => encodeURIComponent(part)).join("/");
+  const sourceUrl = new URL(request.url);
+  const target = `${harnessBaseUrl()}/v1/${targetPath}${sourceUrl.search}`;
+  const headers = new Headers(request.headers);
+  for (const name of HOP_BY_HOP_REQUEST_HEADERS) headers.delete(name);
+
+  let body: ArrayBuffer | undefined;
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    const bounded = await readRequestBytesWithinLimit(request, bodyLimitBytes);
+    if (!bounded.ok) return Response.json({ error: bounded.error }, { status: bounded.status });
+    body = new ArrayBuffer(bounded.value.byteLength);
+    new Uint8Array(body).set(bounded.value);
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(target, {
+      method: request.method,
+      headers,
+      body,
+      signal: request.signal,
+      cache: "no-store",
+    });
+  } catch (error) {
+    if (request.signal.aborted) throw error;
+    return Response.json(
+      {
+        error: `agentic harness unreachable at ${harnessBaseUrl()}: ${
+          error instanceof Error ? error.message : "fetch failed"
+        }`,
+      },
+      { status: 502 },
+    );
+  }
+
+  const responseHeaders = new Headers(upstream.headers);
+  responseHeaders.delete("content-length");
+  responseHeaders.delete("content-encoding");
+  responseHeaders.delete("transfer-encoding");
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: responseHeaders,
+  });
+}

--- a/frontend/src/app/api/harness/proxy-to-harness.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.ts
@@ -1,4 +1,10 @@
 import { readRequestBytesWithinLimit } from "@shared/agent/agent-turn-body";
+import {
+  HARNESS_INTEGRATION_CONTRACT_VERSION,
+  HARNESS_REMOTE_DATA_CONSENT_HEADER,
+  HARNESS_REMOTE_DATA_CONSENT_VERSION,
+  type HarnessIntegrationContract,
+} from "@shared/agent/harness";
 
 const UPSTREAM_REQUEST_HEADER_ALLOWLIST = [
   "accept",
@@ -47,6 +53,31 @@ export function harnessToken(target: HarnessTarget = "managed"): string {
       ? process.env.LOCAL_STUDIO_PROVIDER_HARNESS_TOKEN
       : process.env.LOCAL_STUDIO_HARNESS_TOKEN
     )?.trim() ?? ""
+  );
+}
+
+export function harnessIntegrationContract(target: HarnessTarget): HarnessIntegrationContract {
+  return {
+    contract: HARNESS_INTEGRATION_CONTRACT_VERSION,
+    target,
+    ownership: "external",
+    configuration_source: "server_environment",
+    lifecycle: {
+      state: "reachable",
+      install: "external",
+      start: "external",
+      stop: "external",
+    },
+    remote_data: {
+      mutation_consent_required: true,
+      consent_version: HARNESS_REMOTE_DATA_CONSENT_VERSION,
+    },
+  };
+}
+
+export function hasHarnessMutationConsent(request: Request): boolean {
+  return (
+    request.headers.get(HARNESS_REMOTE_DATA_CONSENT_HEADER) === HARNESS_REMOTE_DATA_CONSENT_VERSION
   );
 }
 
@@ -102,6 +133,37 @@ function harnessPathSegment(part: string): string {
   return encodeURIComponent(part);
 }
 
+async function downstreamHarnessResponse(
+  upstream: Response,
+  namespace: "v1" | "api",
+  path: string[],
+  target: HarnessTarget,
+): Promise<Response> {
+  if (namespace !== "api" || path.join("/") !== "setup" || !upstream.ok) {
+    return new Response(upstream.body, {
+      status: upstream.status,
+      headers: downstreamResponseHeaders(upstream.headers),
+    });
+  }
+  let payload: unknown;
+  try {
+    payload = await upstream.json();
+  } catch {
+    return Response.json({ error: "Harness setup returned invalid JSON" }, { status: 502 });
+  }
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
+    return Response.json({ error: "Harness setup returned an invalid contract" }, { status: 502 });
+  }
+  const headers = downstreamResponseHeaders(upstream.headers);
+  headers.delete("etag");
+  headers.delete("last-modified");
+  headers.set("content-type", "application/json");
+  return new Response(
+    JSON.stringify({ ...payload, integration: harnessIntegrationContract(target) }),
+    { status: upstream.status, headers },
+  );
+}
+
 export function harnessTargetUrl(
   path: string[],
   namespace: "v1" | "api" = "v1",
@@ -124,6 +186,20 @@ async function proxyToHarnessNamespace(
       {
         status: 404,
       },
+    );
+  }
+  if (
+    request.method !== "GET" &&
+    request.method !== "HEAD" &&
+    !hasHarnessMutationConsent(request)
+  ) {
+    return Response.json(
+      {
+        code: "harness_remote_data_consent_required",
+        error: "Confirm that Local Studio may send this request to the externally managed Harness.",
+        consent_version: HARNESS_REMOTE_DATA_CONSENT_VERSION,
+      },
+      { status: 428 },
     );
   }
   const token = harnessToken(target);
@@ -178,10 +254,7 @@ async function proxyToHarnessNamespace(
     );
   }
 
-  return new Response(upstream.body, {
-    status: upstream.status,
-    headers: downstreamResponseHeaders(upstream.headers),
-  });
+  return downstreamHarnessResponse(upstream, namespace, path, target);
 }
 
 export function proxyToHarness(

--- a/frontend/src/app/api/harness/proxy-to-harness.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.ts
@@ -8,6 +8,12 @@ const UPSTREAM_REQUEST_HEADERS_TO_REMOVE = [
   // The Harness server validates browser-origin requests against its own
   // listener. These headers describe the browser-to-Local-Studio hop and must
   // not be replayed on the trusted Local-Studio-to-Harness hop.
+  // Stripping them here is safe because the browser hop is already enforced
+  // before this route runs: src/proxy.ts applies evaluateRequestBoundary
+  // (host allowlist, cross-site rejection, Origin match, CSRF double-submit;
+  // see src/lib/security/request-boundary.ts and its tests) and the route
+  // handler re-checks the access token via requireApiAccess. Do not add a
+  // second origin gate here, and do not stop stripping these headers.
   "origin",
   "sec-fetch-dest",
   "sec-fetch-mode",
@@ -15,10 +21,18 @@ const UPSTREAM_REQUEST_HEADERS_TO_REMOVE = [
   "sec-fetch-user",
 ];
 const DEFAULT_HARNESS_URL = "http://127.0.0.1:8771";
+const DEFAULT_PROVIDER_HARNESS_URL = "http://127.0.0.1:8772";
 
-export function harnessBaseUrl(): string {
-  const raw = process.env.LOCAL_STUDIO_HARNESS_URL?.trim();
-  return (raw || DEFAULT_HARNESS_URL).replace(/\/+$/, "");
+export type HarnessTarget = "managed" | "provider";
+
+export function harnessBaseUrl(target: HarnessTarget = "managed"): string {
+  const raw = (
+    target === "provider"
+      ? process.env.LOCAL_STUDIO_PROVIDER_HARNESS_URL
+      : process.env.LOCAL_STUDIO_HARNESS_URL
+  )?.trim();
+  const fallback = target === "provider" ? DEFAULT_PROVIDER_HARNESS_URL : DEFAULT_HARNESS_URL;
+  return (raw || fallback).replace(/\/+$/, "");
 }
 
 export function upstreamRequestHeaders(requestHeaders: Headers): Headers {
@@ -27,14 +41,24 @@ export function upstreamRequestHeaders(requestHeaders: Headers): Headers {
   return headers;
 }
 
-export async function proxyToHarness(
+export function harnessTargetUrl(
+  path: string[],
+  namespace: "v1" | "api" = "v1",
+  target: HarnessTarget = "managed",
+): string {
+  const targetPath = path.map((part) => encodeURIComponent(part)).join("/");
+  return `${harnessBaseUrl(target)}/${namespace}/${targetPath}`;
+}
+
+async function proxyToHarnessNamespace(
   request: Request,
   path: string[],
+  namespace: "v1" | "api",
+  target: HarnessTarget,
   bodyLimitBytes = 256 * 1024,
 ): Promise<Response> {
-  const targetPath = path.map((part) => encodeURIComponent(part)).join("/");
   const sourceUrl = new URL(request.url);
-  const target = `${harnessBaseUrl()}/v1/${targetPath}${sourceUrl.search}`;
+  const upstreamTarget = `${harnessTargetUrl(path, namespace, target)}${sourceUrl.search}`;
   const headers = upstreamRequestHeaders(request.headers);
 
   let body: ArrayBuffer | undefined;
@@ -47,7 +71,7 @@ export async function proxyToHarness(
 
   let upstream: Response;
   try {
-    upstream = await fetch(target, {
+    upstream = await fetch(upstreamTarget, {
       method: request.method,
       headers,
       body,
@@ -58,7 +82,7 @@ export async function proxyToHarness(
     if (request.signal.aborted) throw error;
     return Response.json(
       {
-        error: `agentic harness unreachable at ${harnessBaseUrl()}: ${
+        error: `agentic harness unreachable at ${harnessBaseUrl(target)}: ${
           error instanceof Error ? error.message : "fetch failed"
         }`,
       },
@@ -74,4 +98,33 @@ export async function proxyToHarness(
     status: upstream.status,
     headers: responseHeaders,
   });
+}
+
+export function proxyToHarness(
+  request: Request,
+  path: string[],
+  bodyLimitBytes = 256 * 1024,
+): Promise<Response> {
+  return proxyToHarnessNamespace(request, path, "v1", "managed", bodyLimitBytes);
+}
+
+/**
+ * Proxy the managed local-goal API separately from the read-only integration
+ * API. Keeping the namespace explicit prevents a UI caller from accidentally
+ * turning a v1 canary endpoint into a privileged durable-goal action.
+ */
+export function proxyToManagedHarness(
+  request: Request,
+  path: string[],
+  bodyLimitBytes = 256 * 1024,
+): Promise<Response> {
+  return proxyToHarnessNamespace(request, path, "api", "managed", bodyLimitBytes);
+}
+
+export function proxyToProviderHarness(
+  request: Request,
+  path: string[],
+  bodyLimitBytes = 256 * 1024,
+): Promise<Response> {
+  return proxyToHarnessNamespace(request, path, "api", "provider", bodyLimitBytes);
 }

--- a/frontend/src/app/api/harness/proxy-to-harness.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.ts
@@ -21,6 +21,16 @@ const DEFAULT_PROVIDER_HARNESS_URL = "http://127.0.0.1:8772";
 
 export type HarnessTarget = "managed" | "provider";
 
+const V1_GET_ROUTES = [
+  /^routes$/,
+  /^tasks$/,
+  /^tasks\/current$/,
+  /^tasks\/[^/]+$/,
+  /^tasks\/[^/]+\/(?:events|artifacts)$/,
+];
+const API_GET_ROUTES = [/^modes$/, /^setup$/, /^tasks\/current$/, /^tasks\/current\/events$/];
+const API_POST_ROUTES = [/^tasks$/, /^tasks\/current\/(?:stop|continue|accept)$/];
+
 export function harnessBaseUrl(target: HarnessTarget = "managed"): string {
   const raw = (
     target === "provider"
@@ -29,6 +39,36 @@ export function harnessBaseUrl(target: HarnessTarget = "managed"): string {
   )?.trim();
   const fallback = target === "provider" ? DEFAULT_PROVIDER_HARNESS_URL : DEFAULT_HARNESS_URL;
   return (raw || fallback).replace(/\/+$/, "");
+}
+
+export function harnessToken(target: HarnessTarget = "managed"): string {
+  return (
+    (target === "provider"
+      ? process.env.LOCAL_STUDIO_PROVIDER_HARNESS_TOKEN
+      : process.env.LOCAL_STUDIO_HARNESS_TOKEN
+    )?.trim() ?? ""
+  );
+}
+
+export function isHarnessRouteAllowed(
+  method: string,
+  path: string[],
+  namespace: "v1" | "api",
+  target: HarnessTarget,
+): boolean {
+  const route = path.join("/");
+  const normalizedMethod = method.toUpperCase();
+  if (namespace === "v1") {
+    return normalizedMethod === "GET"
+      ? V1_GET_ROUTES.some((pattern) => pattern.test(route))
+      : normalizedMethod === "POST" && route === "tasks";
+  }
+  if (normalizedMethod === "GET") {
+    return API_GET_ROUTES.some((pattern) => pattern.test(route));
+  }
+  if (normalizedMethod !== "POST") return false;
+  if (API_POST_ROUTES.some((pattern) => pattern.test(route))) return true;
+  return target === "provider" && /^(?:setup|setup\/test)$/.test(route);
 }
 
 export function upstreamRequestHeaders(requestHeaders: Headers): Headers {
@@ -78,6 +118,23 @@ async function proxyToHarnessNamespace(
   target: HarnessTarget,
   bodyLimitBytes = 256 * 1024,
 ): Promise<Response> {
+  if (!isHarnessRouteAllowed(request.method, path, namespace, target)) {
+    return Response.json(
+      { error: "Harness route is not available through Local Studio" },
+      {
+        status: 404,
+      },
+    );
+  }
+  const token = harnessToken(target);
+  if (!token) {
+    return Response.json(
+      {
+        error: `Harness authentication is not configured for the ${target} integration`,
+      },
+      { status: 503 },
+    );
+  }
   const sourceUrl = new URL(request.url);
   let upstreamTarget: string;
   try {
@@ -89,6 +146,8 @@ async function proxyToHarnessNamespace(
     );
   }
   const headers = upstreamRequestHeaders(request.headers);
+  headers.set("authorization", `Bearer ${token}`);
+  headers.set("x-agentic-harness-client-scope", "remote");
 
   let body: ArrayBuffer | undefined;
   if (request.method !== "GET" && request.method !== "HEAD") {

--- a/frontend/src/app/api/harness/proxy-to-harness.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.ts
@@ -313,6 +313,9 @@ export function projectHarnessPayload(
       events: projectedEvents(source.events),
     };
   }
+  if (typeof source.id === "string" && typeof source.status === "string") {
+    return projectedTask(source);
+  }
   const envelope = projectedRecord(source, ["api_version"]);
   if ("task" in source) envelope.task = projectedTask(source.task);
   if ("current" in source) envelope.current = projectedTask(source.current);

--- a/frontend/src/app/api/harness/proxy-to-harness.ts
+++ b/frontend/src/app/api/harness/proxy-to-harness.ts
@@ -1,24 +1,20 @@
 import { readRequestBytesWithinLimit } from "@shared/agent/agent-turn-body";
 
-const UPSTREAM_REQUEST_HEADERS_TO_REMOVE = [
-  "host",
-  "connection",
-  "content-length",
-  "accept-encoding",
-  // The Harness server validates browser-origin requests against its own
-  // listener. These headers describe the browser-to-Local-Studio hop and must
-  // not be replayed on the trusted Local-Studio-to-Harness hop.
-  // Stripping them here is safe because the browser hop is already enforced
-  // before this route runs: src/proxy.ts applies evaluateRequestBoundary
-  // (host allowlist, cross-site rejection, Origin match, CSRF double-submit;
-  // see src/lib/security/request-boundary.ts and its tests) and the route
-  // handler re-checks the access token via requireApiAccess. Do not add a
-  // second origin gate here, and do not stop stripping these headers.
-  "origin",
-  "sec-fetch-dest",
-  "sec-fetch-mode",
-  "sec-fetch-site",
-  "sec-fetch-user",
+const UPSTREAM_REQUEST_HEADER_ALLOWLIST = [
+  "accept",
+  "content-type",
+  "if-match",
+  "if-none-match",
+  "last-event-id",
+  "x-request-id",
+];
+const DOWNSTREAM_RESPONSE_HEADER_ALLOWLIST = [
+  "cache-control",
+  "content-type",
+  "etag",
+  "last-modified",
+  "retry-after",
+  "x-request-id",
 ];
 const DEFAULT_HARNESS_URL = "http://127.0.0.1:8771";
 const DEFAULT_PROVIDER_HARNESS_URL = "http://127.0.0.1:8772";
@@ -36,9 +32,34 @@ export function harnessBaseUrl(target: HarnessTarget = "managed"): string {
 }
 
 export function upstreamRequestHeaders(requestHeaders: Headers): Headers {
-  const headers = new Headers(requestHeaders);
-  for (const name of UPSTREAM_REQUEST_HEADERS_TO_REMOVE) headers.delete(name);
+  const headers = new Headers();
+  for (const name of UPSTREAM_REQUEST_HEADER_ALLOWLIST) {
+    const value = requestHeaders.get(name);
+    if (value !== null) headers.set(name, value);
+  }
   return headers;
+}
+
+export function downstreamResponseHeaders(upstreamHeaders: Headers): Headers {
+  const headers = new Headers();
+  for (const name of DOWNSTREAM_RESPONSE_HEADER_ALLOWLIST) {
+    const value = upstreamHeaders.get(name);
+    if (value !== null) headers.set(name, value);
+  }
+  return headers;
+}
+
+function harnessPathSegment(part: string): string {
+  let decoded = part;
+  try {
+    decoded = decodeURIComponent(part);
+  } catch {
+    throw new TypeError("Harness path contains invalid encoding");
+  }
+  if (decoded === "." || decoded === "..") {
+    throw new TypeError("Harness path cannot contain dot segments");
+  }
+  return encodeURIComponent(part);
 }
 
 export function harnessTargetUrl(
@@ -46,7 +67,7 @@ export function harnessTargetUrl(
   namespace: "v1" | "api" = "v1",
   target: HarnessTarget = "managed",
 ): string {
-  const targetPath = path.map((part) => encodeURIComponent(part)).join("/");
+  const targetPath = path.map(harnessPathSegment).join("/");
   return `${harnessBaseUrl(target)}/${namespace}/${targetPath}`;
 }
 
@@ -58,7 +79,15 @@ async function proxyToHarnessNamespace(
   bodyLimitBytes = 256 * 1024,
 ): Promise<Response> {
   const sourceUrl = new URL(request.url);
-  const upstreamTarget = `${harnessTargetUrl(path, namespace, target)}${sourceUrl.search}`;
+  let upstreamTarget: string;
+  try {
+    upstreamTarget = `${harnessTargetUrl(path, namespace, target)}${sourceUrl.search}`;
+  } catch (error) {
+    return Response.json(
+      { error: error instanceof Error ? error.message : "Harness path is invalid" },
+      { status: 400 },
+    );
+  }
   const headers = upstreamRequestHeaders(request.headers);
 
   let body: ArrayBuffer | undefined;
@@ -90,13 +119,9 @@ async function proxyToHarnessNamespace(
     );
   }
 
-  const responseHeaders = new Headers(upstream.headers);
-  responseHeaders.delete("content-length");
-  responseHeaders.delete("content-encoding");
-  responseHeaders.delete("transfer-encoding");
   return new Response(upstream.body, {
     status: upstream.status,
-    headers: responseHeaders,
+    headers: downstreamResponseHeaders(upstream.headers),
   });
 }
 

--- a/frontend/src/app/harness/page.tsx
+++ b/frontend/src/app/harness/page.tsx
@@ -1,0 +1,5 @@
+import HarnessPage from "@/features/harness/harness-page";
+
+export default function Page() {
+  return <HarnessPage />;
+}

--- a/frontend/src/app/harness/page.tsx
+++ b/frontend/src/app/harness/page.tsx
@@ -1,5 +1,11 @@
 import HarnessPage from "@/features/harness/harness-page";
+import { initialHarnessObjective } from "@/features/harness/harness-page-model";
 
-export default function Page() {
-  return <HarnessPage />;
+type PageProps = {
+  searchParams: Promise<{ objective?: string | string[] }>;
+};
+
+export default async function Page({ searchParams }: PageProps) {
+  const { objective } = await searchParams;
+  return <HarnessPage initialGoal={initialHarnessObjective(objective)} />;
 }

--- a/frontend/src/features/agent/composer/builtin-commands.test.ts
+++ b/frontend/src/features/agent/composer/builtin-commands.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { builtinCommandProvider } from "./builtin-commands";
+
+function requiredActions() {
+  return {
+    compact: () => {},
+    openStatus: () => {},
+    toggleBrowserTool: () => {},
+    openPlugins: () => {},
+  };
+}
+
+describe("builtin composer commands", () => {
+  test("opens an evidence-backed Harness goal with the typed objective", async () => {
+    const opened: string[] = [];
+    const provider = builtinCommandProvider({
+      ...requiredActions(),
+      openVerifiedGoal: (objective) => opened.push(objective),
+    });
+    const command = provider.commands().find((entry) => entry.name === "verified");
+    assert.ok(command);
+    assert.deepEqual(
+      await command.run("  Repair and prove it  ", { running: false, compacting: false }),
+      { kind: "handled" },
+    );
+    assert.deepEqual(opened, ["Repair and prove it"]);
+  });
+
+  test("does not advertise Verified Goal without a Harness action", () => {
+    const provider = builtinCommandProvider(requiredActions());
+    assert.equal(
+      provider.commands().some((entry) => entry.name === "verified"),
+      false,
+    );
+  });
+});

--- a/frontend/src/features/agent/composer/builtin-commands.ts
+++ b/frontend/src/features/agent/composer/builtin-commands.ts
@@ -15,6 +15,7 @@ export type BuiltinComposerActions = {
   /** `/goal <objective>` and `/goal pause|resume|clear`. Resolves to an error message or null. */
   goal?: (args: string) => Promise<string | null>;
   enterGoalMode?: () => void;
+  openVerifiedGoal?: (objective: string) => void;
 };
 
 export function builtinCommandProvider(actions: BuiltinComposerActions): ComposerCommandProvider {
@@ -78,6 +79,22 @@ export function builtinCommandProvider(actions: BuiltinComposerActions): Compose
                 }
                 const message = await actions.goal?.(args.trim());
                 return message ? { kind: "error" as const, message } : { kind: "handled" as const };
+              },
+            },
+          ]
+        : []),
+      ...(actions.openVerifiedGoal
+        ? [
+            {
+              id: "builtin:verified",
+              name: "verified",
+              title: "Verified Goal",
+              description: "Run an evidence-backed goal with Agentic Harness",
+              source: "core",
+              icon: "command" as const,
+              run: (args: string) => {
+                actions.openVerifiedGoal?.(args.trim());
+                return { kind: "handled" as const };
               },
             },
           ]

--- a/frontend/src/features/agent/ui/chat-pane.tsx
+++ b/frontend/src/features/agent/ui/chat-pane.tsx
@@ -504,6 +504,10 @@ export function ChatPane({
           ...(canExport ? { exportSession } : {}),
           goal: goalAction,
           enterGoalMode: () => setGoalModeOn(true),
+          openVerifiedGoal: (objective) =>
+            router.push(
+              objective ? `/harness?objective=${encodeURIComponent(objective)}` : "/harness",
+            ),
         }),
         promptTemplateCommandProvider({
           templates: tools.promptTemplateCatalogue,

--- a/frontend/src/features/harness/harness-page-model.test.ts
+++ b/frontend/src/features/harness/harness-page-model.test.ts
@@ -120,6 +120,8 @@ describe("goal prompt and outcome helpers", () => {
       goalStartBlocker({
         goal: "",
         backend: "managed",
+        integrationReady: true,
+        remoteDataConsent: true,
         providerConfigured: true,
         setupLoading: false,
       }) ?? "",
@@ -129,6 +131,8 @@ describe("goal prompt and outcome helpers", () => {
       goalStartBlocker({
         goal: "Review the provider",
         backend: "provider",
+        integrationReady: true,
+        remoteDataConsent: true,
         providerConfigured: false,
         setupLoading: false,
       }) ?? "",
@@ -138,6 +142,8 @@ describe("goal prompt and outcome helpers", () => {
       goalStartBlocker({
         goal: "Review the provider",
         backend: "managed",
+        integrationReady: true,
+        remoteDataConsent: true,
         providerConfigured: true,
         setupLoading: false,
       }),
@@ -149,6 +155,8 @@ describe("goal prompt and outcome helpers", () => {
     const blocker = goalStartBlocker({
       goal: "Review the provider",
       backend: "managed",
+      integrationReady: true,
+      remoteDataConsent: true,
       providerConfigured: true,
       setupLoading: false,
       activeTaskStatus: "working",
@@ -157,11 +165,38 @@ describe("goal prompt and outcome helpers", () => {
     assert.match(String(blocker), /shared workspace/i);
   });
 
+  test("external Harness readiness and consent both fail closed", () => {
+    assert.match(
+      goalStartBlocker({
+        goal: "Review the provider",
+        backend: "managed",
+        integrationReady: false,
+        remoteDataConsent: true,
+        providerConfigured: true,
+        setupLoading: false,
+      }) ?? "",
+      /not ready/i,
+    );
+    assert.match(
+      goalStartBlocker({
+        goal: "Review the provider",
+        backend: "managed",
+        integrationReady: true,
+        remoteDataConsent: false,
+        providerConfigured: true,
+        setupLoading: false,
+      }) ?? "",
+      /data boundary/i,
+    );
+  });
+
   test("a terminal current task does not block a new goal", () => {
     assert.equal(
       goalStartBlocker({
         goal: "Review the provider",
         backend: "managed",
+        integrationReady: true,
+        remoteDataConsent: true,
         providerConfigured: true,
         setupLoading: false,
         activeTaskStatus: "done",
@@ -170,10 +205,132 @@ describe("goal prompt and outcome helpers", () => {
     );
   });
 
-  test("does not call a done task verified when it has no recorded checks", () => {
+  test("does not call a done task verified when it has no structured checks", () => {
     const outcome = describeGoalOutcome({ id: "task-1", status: "done" });
     assert.equal(outcome?.state, "unverified");
-    assert.match(outcome?.headline ?? "", /without verification/);
+    assert.match(outcome?.headline ?? "", /not verified/);
+    assert.match(outcome?.detail ?? "", /no structured verification checks/i);
+  });
+
+  test("legacy verification text never becomes a successful verdict", () => {
+    const outcome = describeGoalOutcome({
+      id: "task-legacy",
+      status: "done",
+      result_category: "verified_done",
+      final_result: { accepted: true },
+      metadata: {
+        observed_at: "2026-08-04T12:00:00Z",
+        updated_at: "2026-08-04T12:00:00Z",
+      },
+      verification: ["pytest passed"],
+    });
+    assert.equal(outcome?.state, "unverified");
+    assert.match(outcome?.detail ?? "", /legacy text or a malformed/i);
+  });
+
+  test("a failed structured check fails closed", () => {
+    const outcome = describeGoalOutcome({
+      id: "task-failed-check",
+      status: "done",
+      result_category: "verified_done",
+      final_result: { accepted: true },
+      metadata: {
+        observed_at: "2026-08-04T12:00:00Z",
+        updated_at: "2026-08-04T12:00:00Z",
+      },
+      verification: [
+        {
+          name: "tests",
+          passed: false,
+          independent: true,
+          source: "independent",
+        },
+      ],
+    });
+    assert.equal(outcome?.state, "unverified");
+    assert.match(outcome?.detail ?? "", /failed or requires review/i);
+  });
+
+  test("an independent structured receipt with a fresh accepted verdict is verified", () => {
+    const outcome = describeGoalOutcome({
+      id: "task-provider-pass",
+      status: "done",
+      result_category: "verified_done",
+      final_result: { accepted: true },
+      metadata: {
+        observed_at: "2026-08-04T12:00:01Z",
+        updated_at: "2026-08-04T12:00:00Z",
+      },
+      verification: [
+        {
+          name: "tests",
+          passed: true,
+          independent: true,
+          source: "independent",
+        },
+      ],
+    });
+    assert.equal(outcome?.state, "complete");
+    assert.match(outcome?.headline ?? "", /verified complete/i);
+  });
+
+  test("accepted managed-route provenance can carry deterministic structured checks", () => {
+    const outcome = describeGoalOutcome({
+      id: "task-managed-pass",
+      status: "done",
+      result_category: "verified_done",
+      final_result: { accepted: true },
+      metadata: {
+        updated_at: "2026-08-04T12:00:00Z",
+        route_receipt: {
+          contract: "agentic_harness.managed_route_receipt.v1",
+          actual: true,
+          evidence: "observed",
+          status: "accepted",
+          reviewer: "managed deterministic review",
+          observed_at: "2026-08-04T12:00:01Z",
+        },
+      },
+      verification: [
+        {
+          name: "workspace tests",
+          passed: true,
+          independent: false,
+          source: "managed-review",
+        },
+      ],
+    });
+    assert.equal(outcome?.state, "complete");
+  });
+
+  test("stale managed-route provenance fails closed", () => {
+    const outcome = describeGoalOutcome({
+      id: "task-stale",
+      status: "done",
+      result_category: "verified_done",
+      final_result: { accepted: true },
+      metadata: {
+        updated_at: "2026-08-04T12:00:02Z",
+        route_receipt: {
+          contract: "agentic_harness.managed_route_receipt.v1",
+          actual: true,
+          evidence: "observed",
+          status: "accepted",
+          reviewer: "managed deterministic review",
+          observed_at: "2026-08-04T12:00:01Z",
+        },
+      },
+      verification: [
+        {
+          name: "workspace tests",
+          passed: true,
+          independent: false,
+          source: "managed-review",
+        },
+      ],
+    });
+    assert.equal(outcome?.state, "unverified");
+    assert.match(outcome?.detail ?? "", /older than the completed task state/i);
   });
 
   test("treats a provider failure as terminal and actionable", () => {

--- a/frontend/src/features/harness/harness-page-model.test.ts
+++ b/frontend/src/features/harness/harness-page-model.test.ts
@@ -4,6 +4,7 @@ import {
   TERMINAL_TASK_STATUSES,
   describeGoalOutcome,
   goalStartBlocker,
+  initialHarnessObjective,
   isTerminalTaskStatus,
   resolveTaskEnvelope,
   stripGoalCommandPrefix,
@@ -91,6 +92,15 @@ describe("isTerminalTaskStatus", () => {
     for (const status of ["working", "checking", "starting", "queued", "", undefined]) {
       assert.equal(isTerminalTaskStatus(status), false, `${String(status)} must not be terminal`);
     }
+  });
+});
+
+describe("initialHarnessObjective", () => {
+  test("accepts one Workbench objective while rejecting ambiguous query values", () => {
+    assert.equal(initialHarnessObjective("Ship the verified change"), "Ship the verified change");
+    assert.equal(initialHarnessObjective(["first", "second"]), "");
+    assert.equal(initialHarnessObjective(undefined), "");
+    assert.equal(initialHarnessObjective("x".repeat(20_000)).length, 16_384);
   });
 });
 

--- a/frontend/src/features/harness/harness-page-model.test.ts
+++ b/frontend/src/features/harness/harness-page-model.test.ts
@@ -75,7 +75,13 @@ describe("resolveTaskEnvelope", () => {
 
 describe("isTerminalTaskStatus", () => {
   test("matches the Harness durable terminal set exactly", () => {
-    assert.deepEqual([...TERMINAL_TASK_STATUSES].sort(), ["blocked", "done", "failed", "stopped"]);
+    assert.deepEqual([...TERMINAL_TASK_STATUSES].sort(), [
+      "blocked",
+      "complete",
+      "done",
+      "failed",
+      "stopped",
+    ]);
     for (const status of TERMINAL_TASK_STATUSES) {
       assert.equal(isTerminalTaskStatus(status), true);
     }

--- a/frontend/src/features/harness/harness-page-model.test.ts
+++ b/frontend/src/features/harness/harness-page-model.test.ts
@@ -1,0 +1,319 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  TERMINAL_TASK_STATUSES,
+  describeGoalOutcome,
+  goalStartBlocker,
+  isTerminalTaskStatus,
+  resolveTaskEnvelope,
+  stripGoalCommandPrefix,
+  startTaskPolling,
+} from "./harness-page-model";
+
+const runningTask = { id: "task-1", status: "working" };
+
+describe("resolveTaskEnvelope", () => {
+  test("prefers the explicit task envelope over everything else", () => {
+    const resolved = resolveTaskEnvelope({
+      task: runningTask,
+      current: { id: "task-2", status: "done" },
+      id: "envelope-id",
+      status: "working",
+    });
+    assert.equal(resolved?.id, "task-1");
+    assert.equal(resolved?.status, "working");
+  });
+
+  test("an envelope carrying both a top-level id and current resolves to current", () => {
+    // Regression: `{ id: "req-1", current: {...} }` used to be misread as the
+    // task itself because the old discriminator only checked `payload.id`.
+    const resolved = resolveTaskEnvelope({
+      id: "req-1",
+      current: runningTask,
+    });
+    assert.equal(resolved?.id, "task-1");
+    assert.equal(resolved?.status, "working");
+  });
+
+  test("current still wins even when the envelope itself is task-shaped", () => {
+    const resolved = resolveTaskEnvelope({
+      id: "req-1",
+      status: "working",
+      current: runningTask,
+    });
+    assert.equal(resolved?.id, "task-1");
+  });
+
+  test("an invalid explicit envelope value falls through instead of masking the task", () => {
+    assert.equal(resolveTaskEnvelope({ task: {}, current: runningTask })?.id, "task-1");
+    assert.equal(
+      resolveTaskEnvelope({ task: { id: "half-formed" }, current: runningTask })?.id,
+      "task-1",
+    );
+    // The idle shape: tasks/current answers { current: null, tasks: [...] }.
+    assert.equal(resolveTaskEnvelope({ current: null }), null);
+  });
+
+  test("returns null when every candidate is malformed", () => {
+    assert.equal(resolveTaskEnvelope({ task: {}, current: { id: "", status: "" } }), null);
+    assert.equal(resolveTaskEnvelope({ task: null, current: null, id: "req-9" }), null);
+  });
+
+  test("accepts a bare payload only when it has a valid task shape", () => {
+    assert.equal(resolveTaskEnvelope(runningTask)?.id, "task-1");
+    // id without status is not a task.
+    assert.equal(resolveTaskEnvelope({ id: "req-1" }), null);
+    // status without id is not a task.
+    assert.equal(resolveTaskEnvelope({ status: "working" }), null);
+    // Empty ids/statuses do not count.
+    assert.equal(resolveTaskEnvelope({ id: "", status: "" }), null);
+    // The events envelope ({ task_id, events }) has neither key.
+    assert.equal(resolveTaskEnvelope({ events: [] }), null);
+    assert.equal(resolveTaskEnvelope({}), null);
+  });
+});
+
+describe("isTerminalTaskStatus", () => {
+  test("matches the Harness durable terminal set exactly", () => {
+    assert.deepEqual([...TERMINAL_TASK_STATUSES].sort(), ["blocked", "done", "failed", "stopped"]);
+    for (const status of TERMINAL_TASK_STATUSES) {
+      assert.equal(isTerminalTaskStatus(status), true);
+    }
+  });
+
+  test("active, unknown, and missing statuses keep polling", () => {
+    for (const status of ["working", "checking", "starting", "queued", "", undefined]) {
+      assert.equal(isTerminalTaskStatus(status), false, `${String(status)} must not be terminal`);
+    }
+  });
+});
+
+describe("goal prompt and outcome helpers", () => {
+  test("accepts ordinary prose and strips only a standalone /goal prefix", () => {
+    assert.equal(
+      stripGoalCommandPrefix("  Review the provider flow  "),
+      "Review the provider flow",
+    );
+    assert.equal(stripGoalCommandPrefix("/goal  Fix the prompt flow"), "Fix the prompt flow");
+    assert.equal(stripGoalCommandPrefix("/goalkeeper review"), "/goalkeeper review");
+    assert.equal(stripGoalCommandPrefix(" /goal "), "");
+  });
+
+  test("explains why a goal cannot start instead of leaving a dead button", () => {
+    assert.match(
+      goalStartBlocker({
+        goal: "",
+        backend: "managed",
+        providerConfigured: true,
+        setupLoading: false,
+      }) ?? "",
+      /Type a goal first/,
+    );
+    assert.match(
+      goalStartBlocker({
+        goal: "Review the provider",
+        backend: "provider",
+        providerConfigured: false,
+        setupLoading: false,
+      }) ?? "",
+      /endpoint and model/,
+    );
+    assert.equal(
+      goalStartBlocker({
+        goal: "Review the provider",
+        backend: "managed",
+        providerConfigured: true,
+        setupLoading: false,
+      }),
+      null,
+    );
+  });
+
+  test("an active shared-workspace goal explains why a new goal cannot start", () => {
+    const blocker = goalStartBlocker({
+      goal: "Review the provider",
+      backend: "managed",
+      providerConfigured: true,
+      setupLoading: false,
+      activeTaskStatus: "working",
+    });
+    assert.match(String(blocker), /another goal is already running/i);
+    assert.match(String(blocker), /shared workspace/i);
+  });
+
+  test("a terminal current task does not block a new goal", () => {
+    assert.equal(
+      goalStartBlocker({
+        goal: "Review the provider",
+        backend: "managed",
+        providerConfigured: true,
+        setupLoading: false,
+        activeTaskStatus: "done",
+      }),
+      null,
+    );
+  });
+
+  test("does not call a done task verified when it has no recorded checks", () => {
+    const outcome = describeGoalOutcome({ id: "task-1", status: "done" });
+    assert.equal(outcome?.state, "unverified");
+    assert.match(outcome?.headline ?? "", /without verification/);
+  });
+
+  test("treats a provider failure as terminal and actionable", () => {
+    const outcome = describeGoalOutcome({
+      id: "task-2",
+      status: "failed",
+      summary: "Provider stopped with evidence.",
+    });
+    assert.equal(outcome?.state, "blocked");
+    assert.match(outcome?.headline ?? "", /failed/i);
+    assert.match(outcome?.detail ?? "", /Provider stopped/);
+  });
+});
+
+type Deferred = {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+};
+
+function deferred(): Deferred {
+  let resolve!: () => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function manualTimers() {
+  const pending: Array<{ id: number; fn: () => void }> = [];
+  let nextId = 1;
+  return {
+    schedule(fn: () => void, _ms: number): number {
+      const id = nextId++;
+      pending.push({ id, fn });
+      return id;
+    },
+    clearSchedule(id: number): void {
+      const index = pending.findIndex((timer) => timer.id === id);
+      if (index >= 0) pending.splice(index, 1);
+    },
+    fire(): void {
+      const next = pending.shift();
+      assert.ok(next, "expected a pending timer to fire");
+      next.fn();
+    },
+    get count(): number {
+      return pending.length;
+    },
+  };
+}
+
+const settle = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+describe("startTaskPolling", () => {
+  test("serializes polls and re-arms only after the load settles", async () => {
+    const timers = manualTimers();
+    const gate = deferred();
+    const seen: AbortSignal[] = [];
+    const stop = startTaskPolling({
+      intervalMs: 3000,
+      load: (signal) => {
+        seen.push(signal);
+        return gate.promise;
+      },
+      onError: () => assert.fail("no error expected"),
+      schedule: timers.schedule,
+      clearSchedule: timers.clearSchedule,
+    });
+
+    assert.equal(timers.count, 1, "arms an initial timer");
+    timers.fire();
+    assert.equal(seen.length, 1);
+    assert.equal(timers.count, 0, "must not re-arm while a load is in flight");
+
+    gate.resolve();
+    await settle();
+    assert.equal(timers.count, 1, "re-arms after the load settles");
+
+    stop();
+    assert.equal(timers.count, 0, "stop clears the pending timer");
+  });
+
+  test("reports transient errors and keeps polling", async () => {
+    const timers = manualTimers();
+    const errors: unknown[] = [];
+    let attempts = 0;
+    const stop = startTaskPolling({
+      intervalMs: 3000,
+      load: () => {
+        attempts += 1;
+        return Promise.reject(new Error(`boom ${attempts}`));
+      },
+      onError: (error) => errors.push(error),
+      schedule: timers.schedule,
+      clearSchedule: timers.clearSchedule,
+    });
+
+    timers.fire();
+    await settle();
+    assert.equal(errors.length, 1);
+    assert.equal(timers.count, 1, "keeps polling after an error");
+
+    timers.fire();
+    await settle();
+    assert.equal(errors.length, 2);
+
+    stop();
+    assert.equal(timers.count, 0);
+  });
+
+  test("stop aborts the in-flight load and suppresses its error", async () => {
+    const timers = manualTimers();
+    const gate = deferred();
+    const seen: AbortSignal[] = [];
+    const errors: unknown[] = [];
+    const stop = startTaskPolling({
+      intervalMs: 3000,
+      load: (signal) => {
+        seen.push(signal);
+        return gate.promise;
+      },
+      onError: (error) => errors.push(error),
+      schedule: timers.schedule,
+      clearSchedule: timers.clearSchedule,
+    });
+
+    timers.fire();
+    assert.equal(seen[0]?.aborted, false);
+
+    stop();
+    assert.equal(seen[0]?.aborted, true, "stop must abort the in-flight signal");
+
+    gate.reject(new DOMException("The operation was aborted.", "AbortError"));
+    await settle();
+    assert.deepEqual(errors, [], "aborted loads must not surface as errors");
+    assert.equal(timers.count, 0, "no re-arm after stop");
+  });
+
+  test("a load that resolves after stop cannot re-arm the poller", async () => {
+    const timers = manualTimers();
+    const gate = deferred();
+    const stop = startTaskPolling({
+      intervalMs: 3000,
+      load: () => gate.promise,
+      onError: () => assert.fail("no error expected"),
+      schedule: timers.schedule,
+      clearSchedule: timers.clearSchedule,
+    });
+
+    timers.fire();
+    stop();
+    gate.resolve();
+    await settle();
+    assert.equal(timers.count, 0, "stale completion must not restart polling");
+  });
+});

--- a/frontend/src/features/harness/harness-page-model.ts
+++ b/frontend/src/features/harness/harness-page-model.ts
@@ -67,6 +67,10 @@ export type ManagedTaskResponse = Partial<ManagedGoalTask> & {
   events?: ManagedGoalTask["events"];
 };
 
+export function initialHarnessObjective(value: string | string[] | undefined): string {
+  return typeof value === "string" ? value.slice(0, 16_384) : "";
+}
+
 function isTaskShaped(
   candidate: Partial<HarnessTask>,
 ): candidate is Partial<HarnessTask> & { id: string; status: string } {

--- a/frontend/src/features/harness/harness-page-model.ts
+++ b/frontend/src/features/harness/harness-page-model.ts
@@ -1,0 +1,289 @@
+// Pure model logic for the Harness operator surface. Kept framework-free so the
+// envelope discrimination, terminal-status contract, and polling lifecycle can
+// be unit tested without React.
+
+export type HarnessTask = {
+  id?: string;
+  status?: string;
+  status_label?: string;
+  summary?: string;
+  human_title?: string;
+  artifacts?: Array<{ name?: string; path?: string }>;
+  events?: Array<{ seq?: number; summary?: string; checkpoint?: string }>;
+  metadata?: {
+    demo?: { enabled?: boolean; model_used?: boolean; workspace?: string };
+    integration?: {
+      kind?: string;
+      route_id?: string;
+      model_id?: string;
+      node?: string;
+      runtime?: string;
+      model_used?: boolean;
+      connected_workspace_mutated?: boolean;
+    };
+  };
+};
+
+// The Harness GUI server answers with three envelope shapes:
+//   tasks/current      -> { current, tasks }
+//   tasks/{id}         -> { api_version, task, owner }
+//   tasks/{id}/events  -> { api_version, task_id, events }
+// Older builds returned the bare task object. TaskResponse tolerates all of
+// them; resolveTaskEnvelope decides which one we are looking at.
+export type TaskResponse = Partial<HarnessTask> & {
+  task?: HarnessTask | null;
+  current?: HarnessTask | null;
+  events?: HarnessTask["events"];
+};
+
+export type ManagedGoalTask = HarnessTask & {
+  objective?: string;
+  mode?: string;
+  execution_profile?: string;
+  needs_human?: boolean;
+  review_status?: string;
+  changed_files?: string[];
+  verification?: string[];
+  progress?: { label?: string; percent?: number; determinate?: boolean };
+  current?: { checkpoint?: string; current_subgoal?: string; cycle?: number };
+  readiness_gate?: {
+    can_start?: boolean;
+    can_queue?: boolean;
+    state?: string;
+    label?: string;
+    next_action?: string;
+    summary?: string;
+    requires_review?: boolean;
+  };
+  advanced_details?: {
+    payload?: { events?: HarnessTask["events"] };
+    last_run?: { run_dir?: string; prompt_path?: string };
+  };
+};
+
+export type ManagedTaskResponse = Partial<ManagedGoalTask> & {
+  task?: ManagedGoalTask | null;
+  current?: ManagedGoalTask | null;
+  events?: ManagedGoalTask["events"];
+};
+
+function isTaskShaped(
+  candidate: Partial<HarnessTask>,
+): candidate is Partial<HarnessTask> & { id: string; status: string } {
+  return (
+    typeof candidate.id === "string" &&
+    candidate.id.length > 0 &&
+    typeof candidate.status === "string" &&
+    candidate.status.length > 0
+  );
+}
+
+/** Explicit `task` / `current` envelopes win, in that order, but only when the
+ *  value actually looks like a task (non-empty id AND status). Every valid
+ *  Harness response serializes both fields, so this rejects only malformed
+ *  values — `current: null` while idle, `task: {}` from a broken upstream —
+ *  and lets them fall through to the next candidate instead of masking it.
+ *  The top-level payload is checked last so an envelope that happens to carry
+ *  a top-level id (e.g. a request id next to `current`) can never shadow the
+ *  real task. */
+export function resolveTaskEnvelope(payload: TaskResponse): HarnessTask | null {
+  for (const candidate of [payload.task, payload.current, payload]) {
+    if (candidate && isTaskShaped(candidate)) return candidate;
+  }
+  return null;
+}
+
+// Task statuses come from the managed and provider Harness adapters:
+// done | stopped | blocked | failed | checking | starting | working. The
+// durable terminal set includes provider failures because a failed worker run
+// is complete evidence and must not block a fresh goal.
+// Unknown/future statuses are treated as active so we keep polling — the safe
+// default for states we have never seen.
+export const TERMINAL_TASK_STATUSES: ReadonlySet<string> = new Set([
+  "done",
+  "stopped",
+  "blocked",
+  "failed",
+]);
+
+export function isTerminalTaskStatus(status: string | undefined): boolean {
+  return status !== undefined && TERMINAL_TASK_STATUSES.has(status);
+}
+
+export type GoalBackendKind = "managed" | "provider";
+
+/** The prompt box accepts an ordinary sentence; `/goal` is an optional
+ *  Codex-style prefix. Stripping it here keeps the submit path and its tests
+ *  in agreement about what counts as an empty objective. */
+export function stripGoalCommandPrefix(raw: string): string {
+  return raw
+    .trim()
+    .replace(/^\/goal(?:\s+|$)/i, "")
+    .trim();
+}
+
+export type GoalStartInput = {
+  goal: string;
+  backend: GoalBackendKind;
+  /** `setup.configured` for the currently selected backend. Callers must pass
+   *  `false` while the setup payload is unknown so the gate fails closed. */
+  providerConfigured: boolean;
+  setupLoading: boolean;
+  /** Current task status for the selected shared workspace, when known. */
+  activeTaskStatus?: string;
+};
+
+/** Why a goal cannot start yet, phrased for a first-time user, or null when it
+ *  can. Returning a reason (instead of only disabling the button) is what makes
+ *  the empty-prompt and unconfigured-provider cases explainable rather than a
+ *  dead control. Provider copy stays generic: no host, path, or node names. */
+export function goalStartBlocker(input: GoalStartInput): string | null {
+  if (input.setupLoading) return "Loading goal setup…";
+  const objective = stripGoalCommandPrefix(input.goal);
+  if (!objective) {
+    return input.goal.trim()
+      ? "Add an objective after /goal, for example: /goal summarise the open issues."
+      : "Type a goal first. You can start it with /goal.";
+  }
+  if (input.backend === "provider" && !input.providerConfigured) {
+    return "Add an endpoint and model under Model provider, then save, before starting a goal.";
+  }
+  if (
+    input.activeTaskStatus &&
+    !isTerminalTaskStatus(input.activeTaskStatus) &&
+    input.activeTaskStatus !== "needs_review" &&
+    input.activeTaskStatus !== "ready"
+  ) {
+    return "Another goal is already running in this shared workspace. Continue or stop it before starting a new one.";
+  }
+  return null;
+}
+
+export type GoalOutcomeTone = "default" | "good" | "warning" | "danger";
+
+export type GoalOutcome = {
+  state: "running" | "needs_review" | "stopped" | "blocked" | "complete" | "unverified";
+  tone: GoalOutcomeTone;
+  headline: string;
+  detail: string;
+};
+
+/** Plain-language terminal state for the goal card.
+ *
+ *  Completion honesty: "verified" is only claimed when the Harness actually
+ *  recorded verification checks on the task. A `done` task with no checks is
+ *  reported as finished-but-unverified, never as verified, so UI prose can
+ *  never outrun the evidence contract. Check counts are described as
+ *  "recorded" because the task payload carries the checks, not their verdicts. */
+export function describeGoalOutcome(task: ManagedGoalTask | null): GoalOutcome | null {
+  if (!task?.id) return null;
+  const status = task.status ?? "";
+  const summary = task.summary?.trim();
+  const checks = task.verification?.length ?? 0;
+  const files = task.changed_files?.length ?? 0;
+
+  if (status === "done" || status === "complete") {
+    if (checks === 0) {
+      return {
+        state: "unverified",
+        tone: "warning",
+        headline: "Finished without verification evidence",
+        detail:
+          summary ??
+          "The harness recorded no verification checks for this goal, so it is not a verified completion.",
+      };
+    }
+    return {
+      state: "complete",
+      tone: "good",
+      headline: "Goal complete with recorded evidence",
+      detail: `${checks} verification check${checks === 1 ? "" : "s"} recorded · ${files} changed file${
+        files === 1 ? "" : "s"
+      }.`,
+    };
+  }
+  if (status === "stopped") {
+    return {
+      state: "stopped",
+      tone: "warning",
+      headline: "Goal stopped",
+      detail: summary ?? "This goal was stopped before it finished. Start a new goal to continue.",
+    };
+  }
+  if (status === "blocked") {
+    return {
+      state: "blocked",
+      tone: "danger",
+      headline: "Goal blocked",
+      detail:
+        summary ?? "The harness could not continue. Add feedback below and continue the goal.",
+    };
+  }
+  if (status === "failed") {
+    return {
+      state: "blocked",
+      tone: "danger",
+      headline: "Goal failed",
+      detail:
+        summary ?? "The provider could not complete this goal. Start a new goal to try again.",
+    };
+  }
+  if (status === "needs_review") {
+    return {
+      state: "needs_review",
+      tone: "warning",
+      headline: "Waiting for your review",
+      detail: summary ?? "The harness finished a cycle and needs your decision before continuing.",
+    };
+  }
+  return {
+    state: "running",
+    tone: "default",
+    headline: task.progress?.label ?? task.current?.checkpoint ?? "Working",
+    detail: summary ?? "The harness is working on this goal.",
+  };
+}
+
+export type TaskPollerOptions = {
+  intervalMs: number;
+  /** Load one refresh. Receives the poller's AbortSignal; implementations must
+   *  pass it to fetch and stop touching state once it is aborted. */
+  load: (signal: AbortSignal) => Promise<void>;
+  /** Called for load failures, except aborts caused by stopping the poller. */
+  onError: (error: unknown) => void;
+  /** Injectable timers for tests. Default to window timers in the browser. */
+  schedule?: (fn: () => void, ms: number) => number;
+  clearSchedule?: (id: number) => void;
+};
+
+/** Serialized task polling: each cycle waits for the previous load to settle
+ *  before arming the next timer, so requests never overlap; a failed load
+ *  reports the error and keeps polling. The returned stop function clears any
+ *  pending timer, aborts an in-flight load, and guarantees no re-arm and no
+ *  error report afterwards. */
+export function startTaskPolling(options: TaskPollerOptions): () => void {
+  const schedule = options.schedule ?? ((fn, ms) => window.setTimeout(fn, ms));
+  const clearSchedule = options.clearSchedule ?? ((id) => window.clearTimeout(id));
+  const controller = new AbortController();
+  let timer: number | undefined;
+  let stopped = false;
+
+  const tick = async (): Promise<void> => {
+    try {
+      await options.load(controller.signal);
+    } catch (error) {
+      if (!stopped && !controller.signal.aborted) options.onError(error);
+    }
+    if (!stopped) arm();
+  };
+  const arm = (): void => {
+    timer = schedule(() => void tick(), options.intervalMs);
+  };
+  arm();
+
+  return () => {
+    stopped = true;
+    controller.abort();
+    if (timer !== undefined) clearSchedule(timer);
+  };
+}

--- a/frontend/src/features/harness/harness-page-model.ts
+++ b/frontend/src/features/harness/harness-page-model.ts
@@ -1,6 +1,7 @@
-// Pure model logic for the Harness operator surface. Kept framework-free so the
-// envelope discrimination, terminal-status contract, and polling lifecycle can
-// be unit tested without React.
+import {
+  decodeHarnessVerificationCheck,
+  type HarnessVerificationCheck,
+} from "@shared/agent/harness";
 
 export type HarnessTask = {
   id?: string;
@@ -11,6 +12,16 @@ export type HarnessTask = {
   artifacts?: Array<{ name?: string; path?: string }>;
   events?: Array<{ seq?: number; summary?: string; checkpoint?: string }>;
   metadata?: {
+    observed_at?: string;
+    updated_at?: string;
+    route_receipt?: {
+      contract?: string;
+      actual?: boolean;
+      evidence?: string;
+      status?: string;
+      reviewer?: string;
+      observed_at?: string;
+    };
     demo?: { enabled?: boolean; model_used?: boolean; workspace?: string };
     integration?: {
       kind?: string;
@@ -43,7 +54,12 @@ export type ManagedGoalTask = HarnessTask & {
   needs_human?: boolean;
   review_status?: string;
   changed_files?: string[];
-  verification?: string[];
+  verification?: unknown[];
+  result_category?: string;
+  final_result?: {
+    accepted?: boolean;
+    worker_claim?: { trusted?: boolean; label?: string; summary?: string };
+  };
   progress?: { label?: string; percent?: number; determinate?: boolean };
   current?: { checkpoint?: string; current_subgoal?: string; cycle?: number };
   readiness_gate?: {
@@ -130,6 +146,8 @@ export function stripGoalCommandPrefix(raw: string): string {
 export type GoalStartInput = {
   goal: string;
   backend: GoalBackendKind;
+  integrationReady: boolean;
+  remoteDataConsent: boolean;
   /** `setup.configured` for the currently selected backend. Callers must pass
    *  `false` while the setup payload is unknown so the gate fails closed. */
   providerConfigured: boolean;
@@ -144,11 +162,17 @@ export type GoalStartInput = {
  *  dead control. Provider copy stays generic: no host, path, or node names. */
 export function goalStartBlocker(input: GoalStartInput): string | null {
   if (input.setupLoading) return "Loading goal setup…";
+  if (!input.integrationReady) {
+    return "The external Harness is not ready. Ask the host owner to configure and start it, then refresh.";
+  }
   const objective = stripGoalCommandPrefix(input.goal);
   if (!objective) {
     return input.goal.trim()
       ? "Add an objective after /goal, for example: /goal summarise the open issues."
       : "Type a goal first. You can start it with /goal.";
+  }
+  if (!input.remoteDataConsent) {
+    return "Confirm the external Harness data boundary before starting or changing a goal.";
   }
   if (input.backend === "provider" && !input.providerConfigured) {
     return "Add an endpoint and model under Model provider, then save, before starting a goal.";
@@ -173,39 +197,119 @@ export type GoalOutcome = {
   detail: string;
 };
 
-/** Plain-language terminal state for the goal card.
- *
- *  Completion honesty: "verified" is only claimed when the Harness actually
- *  recorded verification checks on the task. A `done` task with no checks is
- *  reported as finished-but-unverified, never as verified, so UI prose can
- *  never outrun the evidence contract. Check counts are described as
- *  "recorded" because the task payload carries the checks, not their verdicts. */
+export type GoalVerificationAssessment = {
+  state: "verified" | "missing" | "failed" | "invalid" | "rejected" | "stale";
+  checks: HarnessVerificationCheck[];
+  detail: string;
+};
+
+function timestamp(value: string | undefined): number | null {
+  if (!value?.trim()) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function managedRouteProvenance(task: ManagedGoalTask): {
+  valid: boolean;
+  observedAt: number | null;
+} {
+  const receipt = task.metadata?.route_receipt;
+  const observedAt = timestamp(receipt?.observed_at);
+  return {
+    valid:
+      receipt?.contract === "agentic_harness.managed_route_receipt.v1" &&
+      receipt.actual === true &&
+      receipt.evidence === "observed" &&
+      receipt.status === "accepted" &&
+      Boolean(receipt.reviewer?.trim()) &&
+      observedAt !== null,
+    observedAt,
+  };
+}
+
+export function assessGoalVerification(task: ManagedGoalTask): GoalVerificationAssessment {
+  const reported = task.verification ?? [];
+  if (reported.length === 0) {
+    return {
+      state: "missing",
+      checks: [],
+      detail: "The Harness returned no structured verification checks.",
+    };
+  }
+  const checks = reported.map(decodeHarnessVerificationCheck);
+  if (checks.some((check) => check === null)) {
+    return {
+      state: "invalid",
+      checks: checks.filter((check): check is HarnessVerificationCheck => check !== null),
+      detail: "The Harness returned legacy text or a malformed verification receipt.",
+    };
+  }
+  const structured = checks as HarnessVerificationCheck[];
+  if (structured.some((check) => !check.passed)) {
+    return {
+      state: "failed",
+      checks: structured,
+      detail: "At least one verification check failed or requires review.",
+    };
+  }
+  if (task.final_result?.accepted !== true || task.result_category !== "verified_done") {
+    return {
+      state: "rejected",
+      checks: structured,
+      detail: "The Harness did not issue an accepted verified-completion verdict.",
+    };
+  }
+  const managed = managedRouteProvenance(task);
+  const independent = structured.some((check) => check.independent);
+  const observedAt = managed.valid ? managed.observedAt : timestamp(task.metadata?.observed_at);
+  const updatedAt = timestamp(task.metadata?.updated_at);
+  if (!independent && !managed.valid) {
+    return {
+      state: "invalid",
+      checks: structured,
+      detail: "The checks have no independent verifier or accepted managed-route provenance.",
+    };
+  }
+  if (observedAt === null || (updatedAt !== null && observedAt < updatedAt)) {
+    return {
+      state: "stale",
+      checks: structured,
+      detail: "The verification provenance is missing or older than the completed task state.",
+    };
+  }
+  return {
+    state: "verified",
+    checks: structured,
+    detail: `${structured.length} structured verification check${structured.length === 1 ? "" : "s"} passed with an accepted verdict and provenance.`,
+  };
+}
+
+function describeCompletedGoal(task: ManagedGoalTask): GoalOutcome {
+  const verification = assessGoalVerification(task);
+  if (verification.state !== "verified") {
+    return {
+      state: "unverified",
+      tone: "warning",
+      headline: "Finished but not verified",
+      detail: verification.detail,
+    };
+  }
+  const files = task.changed_files?.length ?? 0;
+  return {
+    state: "complete",
+    tone: "good",
+    headline: "Goal verified complete",
+    detail: `${verification.checks.length} verification check${verification.checks.length === 1 ? "" : "s"} passed · ${files} changed file${files === 1 ? "" : "s"}.`,
+  };
+}
+
 export function describeGoalOutcome(task: ManagedGoalTask | null): GoalOutcome | null {
   if (!task?.id) return null;
   const status = task.status ?? "";
   const summary = task.summary?.trim();
-  const checks = task.verification?.length ?? 0;
-  const files = task.changed_files?.length ?? 0;
 
   if (status === "done" || status === "complete") {
-    if (checks === 0) {
-      return {
-        state: "unverified",
-        tone: "warning",
-        headline: "Finished without verification evidence",
-        detail:
-          summary ??
-          "The harness recorded no verification checks for this goal, so it is not a verified completion.",
-      };
-    }
-    return {
-      state: "complete",
-      tone: "good",
-      headline: "Goal complete with recorded evidence",
-      detail: `${checks} verification check${checks === 1 ? "" : "s"} recorded · ${files} changed file${
-        files === 1 ? "" : "s"
-      }.`,
-    };
+    return describeCompletedGoal(task);
   }
   if (status === "stopped") {
     return {

--- a/frontend/src/features/harness/harness-page-model.ts
+++ b/frontend/src/features/harness/harness-page-model.ts
@@ -100,6 +100,7 @@ export function resolveTaskEnvelope(payload: TaskResponse): HarnessTask | null {
 // Unknown/future statuses are treated as active so we keep polling — the safe
 // default for states we have never seen.
 export const TERMINAL_TASK_STATUSES: ReadonlySet<string> = new Set([
+  "complete",
   "done",
   "stopped",
   "blocked",

--- a/frontend/src/features/harness/harness-page.tsx
+++ b/frontend/src/features/harness/harness-page.tsx
@@ -102,7 +102,7 @@ function managedTaskFromResponse(payload: ManagedTaskResponse): ManagedGoalTask 
 
 // The page coordinates route, task, event, and evidence state in one operator surface.
 // eslint-disable-next-line complexity
-export default function HarnessPage() {
+export default function HarnessPage({ initialGoal = "" }: { initialGoal?: string }) {
   const [routes, setRoutes] = useState<HarnessRoute[]>([]);
   const [selectionPolicy, setSelectionPolicy] = useState("harness_decides");
   const [selectedRoute, setSelectedRoute] = useState("auto");
@@ -111,10 +111,10 @@ export default function HarnessPage() {
   const [loading, setLoading] = useState(true);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState("");
-  const [goal, setGoal] = useState("");
+  const [goal, setGoal] = useState(initialGoal);
   const [goalBackend, setGoalBackend] = useState<GoalBackend>("managed");
   const [goalMode, setGoalMode] = useState("local");
-  const [goalProfile, setGoalProfile] = useState("qwen-primary");
+  const [goalProfile, setGoalProfile] = useState("");
   const [goalFeedback, setGoalFeedback] = useState("");
   const [managedTask, setManagedTask] = useState<ManagedGoalTask | null>(null);
   const [managedEvents, setManagedEvents] = useState<NonNullable<HarnessTask["events"]>>([]);
@@ -205,6 +205,12 @@ export default function HarnessPage() {
       setGoalMode((current) =>
         availableModes.some((mode) => mode.key === current) ? current : fallbackMode,
       );
+      const availableProfiles = modesPayload.execution_profiles ?? [];
+      const fallbackProfile =
+        modesPayload.default_execution_profile ?? availableProfiles[0]?.key ?? "";
+      setGoalProfile((current) =>
+        availableProfiles.some((profile) => profile.key === current) ? current : fallbackProfile,
+      );
       if (backend === "provider") {
         // Switching into the provider lane must reflect that lane's saved
         // setup, not stale values left in the form by a previous selection.
@@ -292,7 +298,11 @@ export default function HarnessPage() {
         body: JSON.stringify(
           goalBackend === "provider"
             ? { objective, strategy: goalMode }
-            : { objective, mode: goalMode, execution_profile: goalProfile },
+            : {
+                objective,
+                mode: goalMode,
+                ...(goalProfile ? { execution_profile: goalProfile } : {}),
+              },
         ),
       });
       const nextTask = managedTaskFromResponse(payload);
@@ -380,7 +390,7 @@ export default function HarnessPage() {
     }
   };
 
-  const node1GoalMode: ManagedMode = {
+  const managedGoalMode: ManagedMode = {
     ...(managedModes.find((mode) => mode.key === "local") ?? {
       key: "local",
       label: "Managed goal loop",
@@ -401,7 +411,7 @@ export default function HarnessPage() {
   const selectedMode =
     goalBackend === "provider"
       ? (providerModeOptions.find((mode) => mode.key === goalMode) ?? providerModeOptions[0])
-      : node1GoalMode;
+      : managedGoalMode;
 
   const startBlocker = goalStartBlocker({
     goal,
@@ -509,9 +519,7 @@ export default function HarnessPage() {
                 rows={5}
                 placeholder="Describe the outcome in plain language, for example: Review the Local Studio integration, make a bounded improvement, and verify it end to end."
                 aria-describedby={
-                  showStartBlocker
-                    ? "harness-goal-hint harness-goal-blocker"
-                    : "harness-goal-hint"
+                  showStartBlocker ? "harness-goal-hint harness-goal-blocker" : "harness-goal-hint"
                 }
                 aria-invalid={Boolean(goalError && !goal.trim())}
                 className="mt-2 block w-full resize-y rounded-xl border border-(--ui-border) bg-(--ui-bg) px-3 py-3 text-[length:var(--fs-md)] leading-relaxed text-(--ui-fg) outline-none transition focus:border-(--ui-accent) focus:ring-2 focus:ring-(--ui-accent)/20"
@@ -595,7 +603,7 @@ export default function HarnessPage() {
                     className="mt-2 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
                     disabled={goalBusy}
                   >
-                    {(goalBackend === "provider" ? providerModeOptions : [node1GoalMode]).map(
+                    {(goalBackend === "provider" ? providerModeOptions : [managedGoalMode]).map(
                       (mode) => (
                         <option key={mode.key} value={mode.key}>
                           {mode.label}
@@ -1006,106 +1014,106 @@ export default function HarnessPage() {
             </Button>
           </div>
           <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1.45fr)_minmax(18rem,0.8fr)]">
-          <Card
-            title="Live route registry"
-            description={`Harness-owned live probes · selection policy: ${selectionPolicy}`}
-          >
-            {loading && routes.length === 0 ? (
-              <p className="text-[length:var(--fs-sm)] text-(--ui-muted)">
-                Checking Node1 and Node2...
-              </p>
-            ) : routes.length === 0 ? (
-              <p className="text-[length:var(--fs-sm)] text-(--ui-muted)">No routes reported.</p>
-            ) : (
-              <div className="divide-y divide-(--ui-border)">
-                {routes.map((route) => (
-                  <div
-                    key={route.id}
-                    className="grid gap-3 py-3 first:pt-0 last:pb-0 sm:grid-cols-[1fr_auto] sm:items-center"
-                  >
-                    <div className="min-w-0">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <GitBranch className="h-4 w-4 text-(--ui-muted)" />
-                        <span className="truncate text-[length:var(--fs-md)] font-medium text-(--ui-fg)">
-                          {route.model_id}
-                        </span>
-                        <StatusPill tone={toneForStatus(route.status)} variant="badge">
-                          {route.status}
-                        </StatusPill>
-                      </div>
-                      <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[length:var(--fs-xs)] text-(--ui-muted)">
-                        <span>{route.node}</span>
-                        <span>{route.runtime}</span>
-                        <span>{route.role}</span>
-                        <span>{formatContext(route.max_context_tokens)}</span>
-                      </div>
-                    </div>
-                    <div className="flex flex-wrap gap-1 sm:justify-end">
-                      {route.capabilities.map((capability) => (
-                        <span
-                          key={capability}
-                          className="rounded-full bg-(--ui-fg)/5 px-2 py-1 text-[length:var(--fs-xs)] text-(--ui-muted)"
-                        >
-                          {capability}
-                        </span>
-                      ))}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-          </Card>
-
-          <Card title="Ownership boundary" description="The two products have different jobs.">
-            <div className="space-y-3 text-[length:var(--fs-sm)]">
-              <BoundaryRow
-                icon={<ShieldCheck className="h-4 w-4" />}
-                label="Harness"
-                value="Executor, router, durable state, events, artifacts"
-              />
-              <BoundaryRow
-                icon={<GitBranch className="h-4 w-4" />}
-                label="Local Studio"
-                value="Operator UI and model/chat surface"
-              />
-              <div className="rounded-xl bg-(--ui-fg)/5 p-3 text-[length:var(--fs-xs)] leading-relaxed text-(--ui-muted)">
-                The safe canary is credential-free. Model analysis uses the selected vLLM route in a
-                temporary isolated workspace with write tools disabled.
-              </div>
-              <div className="rounded-xl border border-(--ui-border) p-3">
-                <label
-                  htmlFor="harness-route"
-                  className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)"
-                >
-                  Model route
-                </label>
-                <select
-                  id="harness-route"
-                  value={selectedRoute}
-                  onChange={(event) => setSelectedRoute(event.target.value)}
-                  className="mt-2 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
-                >
-                  <option value="auto">Auto: Node1 primary, Node2 overflow</option>
+            <Card
+              title="Live route registry"
+              description={`Harness-owned live probes · selection policy: ${selectionPolicy}`}
+            >
+              {loading && routes.length === 0 ? (
+                <p className="text-[length:var(--fs-sm)] text-(--ui-muted)">
+                  Checking configured routes...
+                </p>
+              ) : routes.length === 0 ? (
+                <p className="text-[length:var(--fs-sm)] text-(--ui-muted)">No routes reported.</p>
+              ) : (
+                <div className="divide-y divide-(--ui-border)">
                   {routes.map((route) => (
-                    <option key={route.id} value={route.id} disabled={route.status !== "ready"}>
-                      {route.node} · {route.model_id} ({route.status})
-                    </option>
+                    <div
+                      key={route.id}
+                      className="grid gap-3 py-3 first:pt-0 last:pb-0 sm:grid-cols-[1fr_auto] sm:items-center"
+                    >
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <GitBranch className="h-4 w-4 text-(--ui-muted)" />
+                          <span className="truncate text-[length:var(--fs-md)] font-medium text-(--ui-fg)">
+                            {route.model_id}
+                          </span>
+                          <StatusPill tone={toneForStatus(route.status)} variant="badge">
+                            {route.status}
+                          </StatusPill>
+                        </div>
+                        <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[length:var(--fs-xs)] text-(--ui-muted)">
+                          <span>{route.node}</span>
+                          <span>{route.runtime}</span>
+                          <span>{route.role}</span>
+                          <span>{formatContext(route.max_context_tokens)}</span>
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap gap-1 sm:justify-end">
+                        {route.capabilities.map((capability) => (
+                          <span
+                            key={capability}
+                            className="rounded-full bg-(--ui-fg)/5 px-2 py-1 text-[length:var(--fs-xs)] text-(--ui-muted)"
+                          >
+                            {capability}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
                   ))}
-                </select>
-                <Button
-                  className="mt-3 w-full"
-                  variant="secondary"
-                  size="sm"
-                  icon={<Play className="h-3.5 w-3.5" />}
-                  loading={running}
-                  disabled={running}
-                  onClick={() => void runAnalysis()}
-                >
-                  Run vLLM analysis
-                </Button>
+                </div>
+              )}
+            </Card>
+
+            <Card title="Ownership boundary" description="The two products have different jobs.">
+              <div className="space-y-3 text-[length:var(--fs-sm)]">
+                <BoundaryRow
+                  icon={<ShieldCheck className="h-4 w-4" />}
+                  label="Harness"
+                  value="Executor, router, durable state, events, artifacts"
+                />
+                <BoundaryRow
+                  icon={<GitBranch className="h-4 w-4" />}
+                  label="Local Studio"
+                  value="Operator UI and model/chat surface"
+                />
+                <div className="rounded-xl bg-(--ui-fg)/5 p-3 text-[length:var(--fs-xs)] leading-relaxed text-(--ui-muted)">
+                  The safe canary is credential-free. Model analysis uses the selected vLLM route in
+                  a temporary isolated workspace with write tools disabled.
+                </div>
+                <div className="rounded-xl border border-(--ui-border) p-3">
+                  <label
+                    htmlFor="harness-route"
+                    className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)"
+                  >
+                    Model route
+                  </label>
+                  <select
+                    id="harness-route"
+                    value={selectedRoute}
+                    onChange={(event) => setSelectedRoute(event.target.value)}
+                    className="mt-2 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
+                  >
+                    <option value="auto">Auto: let the Harness choose</option>
+                    {routes.map((route) => (
+                      <option key={route.id} value={route.id} disabled={route.status !== "ready"}>
+                        {route.node} · {route.model_id} ({route.status})
+                      </option>
+                    ))}
+                  </select>
+                  <Button
+                    className="mt-3 w-full"
+                    variant="secondary"
+                    size="sm"
+                    icon={<Play className="h-3.5 w-3.5" />}
+                    loading={running}
+                    disabled={running}
+                    onClick={() => void runAnalysis()}
+                  >
+                    Run vLLM analysis
+                  </Button>
+                </div>
               </div>
-            </div>
-          </Card>
+            </Card>
           </div>
 
           <Card
@@ -1113,67 +1121,67 @@ export default function HarnessPage() {
             title="Diagnostic task"
             description="Canary and read-only model checks return task evidence through the integration API."
           >
-          {!task?.id ? (
-            <p className="text-[length:var(--fs-sm)] text-(--ui-muted)">No task loaded.</p>
-          ) : (
-            <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_minmax(16rem,0.6fr)]">
-              <div>
-                <div className="flex flex-wrap items-center gap-2">
-                  <StatusPill tone={toneForStatus(task.status ?? "")} variant="badge">
-                    {task.status_label ?? task.status ?? "unknown"}
-                  </StatusPill>
-                  <code className="text-[length:var(--fs-xs)] text-(--ui-muted)">{task.id}</code>
-                </div>
-                <p className="mt-3 text-[length:var(--fs-sm)] text-(--ui-fg)">
-                  {task.summary ?? task.human_title}
-                </p>
-                {task.metadata?.integration ? (
-                  <div className="mt-3 flex flex-wrap gap-2 text-[length:var(--fs-xs)] text-(--ui-muted)">
-                    <span>
-                      {task.metadata.integration.node} · {task.metadata.integration.model_id}
-                    </span>
-                    <span>{task.metadata.integration.runtime}</span>
-                    <span>read-only</span>
-                    <span>
-                      workspace{" "}
-                      {task.metadata.integration.connected_workspace_mutated
-                        ? "changed"
-                        : "unchanged"}
-                    </span>
+            {!task?.id ? (
+              <p className="text-[length:var(--fs-sm)] text-(--ui-muted)">No task loaded.</p>
+            ) : (
+              <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_minmax(16rem,0.6fr)]">
+                <div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <StatusPill tone={toneForStatus(task.status ?? "")} variant="badge">
+                      {task.status_label ?? task.status ?? "unknown"}
+                    </StatusPill>
+                    <code className="text-[length:var(--fs-xs)] text-(--ui-muted)">{task.id}</code>
                   </div>
-                ) : null}
-                <div className="mt-4 space-y-2">
-                  {(events ?? []).slice(-6).map((event, index) => (
-                    <div
-                      key={`${event.seq ?? index}-${event.checkpoint ?? "event"}`}
-                      className="flex gap-2 text-[length:var(--fs-xs)] text-(--ui-muted)"
-                    >
-                      <span className="shrink-0 tabular-nums">{event.seq ?? "·"}</span>
-                      <span>{event.summary ?? event.checkpoint ?? "Harness event"}</span>
+                  <p className="mt-3 text-[length:var(--fs-sm)] text-(--ui-fg)">
+                    {task.summary ?? task.human_title}
+                  </p>
+                  {task.metadata?.integration ? (
+                    <div className="mt-3 flex flex-wrap gap-2 text-[length:var(--fs-xs)] text-(--ui-muted)">
+                      <span>
+                        {task.metadata.integration.node} · {task.metadata.integration.model_id}
+                      </span>
+                      <span>{task.metadata.integration.runtime}</span>
+                      <span>read-only</span>
+                      <span>
+                        workspace{" "}
+                        {task.metadata.integration.connected_workspace_mutated
+                          ? "changed"
+                          : "unchanged"}
+                      </span>
                     </div>
-                  ))}
+                  ) : null}
+                  <div className="mt-4 space-y-2">
+                    {(events ?? []).slice(-6).map((event, index) => (
+                      <div
+                        key={`${event.seq ?? index}-${event.checkpoint ?? "event"}`}
+                        className="flex gap-2 text-[length:var(--fs-xs)] text-(--ui-muted)"
+                      >
+                        <span className="shrink-0 tabular-nums">{event.seq ?? "·"}</span>
+                        <span>{event.summary ?? event.checkpoint ?? "Harness event"}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+                <div className="rounded-xl bg-(--ui-fg)/5 p-3">
+                  <div className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)">
+                    Evidence
+                  </div>
+                  <div className="mt-2 text-[length:var(--fs-sm)] text-(--ui-fg)">
+                    {task.artifacts?.length ?? 0} artifact{task.artifacts?.length === 1 ? "" : "s"}
+                  </div>
+                  <div className="mt-2 space-y-1">
+                    {(task.artifacts ?? []).map((artifact) => (
+                      <div
+                        key={artifact.path ?? artifact.name}
+                        className="truncate text-[length:var(--fs-xs)] text-(--ui-muted)"
+                      >
+                        {artifact.name ?? artifact.path}
+                      </div>
+                    ))}
+                  </div>
                 </div>
               </div>
-              <div className="rounded-xl bg-(--ui-fg)/5 p-3">
-                <div className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)">
-                  Evidence
-                </div>
-                <div className="mt-2 text-[length:var(--fs-sm)] text-(--ui-fg)">
-                  {task.artifacts?.length ?? 0} artifact{task.artifacts?.length === 1 ? "" : "s"}
-                </div>
-                <div className="mt-2 space-y-1">
-                  {(task.artifacts ?? []).map((artifact) => (
-                    <div
-                      key={artifact.path ?? artifact.name}
-                      className="truncate text-[length:var(--fs-xs)] text-(--ui-muted)"
-                    >
-                      {artifact.name ?? artifact.path}
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
-          )}
+            )}
           </Card>
         </details>
       </PageContainer>

--- a/frontend/src/features/harness/harness-page.tsx
+++ b/frontend/src/features/harness/harness-page.tsx
@@ -26,7 +26,18 @@ type HarnessTask = {
   human_title?: string;
   artifacts?: Array<{ name?: string; path?: string }>;
   events?: Array<{ seq?: number; summary?: string; checkpoint?: string }>;
-  metadata?: { demo?: { enabled?: boolean; model_used?: boolean; workspace?: string } };
+  metadata?: {
+    demo?: { enabled?: boolean; model_used?: boolean; workspace?: string };
+    integration?: {
+      kind?: string;
+      route_id?: string;
+      model_id?: string;
+      node?: string;
+      runtime?: string;
+      model_used?: boolean;
+      connected_workspace_mutated?: boolean;
+    };
+  };
 };
 
 type RoutesResponse = { routes?: HarnessRoute[]; selection?: { policy?: string } };
@@ -51,9 +62,12 @@ function formatContext(tokens: number): string {
   return `${tokens} context`;
 }
 
+// The page coordinates route, task, event, and evidence state in one operator surface.
+// eslint-disable-next-line complexity
 export default function HarnessPage() {
   const [routes, setRoutes] = useState<HarnessRoute[]>([]);
   const [selectionPolicy, setSelectionPolicy] = useState("harness_decides");
+  const [selectedRoute, setSelectedRoute] = useState("auto");
   const [task, setTask] = useState<HarnessTask | null>(null);
   const [events, setEvents] = useState<HarnessTask["events"]>([]);
   const [loading, setLoading] = useState(true);
@@ -125,6 +139,31 @@ export default function HarnessPage() {
       setEvents(nextTask?.events ?? []);
     } catch (nextError) {
       setError(nextError instanceof Error ? nextError.message : "Canary could not start");
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const runAnalysis = async () => {
+    setRunning(true);
+    setError("");
+    try {
+      const payload = await readJson<TaskResponse & { task?: HarnessTask }>("/api/harness/tasks", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          kind: "read_only_analysis",
+          ...(selectedRoute === "auto" ? {} : { route_id: selectedRoute }),
+          objective:
+            "Use the selected cluster vLLM route to confirm the Harness execution boundary. " +
+            "Report the selected model and explain that this analysis is read-only; do not change files.",
+        }),
+      });
+      const nextTask = payload.task ?? null;
+      setTask(nextTask);
+      setEvents(nextTask?.events ?? []);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : "Model analysis could not start");
     } finally {
       setRunning(false);
     }
@@ -227,8 +266,39 @@ export default function HarnessPage() {
                 value="Operator UI and model/chat surface"
               />
               <div className="rounded-xl bg-(--ui-fg)/5 p-3 text-[length:var(--fs-xs)] leading-relaxed text-(--ui-muted)">
-                The canary is intentionally credential-free and isolated. It proves the client path
-                without sending work to vLLM or changing your connected project.
+                The safe canary is credential-free. Model analysis uses the selected vLLM route in a
+                temporary isolated workspace with write tools disabled.
+              </div>
+              <div className="rounded-xl border border-(--ui-border) p-3">
+                <label
+                  htmlFor="harness-route"
+                  className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)"
+                >
+                  Model route
+                </label>
+                <select
+                  id="harness-route"
+                  value={selectedRoute}
+                  onChange={(event) => setSelectedRoute(event.target.value)}
+                  className="mt-2 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
+                >
+                  <option value="auto">Auto: Node1 primary, Node2 overflow</option>
+                  {routes.map((route) => (
+                    <option key={route.id} value={route.id} disabled={route.status !== "ready"}>
+                      {route.node} · {route.model_id} ({route.status})
+                    </option>
+                  ))}
+                </select>
+                <Button
+                  className="mt-3 w-full"
+                  variant="secondary"
+                  size="sm"
+                  icon={<Play className="h-3.5 w-3.5" />}
+                  loading={running}
+                  onClick={() => void runAnalysis()}
+                >
+                  Run vLLM analysis
+                </Button>
               </div>
             </div>
           </Card>
@@ -253,6 +323,21 @@ export default function HarnessPage() {
                 <p className="mt-3 text-[length:var(--fs-sm)] text-(--ui-fg)">
                   {task.summary ?? task.human_title}
                 </p>
+                {task.metadata?.integration ? (
+                  <div className="mt-3 flex flex-wrap gap-2 text-[length:var(--fs-xs)] text-(--ui-muted)">
+                    <span>
+                      {task.metadata.integration.node} · {task.metadata.integration.model_id}
+                    </span>
+                    <span>{task.metadata.integration.runtime}</span>
+                    <span>read-only</span>
+                    <span>
+                      workspace{" "}
+                      {task.metadata.integration.connected_workspace_mutated
+                        ? "changed"
+                        : "unchanged"}
+                    </span>
+                  </div>
+                ) : null}
                 <div className="mt-4 space-y-2">
                   {(events ?? []).slice(-6).map((event, index) => (
                     <div

--- a/frontend/src/features/harness/harness-page.tsx
+++ b/frontend/src/features/harness/harness-page.tsx
@@ -51,8 +51,10 @@ type ManagedModesResponse = {
   execution_profiles?: ManagedProfile[];
 };
 type ManagedSetupResponse = {
+  allowed_api_key_envs?: string[];
   suggested_check?: string;
   verification_command?: string;
+  verification_contract?: { shell?: boolean; summary?: string };
   workspace?: string;
   worker?: { label?: string; type?: string };
   configured?: boolean;
@@ -307,6 +309,10 @@ export default function HarnessPage() {
   };
 
   const runManagedAction = async (action: "stop" | "continue" | "accept") => {
+    if (!managedTask?.id) {
+      setGoalError("The current goal changed. Refresh before trying that action again.");
+      return;
+    }
     setGoalBusy(true);
     setGoalError("");
     try {
@@ -315,7 +321,10 @@ export default function HarnessPage() {
         {
           method: "POST",
           headers: { "content-type": "application/json" },
-          body: JSON.stringify(action === "continue" ? { feedback: goalFeedback.trim() } : {}),
+          body: JSON.stringify({
+            task_id: managedTask.id,
+            ...(action === "continue" ? { feedback: goalFeedback.trim() } : {}),
+          }),
         },
       );
       const nextTask = managedTaskFromResponse(payload);
@@ -380,7 +389,15 @@ export default function HarnessPage() {
     label: "Managed goal loop",
     best_for: "Runs through the configured managed worker and keeps durable task state.",
   };
-  const providerModeOptions = managedModes.length ? managedModes : [];
+  const providerModeOptions = managedModes.length
+    ? managedModes
+    : [
+        {
+          key: goalMode || "quick",
+          label: "Standard goal loop",
+          best_for: "Plan, act, verify, and keep working until the goal reaches a terminal result.",
+        },
+      ];
   const selectedMode =
     goalBackend === "provider"
       ? (providerModeOptions.find((mode) => mode.key === goalMode) ?? providerModeOptions[0])
@@ -407,7 +424,7 @@ export default function HarnessPage() {
           objective: "Verify the Local Studio to Agentic Harness task boundary",
         }),
       });
-      const nextTask = payload.task ?? null;
+      const nextTask = resolveTaskEnvelope(payload);
       setTask(nextTask);
       setEvents(nextTask?.events ?? []);
     } catch (nextError) {
@@ -432,7 +449,7 @@ export default function HarnessPage() {
             "Report the selected model and explain that this analysis is read-only; do not change files.",
         }),
       });
-      const nextTask = payload.task ?? null;
+      const nextTask = resolveTaskEnvelope(payload);
       setTask(nextTask);
       setEvents(nextTask?.events ?? []);
     } catch (nextError) {
@@ -446,34 +463,21 @@ export default function HarnessPage() {
     <AppPage>
       <PageContainer width="lg" className="pt-6 sm:pt-8">
         <PageHeader
-          eyebrow="Agentic Harness"
-          title="Cluster execution"
-          description="Local Studio is the operator surface. Harness owns task state, routing, events, and evidence."
+          eyebrow="Goals"
+          title="What should your agent accomplish?"
+          description="Describe the result in plain language. The harness will keep working, verify the outcome, and ask only when it needs your decision."
           actions={
-            <div className="flex items-center gap-2">
-              <Button
-                variant="icon"
-                size="md"
-                aria-label="Refresh Harness"
-                title="Refresh"
-                onClick={() => void refresh()}
-              >
-                <RefreshCw className="h-4 w-4" />
-              </Button>
-              <Button
-                variant="primary"
-                size="sm"
-                icon={<Play className="h-3.5 w-3.5" />}
-                loading={running}
-                onClick={() => void runCanary()}
-              >
-                Run safe canary
-              </Button>
-            </div>
+            <Button
+              variant="icon"
+              size="md"
+              aria-label="Refresh goals"
+              title="Refresh"
+              onClick={() => void refresh()}
+            >
+              <RefreshCw className="h-4 w-4" />
+            </Button>
           }
         />
-
-        {error ? <ErrorBox className="mb-5">{error}</ErrorBox> : null}
 
         <Card
           className="mb-4"
@@ -673,15 +677,23 @@ export default function HarnessPage() {
                       />
                     </label>
                     <label className="text-[length:var(--fs-xs)] text-(--ui-muted)">
-                      API key environment variable
-                      <input
+                      Saved credential
+                      <select
                         value={providerApiKeyEnv}
                         onChange={(event) => setProviderApiKeyEnv(event.target.value)}
-                        placeholder="OPENAI_API_KEY (optional)"
-                        autoComplete="off"
                         className="mt-1 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
                         disabled={providerBusy || goalBusy}
-                      />
+                      >
+                        <option value="">No saved credential</option>
+                        {(managedSetup?.allowed_api_key_envs ?? []).map((name) => (
+                          <option key={name} value={name}>
+                            {name}
+                          </option>
+                        ))}
+                      </select>
+                      <span className="mt-1 block leading-relaxed">
+                        Only credential names approved by this installation are available.
+                      </span>
                     </label>
                     <label className="text-[length:var(--fs-xs)] text-(--ui-muted)">
                       Session API key
@@ -706,9 +718,10 @@ export default function HarnessPage() {
                       disabled={providerBusy || goalBusy}
                     />
                     <span className="mt-1 block leading-relaxed">
-                      {providerVerificationCommand.trim()
-                        ? "This is the check saved with this provider setup and used to verify provider goals."
-                        : "Saving requires a check. If this workspace already has one, it will appear here after setup loads."}
+                      {managedSetup?.verification_contract?.summary ??
+                        (providerVerificationCommand.trim()
+                          ? "This check is saved with the provider setup and verifies each goal."
+                          : "Saving requires a check. If this workspace already has one, it will appear here after setup loads.")}
                     </span>
                   </label>
                   <label className="mt-3 flex items-start gap-2 text-[length:var(--fs-xs)] text-(--ui-muted)">
@@ -967,7 +980,28 @@ export default function HarnessPage() {
           ) : null}
         </Card>
 
-        <div className="grid gap-4 lg:grid-cols-[minmax(0,1.45fr)_minmax(18rem,0.8fr)]">
+        <details className="rounded-xl border border-(--ui-border) p-4">
+          <summary className="cursor-pointer text-[length:var(--fs-sm)] font-medium text-(--ui-fg)">
+            Advanced diagnostics
+          </summary>
+          <p className="mt-2 text-[length:var(--fs-xs)] text-(--ui-muted)">
+            Inspect routes, run a credential-free boundary check, or test a read-only model route.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              icon={<Play className="h-3.5 w-3.5" />}
+              loading={running}
+              disabled={running}
+              onClick={() => void runCanary()}
+            >
+              Run safe canary
+            </Button>
+          </div>
+          {error ? <ErrorBox className="mt-3">{error}</ErrorBox> : null}
+
+          <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1.45fr)_minmax(18rem,0.8fr)]">
           <Card
             title="Live route registry"
             description={`Harness-owned live probes · selection policy: ${selectionPolicy}`}
@@ -1068,13 +1102,13 @@ export default function HarnessPage() {
               </div>
             </div>
           </Card>
-        </div>
+          </div>
 
-        <Card
-          className="mt-4"
-          title="Harness task"
-          description="The safe canary uses the real Harness lifecycle and returns task evidence through the integration API."
-        >
+          <Card
+            className="mt-4"
+            title="Diagnostic task"
+            description="Canary and read-only model checks return task evidence through the integration API."
+          >
           {!task?.id ? (
             <p className="text-[length:var(--fs-sm)] text-(--ui-muted)">No task loaded.</p>
           ) : (
@@ -1136,7 +1170,8 @@ export default function HarnessPage() {
               </div>
             </div>
           )}
-        </Card>
+          </Card>
+        </details>
       </PageContainer>
     </AppPage>
   );

--- a/frontend/src/features/harness/harness-page.tsx
+++ b/frontend/src/features/harness/harness-page.tsx
@@ -295,6 +295,7 @@ export default function HarnessPage() {
                   size="sm"
                   icon={<Play className="h-3.5 w-3.5" />}
                   loading={running}
+                  disabled={running}
                   onClick={() => void runAnalysis()}
                 >
                   Run vLLM analysis

--- a/frontend/src/features/harness/harness-page.tsx
+++ b/frontend/src/features/harness/harness-page.tsx
@@ -4,6 +4,12 @@ import { useCallback, useState, type ReactNode } from "react";
 import { AppPage, Button, Card, ErrorBox, PageContainer, PageHeader, StatusPill } from "@/ui";
 import { useMountSubscription } from "@/hooks/use-mount-subscription";
 import {
+  HARNESS_REMOTE_DATA_CONSENT_HEADER,
+  HARNESS_REMOTE_DATA_CONSENT_VERSION,
+  type HarnessIntegrationContract,
+} from "@shared/agent/harness";
+import {
+  assessGoalVerification,
   describeGoalOutcome,
   goalStartBlocker,
   isTerminalTaskStatus,
@@ -58,6 +64,7 @@ type ManagedSetupResponse = {
   workspace?: string;
   worker?: { label?: string; type?: string };
   configured?: boolean;
+  integration?: HarnessIntegrationContract;
   provider?: {
     endpoint?: string;
     model?: string;
@@ -130,6 +137,7 @@ export default function HarnessPage({ initialGoal = "" }: { initialGoal?: string
   const [providerApiKey, setProviderApiKey] = useState("");
   const [providerVerificationCommand, setProviderVerificationCommand] = useState("");
   const [providerRemoteConfirmed, setProviderRemoteConfirmed] = useState(false);
+  const [harnessConsentConfirmed, setHarnessConsentConfirmed] = useState(false);
   const [providerBusy, setProviderBusy] = useState(false);
   const [providerMessage, setProviderMessage] = useState("");
 
@@ -273,6 +281,13 @@ export default function HarnessPage({ initialGoal = "" }: { initialGoal?: string
 
   const goalApiPrefix =
     goalBackend === "provider" ? "/api/harness/provider" : "/api/harness/managed";
+  const integrationReady = managedSetup?.integration?.lifecycle.state === "reachable";
+  const mutationHeaders = {
+    "content-type": "application/json",
+    [HARNESS_REMOTE_DATA_CONSENT_HEADER]: harnessConsentConfirmed
+      ? HARNESS_REMOTE_DATA_CONSENT_VERSION
+      : "",
+  };
 
   const startGoal = async () => {
     // Validate on submit rather than only disabling the button, so a new user is
@@ -280,6 +295,8 @@ export default function HarnessPage({ initialGoal = "" }: { initialGoal?: string
     const blocker = goalStartBlocker({
       goal,
       backend: goalBackend,
+      integrationReady,
+      remoteDataConsent: harnessConsentConfirmed,
       providerConfigured: managedSetup?.configured === true,
       setupLoading: goalLoading,
       activeTaskStatus: managedTask?.status,
@@ -294,7 +311,7 @@ export default function HarnessPage({ initialGoal = "" }: { initialGoal?: string
     try {
       const payload = await readJson<ManagedTaskResponse>(`${goalApiPrefix}/tasks`, {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: mutationHeaders,
         body: JSON.stringify(
           goalBackend === "provider"
             ? { objective, strategy: goalMode }
@@ -319,6 +336,10 @@ export default function HarnessPage({ initialGoal = "" }: { initialGoal?: string
   };
 
   const runManagedAction = async (action: "stop" | "continue" | "accept") => {
+    if (!harnessConsentConfirmed) {
+      setGoalError("Confirm the external Harness data boundary before changing this goal.");
+      return;
+    }
     if (!managedTask?.id) {
       setGoalError("The current goal changed. Refresh before trying that action again.");
       return;
@@ -330,7 +351,7 @@ export default function HarnessPage({ initialGoal = "" }: { initialGoal?: string
         `${goalApiPrefix}/tasks/current/${action}`,
         {
           method: "POST",
-          headers: { "content-type": "application/json" },
+          headers: mutationHeaders,
           body: JSON.stringify({
             task_id: managedTask.id,
             ...(action === "continue" ? { feedback: goalFeedback.trim() } : {}),
@@ -349,6 +370,12 @@ export default function HarnessPage({ initialGoal = "" }: { initialGoal?: string
   };
 
   const configureProvider = async (testOnly: boolean) => {
+    if (!harnessConsentConfirmed) {
+      setGoalError(
+        "Confirm the external Harness data boundary before testing or saving a provider.",
+      );
+      return;
+    }
     if (!providerEndpoint.trim() || !providerModel.trim()) {
       setProviderMessage("");
       setGoalError(
@@ -373,7 +400,7 @@ export default function HarnessPage({ initialGoal = "" }: { initialGoal?: string
         `${goalApiPrefix}/setup${testOnly ? "/test" : ""}`,
         {
           method: "POST",
-          headers: { "content-type": "application/json" },
+          headers: mutationHeaders,
           body: JSON.stringify(payload),
         },
       );
@@ -416,20 +443,27 @@ export default function HarnessPage({ initialGoal = "" }: { initialGoal?: string
   const startBlocker = goalStartBlocker({
     goal,
     backend: goalBackend,
+    integrationReady,
+    remoteDataConsent: harnessConsentConfirmed,
     providerConfigured: managedSetup?.configured === true,
     setupLoading: goalLoading,
     activeTaskStatus: managedTask?.status,
   });
   const showStartBlocker = Boolean(startBlocker && !goalError && !error);
   const goalOutcome = describeGoalOutcome(managedTask);
+  const goalVerification = managedTask ? assessGoalVerification(managedTask) : null;
 
   const runCanary = async () => {
+    if (!harnessConsentConfirmed) {
+      setError("Confirm the external Harness data boundary before running a canary.");
+      return;
+    }
     setRunning(true);
     setError("");
     try {
       const payload = await readJson<TaskResponse & { task?: HarnessTask }>("/api/harness/tasks", {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: mutationHeaders,
         body: JSON.stringify({
           kind: "read_only_canary",
           objective: "Verify the Local Studio to Agentic Harness task boundary",
@@ -446,12 +480,16 @@ export default function HarnessPage({ initialGoal = "" }: { initialGoal?: string
   };
 
   const runAnalysis = async () => {
+    if (!harnessConsentConfirmed) {
+      setError("Confirm the external Harness data boundary before running model analysis.");
+      return;
+    }
     setRunning(true);
     setError("");
     try {
       const payload = await readJson<TaskResponse & { task?: HarnessTask }>("/api/harness/tasks", {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: mutationHeaders,
         body: JSON.stringify({
           kind: "read_only_analysis",
           ...(selectedRoute === "auto" ? {} : { route_id: selectedRoute }),
@@ -493,7 +531,7 @@ export default function HarnessPage({ initialGoal = "" }: { initialGoal?: string
         <Card
           className="mb-4"
           title="Work on a goal"
-          description="Type one objective, then let the managed harness keep working until it has evidence or needs your decision."
+          description="Type one objective, then let the externally managed Harness work until it has a structured result or needs your decision."
         >
           <div className="grid gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(18rem,0.65fr)]">
             <div>
@@ -580,13 +618,13 @@ export default function HarnessPage({ initialGoal = "" }: { initialGoal?: string
                     className="mt-2 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
                     disabled={goalBusy || providerBusy}
                   >
-                    <option value="managed">Configured managed worker</option>
-                    <option value="provider">Any OpenAI-compatible model</option>
+                    <option value="managed">Externally managed worker</option>
+                    <option value="provider">External Harness with any model</option>
                   </select>
                   <p className="mt-1 text-[length:var(--fs-xs)] text-(--ui-muted)">
                     {goalBackend === "provider"
                       ? "Use a local, LAN, or cloud endpoint configured below."
-                      : "Use the deployment's existing durable worker and route policy."}
+                      : "Use the host's separately installed durable worker and route policy."}
                   </p>
                 </div>
                 <div>
@@ -657,6 +695,36 @@ export default function HarnessPage({ initialGoal = "" }: { initialGoal?: string
                     </div>
                   </div>
                 )}
+              </div>
+
+              <div className="mt-4 rounded-xl border border-(--ui-border) p-4">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)">
+                    External Harness boundary
+                  </div>
+                  <StatusPill tone={integrationReady ? "good" : "warning"} variant="badge">
+                    {integrationReady ? "reachable" : goalLoading ? "checking" : "not ready"}
+                  </StatusPill>
+                </div>
+                <p className="mt-2 text-[length:var(--fs-sm)] leading-relaxed text-(--ui-muted)">
+                  Local Studio uses this Harness but does not install, start, stop, or reconfigure
+                  its service. Those lifecycle actions remain with the host owner.
+                </p>
+                <label className="mt-3 flex items-start gap-2 text-[length:var(--fs-xs)] text-(--ui-muted)">
+                  <input
+                    type="checkbox"
+                    checked={harnessConsentConfirmed}
+                    onChange={(event) => {
+                      setHarnessConsentConfirmed(event.target.checked);
+                      if (goalError) setGoalError("");
+                      if (error) setError("");
+                    }}
+                    className="mt-0.5"
+                    disabled={goalBusy || providerBusy}
+                  />
+                  I approve sending goal prompts, selected file excerpts, tool results, and task
+                  actions from this Local Studio session to the external Harness.
+                </label>
               </div>
 
               {goalBackend === "provider" ? (
@@ -762,6 +830,7 @@ export default function HarnessPage({ initialGoal = "" }: { initialGoal?: string
                         providerBusy ||
                         goalBusy ||
                         goalLoading ||
+                        !harnessConsentConfirmed ||
                         !providerEndpoint.trim() ||
                         !providerModel.trim()
                       }
@@ -777,6 +846,7 @@ export default function HarnessPage({ initialGoal = "" }: { initialGoal?: string
                         providerBusy ||
                         goalBusy ||
                         goalLoading ||
+                        !harnessConsentConfirmed ||
                         !providerEndpoint.trim() ||
                         !providerModel.trim()
                       }
@@ -837,7 +907,7 @@ export default function HarnessPage({ initialGoal = "" }: { initialGoal?: string
                   <p>
                     {goalBackend === "provider"
                       ? "The Harness owns the durable goal loop and uses the configured provider/model."
-                      : "The configured managed worker owns the durable goal loop and route policy."}
+                      : "The external Harness owns the durable goal loop and route policy."}
                   </p>
                   <p>It can plan, act, check, and continue without another prompt.</p>
                   <p>
@@ -858,8 +928,11 @@ export default function HarnessPage({ initialGoal = "" }: { initialGoal?: string
                 </div>
                 <div className="mt-1">
                   {managedSetup?.worker?.label ??
-                    (goalBackend === "provider" ? "Provider model agent" : "Managed goal runtime")}
+                    (goalBackend === "provider"
+                      ? "External provider model agent"
+                      : "External goal runtime")}
                 </div>
+                <div className="mt-1">Lifecycle owner: host installation</div>
               </div>
             </div>
           </div>
@@ -971,9 +1044,14 @@ export default function HarnessPage({ initialGoal = "" }: { initialGoal?: string
                     Evidence
                   </div>
                   <div className="mt-2 text-[length:var(--fs-sm)] text-(--ui-fg)">
-                    {managedTask.verification?.length ?? 0} verification checks ·{" "}
+                    {goalVerification?.checks.length ?? 0} structured checks ·{" "}
                     {managedTask.changed_files?.length ?? 0} owned paths
                   </div>
+                  {goalVerification && goalVerification.state !== "verified" ? (
+                    <div className="mt-1 text-[length:var(--fs-xs)] leading-relaxed text-(--ui-muted)">
+                      Not verified: {goalVerification.detail}
+                    </div>
+                  ) : null}
                   <div className="mt-2 space-y-1">
                     {(managedTask.artifacts ?? []).slice(0, 3).map((artifact) => (
                       <div

--- a/frontend/src/features/harness/harness-page.tsx
+++ b/frontend/src/features/harness/harness-page.tsx
@@ -3,6 +3,18 @@
 import { useCallback, useState, type ReactNode } from "react";
 import { AppPage, Button, Card, ErrorBox, PageContainer, PageHeader, StatusPill } from "@/ui";
 import { useMountSubscription } from "@/hooks/use-mount-subscription";
+import {
+  describeGoalOutcome,
+  goalStartBlocker,
+  isTerminalTaskStatus,
+  resolveTaskEnvelope,
+  startTaskPolling,
+  stripGoalCommandPrefix,
+  type HarnessTask,
+  type ManagedGoalTask,
+  type ManagedTaskResponse,
+  type TaskResponse,
+} from "./harness-page-model";
 import { GitBranch, Play, RefreshCw, ShieldCheck } from "@/ui/icon-registry";
 
 type HarnessRoute = {
@@ -18,35 +30,40 @@ type HarnessRoute = {
   eligible_for: string[];
 };
 
-type HarnessTask = {
-  id?: string;
-  status?: string;
-  status_label?: string;
+type RoutesResponse = { routes?: HarnessRoute[]; selection?: { policy?: string } };
+type ManagedMode = {
+  key: string;
+  label: string;
+  best_for?: string;
+  caution?: string;
+};
+type ManagedProfile = {
+  key: string;
+  label: string;
   summary?: string;
-  human_title?: string;
-  artifacts?: Array<{ name?: string; path?: string }>;
-  events?: Array<{ seq?: number; summary?: string; checkpoint?: string }>;
-  metadata?: {
-    demo?: { enabled?: boolean; model_used?: boolean; workspace?: string };
-    integration?: {
-      kind?: string;
-      route_id?: string;
-      model_id?: string;
-      node?: string;
-      runtime?: string;
-      model_used?: boolean;
-      connected_workspace_mutated?: boolean;
-    };
+  caution?: string;
+};
+type ManagedModesResponse = {
+  kind?: string;
+  default?: string;
+  default_execution_profile?: string;
+  modes?: ManagedMode[];
+  execution_profiles?: ManagedProfile[];
+};
+type ManagedSetupResponse = {
+  suggested_check?: string;
+  verification_command?: string;
+  workspace?: string;
+  worker?: { label?: string; type?: string };
+  configured?: boolean;
+  provider?: {
+    endpoint?: string;
+    model?: string;
+    api_key_env?: string;
+    data_location?: string;
   };
 };
-
-type RoutesResponse = { routes?: HarnessRoute[]; selection?: { policy?: string } };
-type TaskResponse = Partial<HarnessTask> & {
-  task?: HarnessTask;
-  current?: HarnessTask;
-  events?: HarnessTask["events"];
-};
-
+type GoalBackend = "managed" | "provider";
 async function readJson<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, { ...init, cache: "no-store" });
   const payload = (await response.json().catch(() => ({}))) as { error?: string } & T;
@@ -56,14 +73,29 @@ async function readJson<T>(url: string, init?: RequestInit): Promise<T> {
 
 function toneForStatus(status: string): "default" | "good" | "warning" | "danger" {
   if (status === "ready" || status === "done" || status === "complete") return "good";
-  if (status === "unavailable" || status === "blocked") return "danger";
-  if (status === "degraded" || status === "needs_review") return "warning";
+  if (status === "unavailable" || status === "blocked" || status === "failed") return "danger";
+  // "stopped" is a real interruption, not a neutral resting state: showing it in
+  // the default tone made a halted goal look the same as a running one.
+  if (status === "degraded" || status === "needs_review" || status === "stopped") return "warning";
   return "default";
 }
 
 function formatContext(tokens: number): string {
   if (tokens >= 1000) return `${Math.round(tokens / 1000)}k context`;
   return `${tokens} context`;
+}
+
+function isManagedGoalTerminal(task: ManagedGoalTask | null): boolean {
+  return (
+    !task?.id ||
+    isTerminalTaskStatus(task.status) ||
+    task.status === "needs_review" ||
+    task.status === "ready"
+  );
+}
+
+function managedTaskFromResponse(payload: ManagedTaskResponse): ManagedGoalTask | null {
+  return resolveTaskEnvelope(payload as TaskResponse) as ManagedGoalTask | null;
 }
 
 // The page coordinates route, task, event, and evidence state in one operator surface.
@@ -77,6 +109,27 @@ export default function HarnessPage() {
   const [loading, setLoading] = useState(true);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState("");
+  const [goal, setGoal] = useState("");
+  const [goalBackend, setGoalBackend] = useState<GoalBackend>("managed");
+  const [goalMode, setGoalMode] = useState("local");
+  const [goalProfile, setGoalProfile] = useState("qwen-primary");
+  const [goalFeedback, setGoalFeedback] = useState("");
+  const [managedTask, setManagedTask] = useState<ManagedGoalTask | null>(null);
+  const [managedEvents, setManagedEvents] = useState<NonNullable<HarnessTask["events"]>>([]);
+  const [managedModes, setManagedModes] = useState<ManagedMode[]>([]);
+  const [managedProfiles, setManagedProfiles] = useState<ManagedProfile[]>([]);
+  const [managedSetup, setManagedSetup] = useState<ManagedSetupResponse | null>(null);
+  const [goalLoading, setGoalLoading] = useState(true);
+  const [goalBusy, setGoalBusy] = useState(false);
+  const [goalError, setGoalError] = useState("");
+  const [providerEndpoint, setProviderEndpoint] = useState("");
+  const [providerModel, setProviderModel] = useState("");
+  const [providerApiKeyEnv, setProviderApiKeyEnv] = useState("");
+  const [providerApiKey, setProviderApiKey] = useState("");
+  const [providerVerificationCommand, setProviderVerificationCommand] = useState("");
+  const [providerRemoteConfirmed, setProviderRemoteConfirmed] = useState(false);
+  const [providerBusy, setProviderBusy] = useState(false);
+  const [providerMessage, setProviderMessage] = useState("");
 
   const loadRoutes = useCallback(async () => {
     const payload = await readJson<RoutesResponse>("/api/harness/routes");
@@ -84,22 +137,87 @@ export default function HarnessPage() {
     setSelectionPolicy(payload.selection?.policy ?? "harness_decides");
   }, []);
 
-  const loadTask = useCallback(async (taskId?: string) => {
+  const loadTask = useCallback(async (taskId?: string, signal?: AbortSignal) => {
     const target = taskId
       ? `/api/harness/tasks/${encodeURIComponent(taskId)}`
       : "/api/harness/tasks/current";
-    const payload = await readJson<TaskResponse>(target);
-    const nextTask = payload.task ?? (payload.id ? payload : (payload.current ?? null));
+    const payload = await readJson<TaskResponse>(target, { signal });
+    if (signal?.aborted) return;
+    const nextTask = resolveTaskEnvelope(payload);
     setTask(nextTask);
     if (nextTask?.id) {
       const eventPayload = await readJson<TaskResponse>(
         `/api/harness/tasks/${encodeURIComponent(nextTask.id)}/events?after=0`,
+        { signal },
       );
+      if (signal?.aborted) return;
       setEvents(eventPayload.events ?? nextTask.events ?? []);
     } else {
       setEvents([]);
     }
   }, []);
+
+  /** Task + events only. This is the poll payload: `modes` and `setup` do not
+   *  change while a goal runs, so re-fetching them every interval was three
+   *  extra round trips per tick for state that never moved. */
+  const loadManagedTask = useCallback(
+    async (signal?: AbortSignal, backend: GoalBackend = goalBackend) => {
+      const prefix = backend === "provider" ? "/api/harness/provider" : "/api/harness/managed";
+      const taskPayload = await readJson<ManagedTaskResponse>(`${prefix}/tasks/current`, {
+        signal,
+      });
+      if (signal?.aborted) return;
+      const nextTask = managedTaskFromResponse(taskPayload);
+      setManagedTask(nextTask);
+      if (nextTask?.id) {
+        const eventPayload = await readJson<ManagedTaskResponse>(`${prefix}/tasks/current/events`, {
+          signal,
+        });
+        if (signal?.aborted) return;
+        setManagedEvents(eventPayload.events ?? nextTask.events ?? []);
+      } else {
+        setManagedEvents(nextTask?.events ?? []);
+      }
+    },
+    [goalBackend],
+  );
+
+  /** Full load: setup/modes plus the current task. Used on mount and whenever
+   *  the selected goal engine changes, not on the polling interval. */
+  const loadManaged = useCallback(
+    async (signal?: AbortSignal, backend: GoalBackend = goalBackend) => {
+      const prefix = backend === "provider" ? "/api/harness/provider" : "/api/harness/managed";
+      const [modesPayload, setupPayload] = await Promise.all([
+        readJson<ManagedModesResponse>(`${prefix}/modes`, { signal }),
+        readJson<ManagedSetupResponse>(`${prefix}/setup`, { signal }),
+        // Task and events stay in the same parallel batch, so first paint is no
+        // slower than before the poll payload was split out.
+        loadManagedTask(signal, backend),
+      ]);
+      if (signal?.aborted) return;
+      setManagedModes(modesPayload.modes ?? []);
+      setManagedProfiles(modesPayload.execution_profiles ?? []);
+      setManagedSetup(setupPayload);
+      const availableModes = modesPayload.modes ?? [];
+      const fallbackMode = backend === "provider" ? (modesPayload.default ?? "plan") : "local";
+      setGoalMode((current) =>
+        availableModes.some((mode) => mode.key === current) ? current : fallbackMode,
+      );
+      if (backend === "provider") {
+        // Switching into the provider lane must reflect that lane's saved
+        // setup, not stale values left in the form by a previous selection.
+        // verification_command is the effective persisted check; the
+        // detected suggestion is only the first-run fallback.
+        setProviderEndpoint(setupPayload.provider?.endpoint || "");
+        setProviderModel(setupPayload.provider?.model || "");
+        setProviderApiKeyEnv(setupPayload.provider?.api_key_env || "");
+        setProviderVerificationCommand(
+          setupPayload.verification_command || setupPayload.suggested_check || "",
+        );
+      }
+    },
+    [goalBackend, loadManagedTask],
+  );
 
   const refresh = useCallback(async () => {
     setError("");
@@ -117,25 +235,165 @@ export default function HarnessPage() {
   }, [refresh]);
 
   useMountSubscription(() => {
-    if (!task?.id || ["done", "stopped", "blocked"].includes(task.status ?? "")) return;
-    let stopped = false;
-    let timer: number | undefined;
-    const poll = () => {
-      timer = window.setTimeout(async () => {
-        try {
-          await loadTask(task.id!);
-        } catch (nextError) {
-          setError(nextError instanceof Error ? nextError.message : "Task refresh failed");
-        }
-        if (!stopped) poll();
-      }, 3000);
-    };
-    poll();
-    return () => {
-      stopped = true;
-      if (timer !== undefined) window.clearTimeout(timer);
-    };
+    void loadManaged()
+      .catch((nextError) =>
+        setGoalError(nextError instanceof Error ? nextError.message : "Managed goal unavailable"),
+      )
+      .finally(() => setGoalLoading(false));
+  }, [loadManaged]);
+
+  useMountSubscription(() => {
+    if (!task?.id || isTerminalTaskStatus(task.status)) return;
+    const taskId = task.id;
+    return startTaskPolling({
+      intervalMs: 3000,
+      load: (signal) => loadTask(taskId, signal),
+      onError: (nextError) =>
+        setError(nextError instanceof Error ? nextError.message : "Task refresh failed"),
+    });
   }, [loadTask, task?.id, task?.status]);
+
+  useMountSubscription(() => {
+    if (isManagedGoalTerminal(managedTask)) return;
+    return startTaskPolling({
+      intervalMs: 3000,
+      load: (signal) => loadManagedTask(signal),
+      onError: (nextError) =>
+        setGoalError(nextError instanceof Error ? nextError.message : "Goal refresh failed"),
+    });
+  }, [loadManagedTask, managedTask?.id, managedTask?.status]);
+
+  const goalApiPrefix =
+    goalBackend === "provider" ? "/api/harness/provider" : "/api/harness/managed";
+
+  const startGoal = async () => {
+    // Validate on submit rather than only disabling the button, so a new user is
+    // told why nothing happened instead of facing an inert control.
+    const blocker = goalStartBlocker({
+      goal,
+      backend: goalBackend,
+      providerConfigured: managedSetup?.configured === true,
+      setupLoading: goalLoading,
+      activeTaskStatus: managedTask?.status,
+    });
+    if (blocker) {
+      setGoalError(blocker);
+      return;
+    }
+    const objective = stripGoalCommandPrefix(goal);
+    setGoalBusy(true);
+    setGoalError("");
+    try {
+      const payload = await readJson<ManagedTaskResponse>(`${goalApiPrefix}/tasks`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(
+          goalBackend === "provider"
+            ? { objective, strategy: goalMode }
+            : { objective, mode: goalMode, execution_profile: goalProfile },
+        ),
+      });
+      const nextTask = managedTaskFromResponse(payload);
+      setManagedTask(nextTask);
+      setManagedEvents(nextTask?.events ?? []);
+      if (nextTask?.status === "blocked" || nextTask?.status === "needs_review") {
+        setGoalError(nextTask.summary ?? "The goal needs attention before it can continue.");
+      }
+    } catch (nextError) {
+      setGoalError(nextError instanceof Error ? nextError.message : "Goal could not start");
+    } finally {
+      setGoalBusy(false);
+    }
+  };
+
+  const runManagedAction = async (action: "stop" | "continue" | "accept") => {
+    setGoalBusy(true);
+    setGoalError("");
+    try {
+      const payload = await readJson<ManagedTaskResponse>(
+        `${goalApiPrefix}/tasks/current/${action}`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(action === "continue" ? { feedback: goalFeedback.trim() } : {}),
+        },
+      );
+      const nextTask = managedTaskFromResponse(payload);
+      setManagedTask(nextTask);
+      setManagedEvents(nextTask?.events ?? []);
+      if (action === "continue") setGoalFeedback("");
+    } catch (nextError) {
+      setGoalError(nextError instanceof Error ? nextError.message : `Goal ${action} failed`);
+    } finally {
+      setGoalBusy(false);
+    }
+  };
+
+  const configureProvider = async (testOnly: boolean) => {
+    if (!providerEndpoint.trim() || !providerModel.trim()) {
+      setProviderMessage("");
+      setGoalError(
+        "Enter both an OpenAI-compatible endpoint and a model ID before testing or saving.",
+      );
+      return;
+    }
+    setProviderBusy(true);
+    setProviderMessage("");
+    setGoalError("");
+    try {
+      const payload = {
+        execution: providerEndpoint.trim().startsWith("https://") ? "cloud_model" : "local_model",
+        endpoint: providerEndpoint.trim(),
+        model: providerModel.trim(),
+        api_key_env: providerApiKeyEnv.trim(),
+        api_key: providerApiKey.trim(),
+        verification_command: providerVerificationCommand.trim(),
+        confirm_remote_data: providerRemoteConfirmed,
+      };
+      const response = await readJson<ManagedSetupResponse>(
+        `${goalApiPrefix}/setup${testOnly ? "/test" : ""}`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(payload),
+        },
+      );
+      if (!testOnly) {
+        setManagedSetup(response);
+        setProviderApiKey("");
+      }
+      setProviderMessage(testOnly ? "Connection test passed." : "Provider saved.");
+    } catch (nextError) {
+      setProviderMessage("");
+      setGoalError(nextError instanceof Error ? nextError.message : "Provider setup failed");
+    } finally {
+      setProviderBusy(false);
+    }
+  };
+
+  const node1GoalMode: ManagedMode = {
+    ...(managedModes.find((mode) => mode.key === "local") ?? {
+      key: "local",
+      label: "Managed goal loop",
+      best_for: "A durable goal executed by the configured managed worker.",
+    }),
+    label: "Managed goal loop",
+    best_for: "Runs through the configured managed worker and keeps durable task state.",
+  };
+  const providerModeOptions = managedModes.length ? managedModes : [];
+  const selectedMode =
+    goalBackend === "provider"
+      ? (providerModeOptions.find((mode) => mode.key === goalMode) ?? providerModeOptions[0])
+      : node1GoalMode;
+
+  const startBlocker = goalStartBlocker({
+    goal,
+    backend: goalBackend,
+    providerConfigured: managedSetup?.configured === true,
+    setupLoading: goalLoading,
+    activeTaskStatus: managedTask?.status,
+  });
+  const goalOutcome = describeGoalOutcome(managedTask);
 
   const runCanary = async () => {
     setRunning(true);
@@ -216,6 +474,498 @@ export default function HarnessPage() {
         />
 
         {error ? <ErrorBox className="mb-5">{error}</ErrorBox> : null}
+
+        <Card
+          className="mb-4"
+          title="Work on a goal"
+          description="Type one objective, then let the managed harness keep working until it has evidence or needs your decision."
+        >
+          <div className="grid gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(18rem,0.65fr)]">
+            <div>
+              <label
+                htmlFor="harness-goal"
+                className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)"
+              >
+                What do you want done?
+              </label>
+              <textarea
+                id="harness-goal"
+                value={goal}
+                onChange={(event) => {
+                  setGoal(event.target.value);
+                  if (goalError) setGoalError("");
+                }}
+                onKeyDown={(event) => {
+                  if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+                    event.preventDefault();
+                    void startGoal();
+                  }
+                }}
+                rows={5}
+                placeholder="Describe the outcome in plain language, for example: Review the Local Studio integration, make a bounded improvement, and verify it end to end."
+                aria-describedby="harness-goal-hint"
+                aria-invalid={Boolean(goalError && !goal.trim())}
+                className="mt-2 block w-full resize-y rounded-xl border border-(--ui-border) bg-(--ui-bg) px-3 py-3 text-[length:var(--fs-md)] leading-relaxed text-(--ui-fg) outline-none transition focus:border-(--ui-accent) focus:ring-2 focus:ring-(--ui-accent)/20"
+                disabled={goalBusy}
+              />
+              <div
+                id="harness-goal-hint"
+                className="mt-2 flex flex-wrap items-center justify-between gap-2 text-[length:var(--fs-xs)] text-(--ui-muted)"
+              >
+                <span>Plain language is enough; /goal is optional.</span>
+                <span>⌘/Ctrl + Enter to start</span>
+              </div>
+              {managedTask?.id ? (
+                <div
+                  role="status"
+                  className="mt-3 rounded-xl border border-(--ui-border) bg-(--ui-fg)/5 p-3 text-[length:var(--fs-sm)]"
+                >
+                  <div className="font-medium text-(--ui-fg)">
+                    {isManagedGoalTerminal(managedTask)
+                      ? "Last task in this workspace"
+                      : "A goal is already running in this shared workspace"}
+                  </div>
+                  <p className="mt-1 leading-relaxed text-(--ui-muted)">
+                    {isManagedGoalTerminal(managedTask)
+                      ? "The task shown below is history. You can start a new goal."
+                      : "Continue or stop the current goal before starting another one."}
+                  </p>
+                </div>
+              ) : null}
+
+              <div className="mt-4 grid gap-3 sm:grid-cols-3">
+                <div>
+                  <label
+                    htmlFor="harness-goal-backend"
+                    className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)"
+                  >
+                    Goal engine
+                  </label>
+                  <select
+                    id="harness-goal-backend"
+                    value={goalBackend}
+                    onChange={(event) => {
+                      const nextBackend = event.target.value as GoalBackend;
+                      setGoalBackend(nextBackend);
+                      setManagedTask(null);
+                      setManagedEvents([]);
+                      setProviderMessage("");
+                      setGoalError("");
+                      // Drop the previous engine's setup so the provider gate
+                      // fails closed instead of reading the other backend's
+                      // `configured` flag until the new payload lands.
+                      // useMountSubscription diffs its deps and re-subscribes, so
+                      // changing goalBackend gives loadManaged a new identity and
+                      // re-runs that subscription; its finally() clears goalLoading.
+                      setManagedSetup(null);
+                      setGoalLoading(true);
+                    }}
+                    className="mt-2 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
+                    disabled={goalBusy || providerBusy}
+                  >
+                    <option value="managed">Configured managed worker</option>
+                    <option value="provider">Any OpenAI-compatible model</option>
+                  </select>
+                  <p className="mt-1 text-[length:var(--fs-xs)] text-(--ui-muted)">
+                    {goalBackend === "provider"
+                      ? "Use a local, LAN, or cloud endpoint configured below."
+                      : "Use the deployment's existing durable worker and route policy."}
+                  </p>
+                </div>
+                <div>
+                  <label
+                    htmlFor="harness-goal-mode"
+                    className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)"
+                  >
+                    Work mode
+                  </label>
+                  <select
+                    id="harness-goal-mode"
+                    value={goalMode}
+                    onChange={(event) => setGoalMode(event.target.value)}
+                    className="mt-2 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
+                    disabled={goalBusy}
+                  >
+                    {(goalBackend === "provider" ? providerModeOptions : [node1GoalMode]).map(
+                      (mode) => (
+                        <option key={mode.key} value={mode.key}>
+                          {mode.label}
+                        </option>
+                      ),
+                    )}
+                  </select>
+                  <p className="mt-1 text-[length:var(--fs-xs)] text-(--ui-muted)">
+                    {selectedMode?.best_for ?? "Loading work strategies..."}
+                  </p>
+                </div>
+                {goalBackend === "managed" ? (
+                  <div>
+                    <label
+                      htmlFor="harness-goal-profile"
+                      className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)"
+                    >
+                      Execution route
+                    </label>
+                    <select
+                      id="harness-goal-profile"
+                      value={goalProfile}
+                      onChange={(event) => setGoalProfile(event.target.value)}
+                      className="mt-2 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
+                      disabled={goalBusy}
+                    >
+                      {(managedProfiles.length
+                        ? managedProfiles
+                        : [{ key: goalProfile, label: "Configured model profile" }]
+                      ).map((profile) => (
+                        <option key={profile.key} value={profile.key}>
+                          {profile.label}
+                        </option>
+                      ))}
+                    </select>
+                    <p className="mt-1 text-[length:var(--fs-xs)] text-(--ui-muted)">
+                      {managedProfiles.find((profile) => profile.key === goalProfile)?.summary ??
+                        "The managed deployment chooses the endpoint and model for this profile."}
+                    </p>
+                  </div>
+                ) : (
+                  <div className="rounded-lg border border-(--ui-border) p-3 text-[length:var(--fs-xs)] text-(--ui-muted)">
+                    <div className="uppercase tracking-[0.12em]">Selected model</div>
+                    <div className="mt-2 break-words text-(--ui-fg)">
+                      {goalLoading
+                        ? "Loading provider settings…"
+                        : providerModel || "Configure a model below"}
+                    </div>
+                    <div className="mt-1 break-all">
+                      {goalLoading ? "" : providerEndpoint || "No endpoint configured"}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {goalBackend === "provider" ? (
+                <div className="mt-4 rounded-xl border border-(--ui-border) p-4">
+                  <div className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)">
+                    Model provider
+                  </div>
+                  <p className="mt-2 text-[length:var(--fs-sm)] leading-relaxed text-(--ui-muted)">
+                    Enter any OpenAI-compatible chat-completions endpoint and model ID. Keep keys in
+                    an environment variable when possible; a session key is cleared after restart.
+                  </p>
+                  <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                    <label className="text-[length:var(--fs-xs)] text-(--ui-muted)">
+                      Endpoint
+                      <input
+                        value={providerEndpoint}
+                        onChange={(event) => setProviderEndpoint(event.target.value)}
+                        placeholder="http://127.0.0.1:8000/v1/chat/completions"
+                        className="mt-1 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
+                        disabled={providerBusy || goalBusy}
+                      />
+                    </label>
+                    <label className="text-[length:var(--fs-xs)] text-(--ui-muted)">
+                      Model ID
+                      <input
+                        value={providerModel}
+                        onChange={(event) => setProviderModel(event.target.value)}
+                        placeholder="your-provider/model-name"
+                        className="mt-1 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
+                        disabled={providerBusy || goalBusy}
+                      />
+                    </label>
+                    <label className="text-[length:var(--fs-xs)] text-(--ui-muted)">
+                      API key environment variable
+                      <input
+                        value={providerApiKeyEnv}
+                        onChange={(event) => setProviderApiKeyEnv(event.target.value)}
+                        placeholder="OPENAI_API_KEY (optional)"
+                        autoComplete="off"
+                        className="mt-1 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
+                        disabled={providerBusy || goalBusy}
+                      />
+                    </label>
+                    <label className="text-[length:var(--fs-xs)] text-(--ui-muted)">
+                      Session API key
+                      <input
+                        type="password"
+                        value={providerApiKey}
+                        onChange={(event) => setProviderApiKey(event.target.value)}
+                        placeholder="Optional; never written to project state"
+                        autoComplete="new-password"
+                        className="mt-1 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
+                        disabled={providerBusy || goalBusy}
+                      />
+                    </label>
+                  </div>
+                  <label className="mt-3 block text-[length:var(--fs-xs)] text-(--ui-muted)">
+                    Independent verification command (required)
+                    <input
+                      value={providerVerificationCommand}
+                      onChange={(event) => setProviderVerificationCommand(event.target.value)}
+                      placeholder="The workspace's detected check will be used when available"
+                      className="mt-1 w-full rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
+                      disabled={providerBusy || goalBusy}
+                    />
+                    <span className="mt-1 block leading-relaxed">
+                      {providerVerificationCommand.trim()
+                        ? "This is the check saved with this provider setup and used to verify provider goals."
+                        : "Saving requires a check. If this workspace already has one, it will appear here after setup loads."}
+                    </span>
+                  </label>
+                  <label className="mt-3 flex items-start gap-2 text-[length:var(--fs-xs)] text-(--ui-muted)">
+                    <input
+                      type="checkbox"
+                      checked={providerRemoteConfirmed}
+                      onChange={(event) => setProviderRemoteConfirmed(event.target.checked)}
+                      className="mt-0.5"
+                      disabled={providerBusy || goalBusy}
+                    />
+                    I understand that a cloud endpoint may receive selected prompts, file excerpts,
+                    and tool results.
+                  </label>
+                  {providerMessage ? (
+                    <p className="mt-3 text-[length:var(--fs-sm)] text-(--ui-fg)">
+                      {providerMessage}
+                    </p>
+                  ) : null}
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      loading={providerBusy}
+                      disabled={
+                        providerBusy ||
+                        goalBusy ||
+                        goalLoading ||
+                        !providerEndpoint.trim() ||
+                        !providerModel.trim()
+                      }
+                      onClick={() => void configureProvider(true)}
+                    >
+                      Test connection
+                    </Button>
+                    <Button
+                      variant="primary"
+                      size="sm"
+                      loading={providerBusy}
+                      disabled={
+                        providerBusy ||
+                        goalBusy ||
+                        goalLoading ||
+                        !providerEndpoint.trim() ||
+                        !providerModel.trim()
+                      }
+                      onClick={() => void configureProvider(false)}
+                    >
+                      Save provider
+                    </Button>
+                  </div>
+                </div>
+              ) : null}
+
+              {goalError ? <ErrorBox className="mt-4">{goalError}</ErrorBox> : null}
+
+              {startBlocker && !goalError ? (
+                <p
+                  id="harness-goal-blocker"
+                  className="mt-4 text-[length:var(--fs-sm)] text-(--ui-muted)"
+                >
+                  {startBlocker}
+                </p>
+              ) : null}
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                <Button
+                  variant="primary"
+                  size="sm"
+                  icon={<Play className="h-3.5 w-3.5" />}
+                  loading={goalBusy}
+                  // Loading and in-flight states disable the control; other
+                  // reasons are reported by startGoal so they can be read.
+                  disabled={goalBusy || goalLoading}
+                  aria-describedby={startBlocker ? "harness-goal-blocker" : undefined}
+                  onClick={() => void startGoal()}
+                >
+                  Start goal
+                </Button>
+                {managedTask?.id && !isManagedGoalTerminal(managedTask) ? (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    loading={goalBusy}
+                    disabled={goalBusy}
+                    onClick={() => void runManagedAction("stop")}
+                  >
+                    Stop goal
+                  </Button>
+                ) : null}
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <div className="rounded-xl bg-(--ui-fg)/5 p-3">
+                <div className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)">
+                  What happens next
+                </div>
+                <div className="mt-2 space-y-2 text-[length:var(--fs-sm)] leading-relaxed text-(--ui-fg)">
+                  <p>
+                    {goalBackend === "provider"
+                      ? "The Harness owns the durable goal loop and uses the configured provider/model."
+                      : "The configured managed worker owns the durable goal loop and route policy."}
+                  </p>
+                  <p>It can plan, act, check, and continue without another prompt.</p>
+                  <p>
+                    It keeps working until complete, blocked, paused, budget-limited, or awaiting
+                    review.
+                  </p>
+                </div>
+              </div>
+              <div className="rounded-xl border border-(--ui-border) p-3 text-[length:var(--fs-xs)] text-(--ui-muted)">
+                <div className="font-medium text-(--ui-fg)">Live target</div>
+                <div className="mt-1 break-words">
+                  {/* Avoid exposing provider workspace paths in a generic
+                      provider session; managed mode may show its operator target. */}
+                  {goalBackend === "provider"
+                    ? "Configured provider workspace"
+                    : (managedSetup?.workspace ??
+                      (goalLoading ? "Loading workspace..." : "No workspace reported yet"))}
+                </div>
+                <div className="mt-1">
+                  {managedSetup?.worker?.label ??
+                    (goalBackend === "provider" ? "Provider model agent" : "Managed goal runtime")}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {managedTask?.id ? (
+            <div className="mt-5 border-t border-(--ui-border) pt-5">
+              <div className="flex flex-wrap items-center gap-2">
+                <StatusPill tone={toneForStatus(managedTask.status ?? "")} variant="badge">
+                  {managedTask.status_label ?? managedTask.status ?? "working"}
+                </StatusPill>
+                <span className="text-[length:var(--fs-xs)] text-(--ui-muted)">
+                  {managedTask.progress?.label ?? managedTask.current?.checkpoint ?? "Managed goal"}
+                </span>
+                <code className="text-[length:var(--fs-xs)] text-(--ui-muted)">
+                  {managedTask.id}
+                </code>
+              </div>
+              <p className="mt-3 text-[length:var(--fs-sm)] text-(--ui-fg)">
+                {managedTask.objective ?? managedTask.summary ?? "Goal is running."}
+              </p>
+              {goalOutcome && goalOutcome.state !== "running" ? (
+                <div
+                  role="status"
+                  className="mt-3 rounded-xl border border-(--ui-border) p-3 text-[length:var(--fs-sm)]"
+                >
+                  <div className="flex flex-wrap items-center gap-2">
+                    <StatusPill tone={goalOutcome.tone} variant="badge">
+                      {goalOutcome.headline}
+                    </StatusPill>
+                  </div>
+                  <p className="mt-2 leading-relaxed text-(--ui-muted)">{goalOutcome.detail}</p>
+                </div>
+              ) : null}
+              {managedTask.progress?.determinate ? (
+                <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-(--ui-fg)/10">
+                  <div
+                    className="h-full rounded-full bg-(--ui-accent) transition-all"
+                    style={{
+                      width: `${Math.max(0, Math.min(100, managedTask.progress.percent ?? 0))}%`,
+                    }}
+                  />
+                </div>
+              ) : null}
+              {managedTask.summary && goalOutcome?.state === "running" ? (
+                <p className="mt-3 text-[length:var(--fs-sm)] leading-relaxed text-(--ui-muted)">
+                  {managedTask.summary}
+                </p>
+              ) : null}
+              {managedTask.status === "needs_review" || managedTask.status === "blocked" ? (
+                <div className="mt-4 rounded-xl border border-(--ui-border) p-3">
+                  <label
+                    htmlFor="harness-goal-feedback"
+                    className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)"
+                  >
+                    Feedback to continue
+                  </label>
+                  <textarea
+                    id="harness-goal-feedback"
+                    value={goalFeedback}
+                    onChange={(event) => setGoalFeedback(event.target.value)}
+                    rows={3}
+                    placeholder="Tell the worker what to address next, or leave blank to continue."
+                    className="mt-2 block w-full resize-y rounded-lg border border-(--ui-border) bg-(--ui-bg) px-3 py-2 text-[length:var(--fs-sm)] text-(--ui-fg)"
+                    disabled={goalBusy}
+                  />
+                  <Button
+                    className="mt-3"
+                    variant="secondary"
+                    size="sm"
+                    loading={goalBusy}
+                    disabled={goalBusy}
+                    onClick={() => void runManagedAction("continue")}
+                  >
+                    Continue goal
+                  </Button>
+                  {managedTask.status === "needs_review" ? (
+                    <Button
+                      className="mt-3 ml-2"
+                      variant="primary"
+                      size="sm"
+                      loading={goalBusy}
+                      disabled={goalBusy}
+                      onClick={() => void runManagedAction("accept")}
+                    >
+                      Accept result
+                    </Button>
+                  ) : null}
+                </div>
+              ) : null}
+              <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(15rem,0.55fr)]">
+                <div className="space-y-2">
+                  {(managedEvents ?? []).slice(-8).map((event, index) => (
+                    <div
+                      key={`${event.seq ?? index}-${event.checkpoint ?? "goal-event"}`}
+                      className="flex gap-2 text-[length:var(--fs-xs)] text-(--ui-muted)"
+                    >
+                      <span className="shrink-0 tabular-nums">{event.seq ?? "·"}</span>
+                      <span>{event.summary ?? event.checkpoint ?? "Goal event"}</span>
+                    </div>
+                  ))}
+                  {managedEvents.length === 0 ? (
+                    <p className="text-[length:var(--fs-xs)] text-(--ui-muted)">
+                      {goalLoading ? "Loading goal state..." : "Progress events will appear here."}
+                    </p>
+                  ) : null}
+                </div>
+                <div className="rounded-xl bg-(--ui-fg)/5 p-3">
+                  <div className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)">
+                    Evidence
+                  </div>
+                  <div className="mt-2 text-[length:var(--fs-sm)] text-(--ui-fg)">
+                    {managedTask.verification?.length ?? 0} verification checks ·{" "}
+                    {managedTask.changed_files?.length ?? 0} owned paths
+                  </div>
+                  <div className="mt-2 space-y-1">
+                    {(managedTask.artifacts ?? []).slice(0, 3).map((artifact) => (
+                      <div
+                        key={artifact.path ?? artifact.name}
+                        className="truncate text-[length:var(--fs-xs)] text-(--ui-muted)"
+                      >
+                        {artifact.name ?? artifact.path}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+          ) : goalLoading ? (
+            <p className="mt-5 border-t border-(--ui-border) pt-5 text-[length:var(--fs-sm)] text-(--ui-muted)">
+              Loading goal setup...
+            </p>
+          ) : null}
+        </Card>
 
         <div className="grid gap-4 lg:grid-cols-[minmax(0,1.45fr)_minmax(18rem,0.8fr)]">
           <Card

--- a/frontend/src/features/harness/harness-page.tsx
+++ b/frontend/src/features/harness/harness-page.tsx
@@ -41,7 +41,11 @@ type HarnessTask = {
 };
 
 type RoutesResponse = { routes?: HarnessRoute[]; selection?: { policy?: string } };
-type TaskResponse = { task?: HarnessTask; current?: HarnessTask; events?: HarnessTask["events"] };
+type TaskResponse = Partial<HarnessTask> & {
+  task?: HarnessTask;
+  current?: HarnessTask;
+  events?: HarnessTask["events"];
+};
 
 async function readJson<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, { ...init, cache: "no-store" });
@@ -85,7 +89,7 @@ export default function HarnessPage() {
       ? `/api/harness/tasks/${encodeURIComponent(taskId)}`
       : "/api/harness/tasks/current";
     const payload = await readJson<TaskResponse>(target);
-    const nextTask = payload.task ?? payload.current ?? null;
+    const nextTask = payload.task ?? (payload.id ? payload : (payload.current ?? null));
     setTask(nextTask);
     if (nextTask?.id) {
       const eventPayload = await readJson<TaskResponse>(
@@ -114,12 +118,23 @@ export default function HarnessPage() {
 
   useMountSubscription(() => {
     if (!task?.id || ["done", "stopped", "blocked"].includes(task.status ?? "")) return;
-    const timer = window.setTimeout(() => {
-      void loadTask(task.id).catch((nextError) =>
-        setError(nextError instanceof Error ? nextError.message : "Task refresh failed"),
-      );
-    }, 3000);
-    return () => window.clearTimeout(timer);
+    let stopped = false;
+    let timer: number | undefined;
+    const poll = () => {
+      timer = window.setTimeout(async () => {
+        try {
+          await loadTask(task.id!);
+        } catch (nextError) {
+          setError(nextError instanceof Error ? nextError.message : "Task refresh failed");
+        }
+        if (!stopped) poll();
+      }, 3000);
+    };
+    poll();
+    return () => {
+      stopped = true;
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
   }, [loadTask, task?.id, task?.status]);
 
   const runCanary = async () => {

--- a/frontend/src/features/harness/harness-page.tsx
+++ b/frontend/src/features/harness/harness-page.tsx
@@ -410,6 +410,7 @@ export default function HarnessPage() {
     setupLoading: goalLoading,
     activeTaskStatus: managedTask?.status,
   });
+  const showStartBlocker = Boolean(startBlocker && !goalError && !error);
   const goalOutcome = describeGoalOutcome(managedTask);
 
   const runCanary = async () => {
@@ -508,7 +509,7 @@ export default function HarnessPage() {
                 rows={5}
                 placeholder="Describe the outcome in plain language, for example: Review the Local Studio integration, make a bounded improvement, and verify it end to end."
                 aria-describedby={
-                  startBlocker
+                  showStartBlocker
                     ? "harness-goal-hint harness-goal-blocker"
                     : "harness-goal-hint"
                 }
@@ -782,7 +783,7 @@ export default function HarnessPage() {
               {goalError ? <ErrorBox className="mt-4">{goalError}</ErrorBox> : null}
               {!goalError && error ? <ErrorBox className="mt-4">{error}</ErrorBox> : null}
 
-              {startBlocker && !goalError && !error ? (
+              {showStartBlocker ? (
                 <p
                   id="harness-goal-blocker"
                   className="mt-4 text-[length:var(--fs-sm)] text-(--ui-muted)"
@@ -800,7 +801,7 @@ export default function HarnessPage() {
                   // Loading and in-flight states disable the control; other
                   // reasons are reported by startGoal so they can be read.
                   disabled={goalBusy || goalLoading}
-                  aria-describedby={startBlocker ? "harness-goal-blocker" : undefined}
+                  aria-describedby={showStartBlocker ? "harness-goal-blocker" : undefined}
                   onClick={() => void startGoal()}
                 >
                   Start goal

--- a/frontend/src/features/harness/harness-page.tsx
+++ b/frontend/src/features/harness/harness-page.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useCallback, useState, type ReactNode } from "react";
+import { AppPage, Button, Card, ErrorBox, PageContainer, PageHeader, StatusPill } from "@/ui";
+import { useMountSubscription } from "@/hooks/use-mount-subscription";
+import { GitBranch, Play, RefreshCw, ShieldCheck } from "@/ui/icon-registry";
+
+type HarnessRoute = {
+  id: string;
+  model_id: string;
+  node: string;
+  runtime: string;
+  role: string;
+  status: string;
+  status_reason?: string;
+  capabilities: string[];
+  max_context_tokens: number;
+  eligible_for: string[];
+};
+
+type HarnessTask = {
+  id?: string;
+  status?: string;
+  status_label?: string;
+  summary?: string;
+  human_title?: string;
+  artifacts?: Array<{ name?: string; path?: string }>;
+  events?: Array<{ seq?: number; summary?: string; checkpoint?: string }>;
+  metadata?: { demo?: { enabled?: boolean; model_used?: boolean; workspace?: string } };
+};
+
+type RoutesResponse = { routes?: HarnessRoute[]; selection?: { policy?: string } };
+type TaskResponse = { task?: HarnessTask; current?: HarnessTask; events?: HarnessTask["events"] };
+
+async function readJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(url, { ...init, cache: "no-store" });
+  const payload = (await response.json().catch(() => ({}))) as { error?: string } & T;
+  if (!response.ok) throw new Error(payload.error || `Harness request failed (${response.status})`);
+  return payload;
+}
+
+function toneForStatus(status: string): "default" | "good" | "warning" | "danger" {
+  if (status === "ready" || status === "done" || status === "complete") return "good";
+  if (status === "unavailable" || status === "blocked") return "danger";
+  if (status === "degraded" || status === "needs_review") return "warning";
+  return "default";
+}
+
+function formatContext(tokens: number): string {
+  if (tokens >= 1000) return `${Math.round(tokens / 1000)}k context`;
+  return `${tokens} context`;
+}
+
+export default function HarnessPage() {
+  const [routes, setRoutes] = useState<HarnessRoute[]>([]);
+  const [selectionPolicy, setSelectionPolicy] = useState("harness_decides");
+  const [task, setTask] = useState<HarnessTask | null>(null);
+  const [events, setEvents] = useState<HarnessTask["events"]>([]);
+  const [loading, setLoading] = useState(true);
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState("");
+
+  const loadRoutes = useCallback(async () => {
+    const payload = await readJson<RoutesResponse>("/api/harness/routes");
+    setRoutes(payload.routes ?? []);
+    setSelectionPolicy(payload.selection?.policy ?? "harness_decides");
+  }, []);
+
+  const loadTask = useCallback(async (taskId?: string) => {
+    const target = taskId
+      ? `/api/harness/tasks/${encodeURIComponent(taskId)}`
+      : "/api/harness/tasks/current";
+    const payload = await readJson<TaskResponse>(target);
+    const nextTask = payload.task ?? payload.current ?? null;
+    setTask(nextTask);
+    if (nextTask?.id) {
+      const eventPayload = await readJson<TaskResponse>(
+        `/api/harness/tasks/${encodeURIComponent(nextTask.id)}/events?after=0`,
+      );
+      setEvents(eventPayload.events ?? nextTask.events ?? []);
+    } else {
+      setEvents([]);
+    }
+  }, []);
+
+  const refresh = useCallback(async () => {
+    setError("");
+    try {
+      await Promise.all([loadRoutes(), loadTask()]);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : "Harness is unavailable");
+    } finally {
+      setLoading(false);
+    }
+  }, [loadRoutes, loadTask]);
+
+  useMountSubscription(() => {
+    void refresh();
+  }, [refresh]);
+
+  useMountSubscription(() => {
+    if (!task?.id || ["done", "stopped", "blocked"].includes(task.status ?? "")) return;
+    const timer = window.setTimeout(() => {
+      void loadTask(task.id).catch((nextError) =>
+        setError(nextError instanceof Error ? nextError.message : "Task refresh failed"),
+      );
+    }, 3000);
+    return () => window.clearTimeout(timer);
+  }, [loadTask, task?.id, task?.status]);
+
+  const runCanary = async () => {
+    setRunning(true);
+    setError("");
+    try {
+      const payload = await readJson<TaskResponse & { task?: HarnessTask }>("/api/harness/tasks", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          kind: "read_only_canary",
+          objective: "Verify the Local Studio to Agentic Harness task boundary",
+        }),
+      });
+      const nextTask = payload.task ?? null;
+      setTask(nextTask);
+      setEvents(nextTask?.events ?? []);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : "Canary could not start");
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <AppPage>
+      <PageContainer width="lg" className="pt-6 sm:pt-8">
+        <PageHeader
+          eyebrow="Agentic Harness"
+          title="Cluster execution"
+          description="Local Studio is the operator surface. Harness owns task state, routing, events, and evidence."
+          actions={
+            <div className="flex items-center gap-2">
+              <Button
+                variant="icon"
+                size="md"
+                aria-label="Refresh Harness"
+                title="Refresh"
+                onClick={() => void refresh()}
+              >
+                <RefreshCw className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="primary"
+                size="sm"
+                icon={<Play className="h-3.5 w-3.5" />}
+                loading={running}
+                onClick={() => void runCanary()}
+              >
+                Run safe canary
+              </Button>
+            </div>
+          }
+        />
+
+        {error ? <ErrorBox className="mb-5">{error}</ErrorBox> : null}
+
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1.45fr)_minmax(18rem,0.8fr)]">
+          <Card
+            title="Live route registry"
+            description={`Harness-owned live probes · selection policy: ${selectionPolicy}`}
+          >
+            {loading && routes.length === 0 ? (
+              <p className="text-[length:var(--fs-sm)] text-(--ui-muted)">
+                Checking Node1 and Node2...
+              </p>
+            ) : routes.length === 0 ? (
+              <p className="text-[length:var(--fs-sm)] text-(--ui-muted)">No routes reported.</p>
+            ) : (
+              <div className="divide-y divide-(--ui-border)">
+                {routes.map((route) => (
+                  <div
+                    key={route.id}
+                    className="grid gap-3 py-3 first:pt-0 last:pb-0 sm:grid-cols-[1fr_auto] sm:items-center"
+                  >
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <GitBranch className="h-4 w-4 text-(--ui-muted)" />
+                        <span className="truncate text-[length:var(--fs-md)] font-medium text-(--ui-fg)">
+                          {route.model_id}
+                        </span>
+                        <StatusPill tone={toneForStatus(route.status)} variant="badge">
+                          {route.status}
+                        </StatusPill>
+                      </div>
+                      <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[length:var(--fs-xs)] text-(--ui-muted)">
+                        <span>{route.node}</span>
+                        <span>{route.runtime}</span>
+                        <span>{route.role}</span>
+                        <span>{formatContext(route.max_context_tokens)}</span>
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap gap-1 sm:justify-end">
+                      {route.capabilities.map((capability) => (
+                        <span
+                          key={capability}
+                          className="rounded-full bg-(--ui-fg)/5 px-2 py-1 text-[length:var(--fs-xs)] text-(--ui-muted)"
+                        >
+                          {capability}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </Card>
+
+          <Card title="Ownership boundary" description="The two products have different jobs.">
+            <div className="space-y-3 text-[length:var(--fs-sm)]">
+              <BoundaryRow
+                icon={<ShieldCheck className="h-4 w-4" />}
+                label="Harness"
+                value="Executor, router, durable state, events, artifacts"
+              />
+              <BoundaryRow
+                icon={<GitBranch className="h-4 w-4" />}
+                label="Local Studio"
+                value="Operator UI and model/chat surface"
+              />
+              <div className="rounded-xl bg-(--ui-fg)/5 p-3 text-[length:var(--fs-xs)] leading-relaxed text-(--ui-muted)">
+                The canary is intentionally credential-free and isolated. It proves the client path
+                without sending work to vLLM or changing your connected project.
+              </div>
+            </div>
+          </Card>
+        </div>
+
+        <Card
+          className="mt-4"
+          title="Harness task"
+          description="The safe canary uses the real Harness lifecycle and returns task evidence through the integration API."
+        >
+          {!task?.id ? (
+            <p className="text-[length:var(--fs-sm)] text-(--ui-muted)">No task loaded.</p>
+          ) : (
+            <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_minmax(16rem,0.6fr)]">
+              <div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <StatusPill tone={toneForStatus(task.status ?? "")} variant="badge">
+                    {task.status_label ?? task.status ?? "unknown"}
+                  </StatusPill>
+                  <code className="text-[length:var(--fs-xs)] text-(--ui-muted)">{task.id}</code>
+                </div>
+                <p className="mt-3 text-[length:var(--fs-sm)] text-(--ui-fg)">
+                  {task.summary ?? task.human_title}
+                </p>
+                <div className="mt-4 space-y-2">
+                  {(events ?? []).slice(-6).map((event, index) => (
+                    <div
+                      key={`${event.seq ?? index}-${event.checkpoint ?? "event"}`}
+                      className="flex gap-2 text-[length:var(--fs-xs)] text-(--ui-muted)"
+                    >
+                      <span className="shrink-0 tabular-nums">{event.seq ?? "·"}</span>
+                      <span>{event.summary ?? event.checkpoint ?? "Harness event"}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <div className="rounded-xl bg-(--ui-fg)/5 p-3">
+                <div className="text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)">
+                  Evidence
+                </div>
+                <div className="mt-2 text-[length:var(--fs-sm)] text-(--ui-fg)">
+                  {task.artifacts?.length ?? 0} artifact{task.artifacts?.length === 1 ? "" : "s"}
+                </div>
+                <div className="mt-2 space-y-1">
+                  {(task.artifacts ?? []).map((artifact) => (
+                    <div
+                      key={artifact.path ?? artifact.name}
+                      className="truncate text-[length:var(--fs-xs)] text-(--ui-muted)"
+                    >
+                      {artifact.name ?? artifact.path}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+        </Card>
+      </PageContainer>
+    </AppPage>
+  );
+}
+
+function BoundaryRow({ icon, label, value }: { icon: ReactNode; label: string; value: string }) {
+  return (
+    <div className="flex items-start gap-2">
+      <span className="mt-0.5 text-(--ui-muted)">{icon}</span>
+      <div className="min-w-0">
+        <div className="text-(--ui-fg)">{label}</div>
+        <div className="mt-0.5 text-[length:var(--fs-xs)] leading-relaxed text-(--ui-muted)">
+          {value}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/harness/harness-page.tsx
+++ b/frontend/src/features/harness/harness-page.tsx
@@ -507,7 +507,11 @@ export default function HarnessPage() {
                 }}
                 rows={5}
                 placeholder="Describe the outcome in plain language, for example: Review the Local Studio integration, make a bounded improvement, and verify it end to end."
-                aria-describedby="harness-goal-hint"
+                aria-describedby={
+                  startBlocker
+                    ? "harness-goal-hint harness-goal-blocker"
+                    : "harness-goal-hint"
+                }
                 aria-invalid={Boolean(goalError && !goal.trim())}
                 className="mt-2 block w-full resize-y rounded-xl border border-(--ui-border) bg-(--ui-bg) px-3 py-3 text-[length:var(--fs-md)] leading-relaxed text-(--ui-fg) outline-none transition focus:border-(--ui-accent) focus:ring-2 focus:ring-(--ui-accent)/20"
                 disabled={goalBusy}
@@ -776,8 +780,9 @@ export default function HarnessPage() {
               ) : null}
 
               {goalError ? <ErrorBox className="mt-4">{goalError}</ErrorBox> : null}
+              {!goalError && error ? <ErrorBox className="mt-4">{error}</ErrorBox> : null}
 
-              {startBlocker && !goalError ? (
+              {startBlocker && !goalError && !error ? (
                 <p
                   id="harness-goal-blocker"
                   className="mt-4 text-[length:var(--fs-sm)] text-(--ui-muted)"
@@ -999,8 +1004,6 @@ export default function HarnessPage() {
               Run safe canary
             </Button>
           </div>
-          {error ? <ErrorBox className="mt-3">{error}</ErrorBox> : null}
-
           <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1.45fr)_minmax(18rem,0.8fr)]">
           <Card
             title="Live route registry"

--- a/frontend/src/features/shell/left-sidebar-nav.test.ts
+++ b/frontend/src/features/shell/left-sidebar-nav.test.ts
@@ -16,7 +16,7 @@ describe("left sidebar navigation", () => {
       [
         ["/", "Status"],
         ["/agent/automations", "Automations"],
-        ["/harness", "Harness"],
+        ["/harness", "Verified Goals"],
         ["/configure", "Configure"],
         ["/usage", "Usage"],
       ],

--- a/frontend/src/features/shell/left-sidebar-nav.test.ts
+++ b/frontend/src/features/shell/left-sidebar-nav.test.ts
@@ -16,6 +16,7 @@ describe("left sidebar navigation", () => {
       [
         ["/", "Status"],
         ["/agent/automations", "Automations"],
+        ["/harness", "Harness"],
         ["/configure", "Configure"],
         ["/usage", "Usage"],
       ],

--- a/frontend/src/features/shell/left-sidebar-nav.tsx
+++ b/frontend/src/features/shell/left-sidebar-nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { type ComponentType } from "react";
-import { Activity, Clock, ServerCog, TrendingUp } from "@/ui/icon-registry";
+import { Activity, Clock, GitFork, ServerCog, TrendingUp } from "@/ui/icon-registry";
 
 export type IconComponent = ComponentType<{ className?: string; strokeWidth?: number }>;
 
@@ -10,6 +10,7 @@ export type IconComponent = ComponentType<{ className?: string; strokeWidth?: nu
 export const tabs = [
   { href: "/", label: "Status", icon: Activity },
   { href: "/agent/automations", label: "Automations", icon: Clock },
+  { href: "/harness", label: "Harness", icon: GitFork },
   { href: "/configure", label: "Configure", icon: ServerCog },
   { href: "/usage", label: "Usage", icon: TrendingUp },
 ];

--- a/frontend/src/features/shell/left-sidebar-nav.tsx
+++ b/frontend/src/features/shell/left-sidebar-nav.tsx
@@ -10,7 +10,7 @@ export type IconComponent = ComponentType<{ className?: string; strokeWidth?: nu
 export const tabs = [
   { href: "/", label: "Status", icon: Activity },
   { href: "/agent/automations", label: "Automations", icon: Clock },
-  { href: "/harness", label: "Harness", icon: GitFork },
+  { href: "/harness", label: "Verified Goals", icon: GitFork },
   { href: "/configure", label: "Configure", icon: ServerCog },
   { href: "/usage", label: "Usage", icon: TrendingUp },
 ];

--- a/shared/agent/harness.ts
+++ b/shared/agent/harness.ts
@@ -1,0 +1,42 @@
+import { Schema } from "effect";
+
+export const HARNESS_REMOTE_DATA_CONSENT_VERSION = "local_studio.harness_remote_data.v1";
+export const HARNESS_REMOTE_DATA_CONSENT_HEADER = "x-local-studio-harness-consent";
+export const HARNESS_INTEGRATION_CONTRACT_VERSION = "local_studio.harness_integration.v1";
+
+export const HarnessVerificationCheckSchema = Schema.Struct({
+  name: Schema.String,
+  passed: Schema.Boolean,
+  message: Schema.optional(Schema.String),
+  independent: Schema.Boolean,
+  source: Schema.String,
+});
+
+export type HarnessVerificationCheck = Schema.Schema.Type<typeof HarnessVerificationCheckSchema>;
+
+export type HarnessIntegrationContract = {
+  contract: typeof HARNESS_INTEGRATION_CONTRACT_VERSION;
+  target: "managed" | "provider";
+  ownership: "external";
+  configuration_source: "server_environment";
+  lifecycle: {
+    state: "reachable";
+    install: "external";
+    start: "external";
+    stop: "external";
+  };
+  remote_data: {
+    mutation_consent_required: true;
+    consent_version: typeof HARNESS_REMOTE_DATA_CONSENT_VERSION;
+  };
+};
+
+export function decodeHarnessVerificationCheck(value: unknown): HarnessVerificationCheck | null {
+  try {
+    const decoded = Schema.decodeUnknownSync(HarnessVerificationCheckSchema)(value);
+    if (!decoded.name.trim() || !decoded.source.trim()) return null;
+    return decoded;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## What changed

- adds a provider-neutral Verified Goals surface to Local Studio
- adds `/verified <objective>` in the Workbench composer and preserves the objective when opening the goal
- supports the existing managed harness and any OpenAI-compatible provider backend
- removes deployment-specific Node1 defaults from the public UI
- adds bounded, authenticated server-side proxy routes with strict route and header allowlists
- surfaces durable task state, review actions, evidence, route readiness, and actionable startup blockers

## Why

Local Studio already manages model runtimes well, but its agent Workbench did not provide a complete interface for durable Agentic Harness goals. This change connects the two without making a private cluster topology part of the product.

## User impact

A user can type a plain-language objective in Verified Goals or enter `/verified ...` from the Workbench. Local Studio starts the configured durable goal loop, polls the exact task identity, displays evidence and review state, and fails closed when independent verification is unavailable.

## Validation

- `npm run check`
- frontend: 141 passed
- controller: 78 passed
- agent runtime: 91 passed
- production standalone build passed
- focused proxy tests cover route allowlisting, credential separation, response-header filtering, body limits, and remote client scope
- real browser canary launched run `20260802T054959Z-read-only-list-the-five-newest-filenames-in-the-configured-works` through a configured vLLM route, returned evidence, made zero owned workspace changes, and stopped at review
- manual acceptance was correctly refused because that canary had no pre-registered independent verifier

## Notes

This is a draft for maintainer design review. It does not include deployment-specific URLs, tokens, model names, or private network configuration. Lint has no errors and reports two non-blocking complexity warnings in the new harness page/model.
