### PR TITLE
fix: preserve goal sends and queue order

### DIFF
--- a/frontend/src/features/agent/ui/chat-pane.tsx
+++ b/frontend/src/features/agent/ui/chat-pane.tsx
@@ -76,7 +76,7 @@ import {
   useChatPaneRuntimeHandle,
 } from "@/features/agent/ui/chat-pane-hooks";
 import { useChatPaneSessionTitle } from "@/features/agent/ui/chat-pane-session-title";
-import { useGoalCommand } from "@/features/agent/ui/use-goal-command";
+import { canRunGoalCommand, useGoalCommand } from "@/features/agent/ui/use-goal-command";
 import { useGoalMode } from "@/features/agent/ui/use-goal-mode";
 import { useChatPaneComposerActions } from "@/features/agent/ui/use-chat-pane-composer-actions";
 import { useComposerCommandHandlers } from "@/features/agent/ui/use-composer-command-handlers";
@@ -599,7 +599,8 @@ export function ChatPane({
     (event: FormEvent) => {
       if (goalModeApi.submitAsGoal(event, activeTab?.input ?? "")) return;
       const invocation = parseSlashInvocation(activeTab?.input ?? "");
-      if (invocation && commandRegistry.find(invocation.name, commandContext)) {
+      const commandCanRun = invocation?.name !== "goal" || canRunGoalCommand(activePiSessionId);
+      if (invocation && commandCanRun && commandRegistry.find(invocation.name, commandContext)) {
         event.preventDefault();
         void runCommandInvocation(invocation);
         return;
@@ -616,6 +617,7 @@ export function ChatPane({
     },
     [
       activeTab,
+      activePiSessionId,
       commandContext,
       commandRegistry,
       goalModeApi,

--- a/frontend/src/features/agent/ui/projects-nav/helpers.test.ts
+++ b/frontend/src/features/agent/ui/projects-nav/helpers.test.ts
@@ -7,6 +7,10 @@ describe("visibleSessionAge", () => {
     assert.equal(visibleSessionAge(true, "2026-07-31T12:00:00.000Z"), "");
   });
 
+  test("hides timestamps beside completion activity", () => {
+    assert.equal(visibleSessionAge(false, new Date().toISOString(), true), "");
+  });
+
   test("preserves timestamps for inactive sessions", () => {
     assert.equal(visibleSessionAge(false, new Date().toISOString()), "now");
   });

--- a/frontend/src/features/agent/ui/projects-nav/helpers.ts
+++ b/frontend/src/features/agent/ui/projects-nav/helpers.ts
@@ -89,8 +89,12 @@ export function relativeAge(value?: string | null): string {
   return `${Math.floor(days / 7)}w`;
 }
 
-export function visibleSessionAge(isRunning: boolean, value?: string | null): string {
-  return isRunning ? "" : relativeAge(value);
+export function visibleSessionAge(
+  isRunning: boolean,
+  value?: string | null,
+  completionActivity = false,
+): string {
+  return isRunning || completionActivity ? "" : relativeAge(value);
 }
 
 export function hrefWithOpenNonce(href: string): string {

--- a/frontend/src/features/agent/ui/projects-nav/session-nav-row.tsx
+++ b/frontend/src/features/agent/ui/projects-nav/session-nav-row.tsx
@@ -317,7 +317,7 @@ function SessionRowContent({
   timestamp?: string | null;
   label: string;
 }) {
-  const age = visibleSessionAge(isRunning, timestamp);
+  const age = visibleSessionAge(isRunning, timestamp, finished);
   return (
     <>
       <span className="min-w-0 flex-1 overflow-hidden whitespace-nowrap text-[length:var(--fs-md)] font-normal leading-5 [mask-image:linear-gradient(to_right,black_calc(100%-20px),transparent)]">

--- a/frontend/src/features/agent/ui/use-goal-command.test.ts
+++ b/frontend/src/features/agent/ui/use-goal-command.test.ts
@@ -1,0 +1,8 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { canRunGoalCommand } from "./use-goal-command";
+
+test("goal command stays a normal message until the session has a Pi identity", () => {
+  assert.equal(canRunGoalCommand(null), false);
+  assert.equal(canRunGoalCommand("pi-session"), true);
+});

--- a/frontend/src/features/agent/ui/use-goal-command.ts
+++ b/frontend/src/features/agent/ui/use-goal-command.ts
@@ -3,6 +3,10 @@
 import { useCallback, useState } from "react";
 import { clearSessionGoal, updateSessionGoal } from "@/features/agent/runtime/api";
 
+export function canRunGoalCommand(piSessionId: string | null): piSessionId is string {
+  return Boolean(piSessionId);
+}
+
 /** Backs the `/goal` composer command.
  *
  * `revision` bumps on every successful mutation so the composer drawer's goal
@@ -17,7 +21,8 @@ export function useGoalCommand(piSessionId: string | null): {
 
   const goalAction = useCallback(
     async (args: string): Promise<string | null> => {
-      if (!piSessionId) return "Send a first message, then set a goal for this session.";
+      if (!canRunGoalCommand(piSessionId))
+        return "Send a first message, then set a goal for this session.";
       if (!args) return "Usage: /goal <objective> — or /goal pause · resume · clear";
       const verb = args.split(/\s+/)[0]?.toLowerCase() ?? "";
       try {

--- a/services/agent-runtime/src/pi-runtime.ts
+++ b/services/agent-runtime/src/pi-runtime.ts
@@ -86,6 +86,22 @@ export function planQueuedFollowUpMutation(
   };
 }
 
+type QueueTransport = {
+  steer: (message: string, images?: AgentImageInput[]) => Promise<void>;
+  followUp: (message: string, images?: AgentImageInput[]) => Promise<void>;
+};
+
+export async function restoreQueuedMessages(
+  session: QueueTransport,
+  cleared: { steering: readonly string[]; followUp: readonly string[] },
+  mutation: { promoted: string | null; followUp: readonly string[] } | null,
+  images: AgentImageInput[] = [],
+): Promise<void> {
+  for (const queued of cleared.steering) await session.steer(queued);
+  if (mutation?.promoted) await session.steer(mutation.promoted, images);
+  for (const queued of mutation?.followUp ?? cleared.followUp) await session.followUp(queued);
+}
+
 type DurableSessionManager = Pick<
   SessionManager,
   "appendCustomEntry" | "getCwd" | "getEntries" | "getSessionFile" | "getSessionId"
@@ -597,17 +613,10 @@ class PiSdkSession extends EventEmitter implements PiAgentSession {
               replacement,
             );
             if (!mutation) {
-              await Promise.all([
-                ...cleared.steering.map((queued) => session.steer(queued)),
-                ...cleared.followUp.map((queued) => session.followUp(queued)),
-              ]);
+              await restoreQueuedMessages(session, cleared, null);
               throw new Error("Queued follow-up is no longer pending.");
             }
-            await Promise.all([
-              ...cleared.steering.map((queued) => session.steer(queued)),
-              ...(mutation.promoted ? [session.steer(mutation.promoted, images)] : []),
-              ...mutation.followUp.map((queued) => session.followUp(queued)),
-            ]);
+            await restoreQueuedMessages(session, cleared, mutation, images);
           } finally {
             this.queueEventBufferDepth -= 1;
             if (this.queueEventBufferDepth === 0 && this.bufferedQueueEvent) {

--- a/services/agent-runtime/test/queue-promotion.test.ts
+++ b/services/agent-runtime/test/queue-promotion.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { parseAgentTurnRequest } from "../../../shared/agent/agent-turn";
-import { planQueuedFollowUpMutation, takeQueuedFollowUp } from "../src/pi-runtime";
+import {
+  planQueuedFollowUpMutation,
+  restoreQueuedMessages,
+  takeQueuedFollowUp,
+} from "../src/pi-runtime";
 
 describe("takeQueuedFollowUp", () => {
   test("removes one exact queued message and preserves order", () => {
@@ -57,6 +61,24 @@ describe("planQueuedFollowUpMutation", () => {
       followUp: ["first", "new", "last"],
     });
   });
+});
+
+test("restores queued messages in delivery order", async () => {
+  const calls: string[] = [];
+  await restoreQueuedMessages(
+    {
+      steer: async (message) => void calls.push(`steer:${message}`),
+      followUp: async (message) => void calls.push(`follow:${message}`),
+    },
+    { steering: ["already steering"], followUp: ["first", "promote", "last"] },
+    { promoted: "promote", followUp: ["first", "last"] },
+  );
+  expect(calls).toEqual([
+    "steer:already steering",
+    "steer:promote",
+    "follow:first",
+    "follow:last",
+  ]);
 });
 
 describe("queued action contract", () => {


### PR DESCRIPTION
Fixes three user-visible agent regressions.

- New sessions send `/goal …` as ordinary text instead of blocking on a missing Pi identity
- Queue promotion restores Pi messages serially, preserving steer/follow-up order
- Completion dots no longer reserve a timestamp slot

Validated with `npm run check`.