### PR TITLE
fix: restore live steering and tailnet pairing copy

### DIFF
--- a/controller/bun.lock
+++ b/controller/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "local-studio-controller",
       "dependencies": {
-        "@earendil-works/pi-ai": "0.80.8",
+        "@earendil-works/pi-ai": "0.83.0",
         "@hono/standard-validator": "0.2.3",
         "@hono/swagger-ui": "0.5.3",
         "@standard-community/standard-json": "0.3.5",
@@ -112,7 +112,7 @@
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.8", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-GkiMUP3PB0hwBhj7qNppCa6z1U+CnwBf4gcxC+fg2PWdNrliaJQQNp4DUERiZqS7MJBLEu56kwpdrG7Tjymonw=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.83.0", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 
@@ -860,7 +860,7 @@
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
-    "typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
+    "typebox": ["typebox@1.3.7", "", {}, "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg=="],
 
     "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
 

--- a/controller/package.json
+++ b/controller/package.json
@@ -16,7 +16,7 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.80.8",
+    "@earendil-works/pi-ai": "0.83.0",
     "@hono/standard-validator": "0.2.3",
     "@hono/swagger-ui": "0.5.3",
     "@standard-community/standard-json": "0.3.5",

--- a/frontend/.depcheckrc.json
+++ b/frontend/.depcheckrc.json
@@ -2,6 +2,7 @@
   "ignores": [
     "@hono/node-server",
     "@modelcontextprotocol/sdk",
+    "brace-expansion",
     "chromium-bidi",
     "fast-check",
     "playwright-core",

--- a/frontend/desktop/project.mjs
+++ b/frontend/desktop/project.mjs
@@ -1334,10 +1334,10 @@ var init_link_services_node_modules = __esm(() => {
 });
 
 var exports_patch_pi_ai_openai_text_boundaries = {};
-import { existsSync as existsSync7, readFileSync as readFileSync9, writeFileSync as writeFileSync3 } from "node:fs";
+import { cpSync as cpSync4, existsSync as existsSync7, readFileSync as readFileSync9, rmSync as rmSync10, writeFileSync as writeFileSync3 } from "node:fs";
 import path6 from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
-var frontendRoot, targetFiles, helperMarker = "function localStudioJoinTextParts", helper, injectionPoint = `function isTextContentBlock(block) {
+var frontendRoot, targetFiles, secureBraceExpansion, bundledBraceExpansion, helperMarker = "function localStudioJoinTextParts", helper, injectionPoint = `function isTextContentBlock(block) {
     return block.type === "text";
 }
 `, helperStartMarker = "function localStudioTextPartBoundary", helperEndMarker = "function isThinkingContentBlock", originalJoin = 'const assistantText = assistantTextParts.map((part) => part.text).join("");', patchedJoin = "const assistantText = localStudioJoinTextParts(assistantTextParts);", found = 0, patched = 0;
@@ -1345,7 +1345,15 @@ var init_patch_pi_ai_openai_text_boundaries = __esm(() => {
   frontendRoot = path6.resolve(path6.dirname(fileURLToPath5(import.meta.url)), ".."), targetFiles = [
     path6.join(frontendRoot, "node_modules/@earendil-works/pi-ai/dist/api/openai-completions.js"),
     path6.join(frontendRoot, "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/api/openai-completions.js")
-  ], helper = [
+  ], secureBraceExpansion = path6.join(frontendRoot, "node_modules/brace-expansion"), bundledBraceExpansion = path6.join(frontendRoot, "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion");
+  if (existsSync7(secureBraceExpansion) && existsSync7(bundledBraceExpansion)) {
+    let secureVersion = JSON.parse(readFileSync9(path6.join(secureBraceExpansion, "package.json"), "utf8")).version;
+    if (secureVersion !== "5.0.8")
+      throw Error(`Expected brace-expansion 5.0.8, found ${secureVersion}`);
+    if (JSON.parse(readFileSync9(path6.join(bundledBraceExpansion, "package.json"), "utf8")).version !== secureVersion)
+      rmSync10(bundledBraceExpansion, { recursive: !0, force: !0 }), cpSync4(secureBraceExpansion, bundledBraceExpansion, { recursive: !0 }), console.log(`Patched Pi SDK brace-expansion to ${secureVersion}.`);
+  }
+  helper = [
     "function localStudioTextPartBoundary(left, right) {",
     "    if (!left || !right || /\\s$/.test(left) || /^\\s/.test(right))",
     '        return "";',

--- a/frontend/knip.ts
+++ b/frontend/knip.ts
@@ -20,6 +20,7 @@ const config = {
     "@local-studio/agent-runtime",
     "@hono/node-server",
     "@modelcontextprotocol/sdk",
+    "brace-expansion",
     // Declared here but imported from services/agent-runtime (browser-host).
     // knip only sees that importer locally, through the node_modules symlink
     // the frontend postinstall creates. CI has no symlink, so it reports the

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,8 +9,8 @@
       "version": "2.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@earendil-works/pi-ai": "0.80.8",
-        "@earendil-works/pi-coding-agent": "0.80.8",
+        "@earendil-works/pi-ai": "0.83.0",
+        "@earendil-works/pi-coding-agent": "0.83.0",
         "@hono/node-server": "^2.0.12",
         "@local-studio/agent-runtime": "file:../services/agent-runtime",
         "@local-studio/contracts": "file:../controller/contracts",
@@ -75,8 +75,8 @@
       "name": "@local-studio/agent-runtime",
       "version": "2.1.0",
       "dependencies": {
-        "@earendil-works/pi-ai": "0.80.8",
-        "@earendil-works/pi-coding-agent": "0.80.8",
+        "@earendil-works/pi-ai": "0.83.0",
+        "@earendil-works/pi-coding-agent": "0.83.0",
         "@hono/node-server": "^2.0.12",
         "@lydell/node-pty": "1.2.0-beta.12",
         "@modelcontextprotocol/sdk": "1.30.0",
@@ -893,9 +893,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.8",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.8.tgz",
-      "integrity": "sha512-GkiMUP3PB0hwBhj7qNppCa6z1U+CnwBf4gcxC+fg2PWdNrliaJQQNp4DUERiZqS7MJBLEu56kwpdrG7Tjymonw==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.83.0.tgz",
+      "integrity": "sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -908,7 +908,7 @@
         "https-proxy-agent": "7.0.6",
         "openai": "6.26.0",
         "partial-json": "0.1.7",
-        "typebox": "1.1.38"
+        "typebox": "1.3.7"
       },
       "bin": {
         "pi-ai": "dist/cli.js"
@@ -917,16 +917,22 @@
         "node": ">=22.19.0"
       }
     },
+    "node_modules/@earendil-works/pi-ai/node_modules/typebox": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+      "license": "MIT"
+    },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.8",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.8.tgz",
-      "integrity": "sha512-oal0jK9E221Imhrj4Q4wXOhWmhzZEzbt9gmbVHs3UR4+KaClg+Ki1vH2FTVY7hntga89koPFSq4kQ6XV/HoSng==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.83.0.tgz",
+      "integrity": "sha512-uYhF+FsZxogoSX/AxBcUdiY+ZklubwaXyAoEGA2eQwsHcyEAhUYIKh/WLXe/a8+k8eTCmxb+ZN2Zo9mzQtzbWw==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.8",
-        "@earendil-works/pi-ai": "^0.80.8",
-        "@earendil-works/pi-tui": "^0.80.8",
+        "@earendil-works/pi-agent-core": "^0.83.0",
+        "@earendil-works/pi-ai": "^0.83.0",
+        "@earendil-works/pi-tui": "^0.83.0",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -939,7 +945,7 @@
         "minimatch": "10.2.5",
         "proper-lockfile": "4.1.2",
         "semver": "7.8.0",
-        "typebox": "1.1.38",
+        "typebox": "1.3.7",
         "undici": "8.5.0",
         "yaml": "2.9.0"
       },
@@ -1389,13 +1395,14 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.8",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.8.tgz",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.83.0.tgz",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.8",
+        "@earendil-works/pi-ai": "^0.83.0",
+        "diff": "8.0.4",
         "ignore": "7.0.5",
-        "typebox": "1.1.38",
+        "typebox": "1.3.7",
         "yaml": "2.9.0"
       },
       "engines": {
@@ -1403,8 +1410,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.8",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.8.tgz",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.83.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -1417,18 +1424,18 @@
         "https-proxy-agent": "7.0.6",
         "openai": "6.26.0",
         "partial-json": "0.1.7",
-        "typebox": "1.1.38"
+        "typebox": "1.3.7"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.8",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.8.tgz",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.83.0.tgz",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -1536,9 +1543,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1554,9 +1558,6 @@
       "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1574,9 +1575,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1593,9 +1591,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1611,9 +1606,6 @@
       "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1952,9 +1944,9 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2522,9 +2514,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2637,9 +2629,9 @@
       "license": "0BSD"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "@xterm/addon-fit": "0.11.0",
         "@xterm/addon-web-links": "0.13.0-beta.220",
         "@xterm/xterm": "6.1.0-beta.285",
+        "brace-expansion": "5.0.8",
         "chromium-bidi": "0.12.0",
         "effect": "4.0.0-beta.90",
         "electron-updater": "6.8.9",
@@ -1944,15 +1945,15 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
@@ -7540,7 +7541,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -7690,7 +7690,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
       "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,6 +56,7 @@
     "@xterm/addon-fit": "0.11.0",
     "@xterm/addon-web-links": "0.13.0-beta.220",
     "@xterm/xterm": "6.1.0-beta.285",
+    "brace-expansion": "5.0.8",
     "chromium-bidi": "0.12.0",
     "effect": "4.0.0-beta.90",
     "electron-updater": "6.8.9",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,8 +46,8 @@
     "typecheck:extensions": "tsc -p desktop/resources/pi-extensions/tsconfig.json"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.80.8",
-    "@earendil-works/pi-coding-agent": "0.80.8",
+    "@earendil-works/pi-ai": "0.83.0",
+    "@earendil-works/pi-coding-agent": "0.83.0",
     "@hono/node-server": "^2.0.12",
     "@local-studio/agent-runtime": "file:../services/agent-runtime",
     "@local-studio/contracts": "file:../controller/contracts",

--- a/frontend/src/features/agent/ui/assistant-markdown.tsx
+++ b/frontend/src/features/agent/ui/assistant-markdown.tsx
@@ -7,6 +7,7 @@ import remarkGfm from "remark-gfm";
 import { normalizeBrowserInput } from "@/features/agent/tools/browser-url";
 import { useToolsActions } from "@/features/agent/tools/context";
 import type { ComputerTab } from "@/features/agent/tools/types";
+import { writeClipboardText } from "@/lib/clipboard";
 
 const FILE_REF_PATTERN =
   /^(?:file:\/\/|~\/|\.{1,2}\/|\/|[\w.-]+\/)[^\s`'")]+(?:\.[A-Za-z0-9][A-Za-z0-9_-]*)(?::\d+(?::\d+)?)?$/;
@@ -50,8 +51,7 @@ class MarkdownErrorBoundary extends React.Component<
 function CodeBlockCopyButton({ code }: { code: string }) {
   const [copied, markCopied] = useCopiedFlag();
   const handleCopy = useCallback(() => {
-    if (typeof navigator === "undefined" || !navigator.clipboard) return;
-    void navigator.clipboard.writeText(code).then(markCopied, () => undefined);
+    void writeClipboardText(code).then(markCopied, () => undefined);
   }, [code, markCopied]);
   return (
     <button
@@ -220,7 +220,11 @@ function buildComponentsWithAppLinks(tools: ToolHandlers): Components {
     },
     a: ({ node: _n, href, children, ...props }) => {
       if (typeof href === "string" && isFileReference(href)) {
-        return <FileLink onOpen={openFileReference} value={href}>{children}</FileLink>;
+        return (
+          <FileLink onOpen={openFileReference} value={href}>
+            {children}
+          </FileLink>
+        );
       }
       if (!safeExternalHref(href)) return <span>{children}</span>;
       return (

--- a/frontend/src/features/agent/ui/timeline/assistant-message-actions.tsx
+++ b/frontend/src/features/agent/ui/timeline/assistant-message-actions.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { Copy, GitFork } from "@/ui/icon-registry";
 import { useCopiedFlag } from "@/features/agent/ui/use-copied-flag";
+import { writeClipboardText } from "@/lib/clipboard";
 
 export function AssistantActionButton({
   label,
@@ -37,7 +38,7 @@ export function AssistantMessageActions({
   const [copied, markCopied] = useCopiedFlag();
   const copy = async () => {
     if (!copyText.trim()) return;
-    await navigator.clipboard.writeText(copyText);
+    await writeClipboardText(copyText);
     markCopied();
   };
   return (

--- a/frontend/src/features/agent/ui/timeline/user-message-block.tsx
+++ b/frontend/src/features/agent/ui/timeline/user-message-block.tsx
@@ -2,6 +2,7 @@ import { Copy } from "@/ui/icon-registry";
 import { useCopiedFlag } from "@/features/agent/ui/use-copied-flag";
 import type { ChatMessage, ChatMessageAttachment } from "@/features/agent/messages";
 import { AssistantActionButton } from "@/features/agent/ui/timeline/assistant-message-actions";
+import { writeClipboardText } from "@/lib/clipboard";
 
 function formatAttachmentSize(bytes: number) {
   if (bytes < 1024) return `${bytes} B`;
@@ -87,7 +88,7 @@ export function UserMessage({ message }: { message: ChatMessage }) {
   const [copied, markCopied] = useCopiedFlag();
   const copy = async () => {
     if (!message.text.trim()) return;
-    await navigator.clipboard.writeText(message.text);
+    await writeClipboardText(message.text);
     markCopied();
   };
   // A quiet foreground-tinted block sized to its content, capped by the same

--- a/frontend/src/features/integrations/skills-section.tsx
+++ b/frontend/src/features/integrations/skills-section.tsx
@@ -12,6 +12,7 @@ import {
   ModelValue,
 } from "@/features/recipes/recipes-content/model-page";
 import { useMountSubscription } from "@/hooks/use-mount-subscription";
+import { writeClipboardText } from "@/lib/clipboard";
 
 const SkillSchema = Schema.Struct({
   id: Schema.String,
@@ -69,8 +70,7 @@ function SkillDrawer({
           <Button
             variant="secondary"
             onClick={() => {
-              void navigator.clipboard
-                .writeText(skill.path)
+              void writeClipboardText(skill.path)
                 .then(() => setCopied(true))
                 .catch(() => setCopied(false));
             }}

--- a/frontend/src/features/recipes/recipes-content/explore-model-row.tsx
+++ b/frontend/src/features/recipes/recipes-content/explore-model-row.tsx
@@ -19,6 +19,7 @@ import { extractQuantizations } from "@/features/recipes/model-quantizations";
 import type { ModelFit } from "./hardware-profile";
 import { effectTimeout } from "@/lib/effect-timers";
 import { useMountSubscription } from "@/hooks/use-mount-subscription";
+import { writeClipboardText } from "@/lib/clipboard";
 
 function ExploreVramCell({
   needGb,
@@ -103,10 +104,11 @@ export const ExploreModelRow = memo(function ExploreModelRow({
   useMountSubscription(() => () => copiedTimer.current?.cancel(), []);
 
   const copyId = useCallback(() => {
-    void navigator.clipboard.writeText(model.modelId);
-    setCopied(true);
-    copiedTimer.current?.cancel();
-    copiedTimer.current = effectTimeout(() => setCopied(false), 2000);
+    void writeClipboardText(model.modelId).then(() => {
+      setCopied(true);
+      copiedTimer.current?.cancel();
+      copiedTimer.current = effectTimeout(() => setCopied(false), 2000);
+    });
   }, [model.modelId]);
 
   const download = downloadStatus(isLocal, isStarting, activeDownload);

--- a/frontend/src/features/settings/clipboard.test.ts
+++ b/frontend/src/features/settings/clipboard.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { writeClipboardText } from "@/lib/clipboard";
+
+describe("writeClipboardText", () => {
+  test("uses the Clipboard API when available", async () => {
+    const values: string[] = [];
+    await writeClipboardText("connection", {
+      clipboard: { writeText: async (value) => void values.push(value) },
+      fallback: () => false,
+    });
+    assert.deepEqual(values, ["connection"]);
+  });
+
+  test("falls back when the Clipboard API is unavailable", async () => {
+    const values: string[] = [];
+    await writeClipboardText("connection", {
+      clipboard: null,
+      fallback: (value) => {
+        values.push(value);
+        return true;
+      },
+    });
+    assert.deepEqual(values, ["connection"]);
+  });
+
+  test("rejects when neither copy path succeeds", async () => {
+    await assert.rejects(
+      writeClipboardText("connection", { clipboard: null, fallback: () => false }),
+      /Clipboard access is unavailable/,
+    );
+  });
+});

--- a/frontend/src/features/settings/profile-settings.tsx
+++ b/frontend/src/features/settings/profile-settings.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/features/shell/local-profile";
 import { QrCode } from "@/features/shell/qr-code";
 import { useMountSubscription } from "@/hooks/use-mount-subscription";
+import { writeClipboardText } from "@/lib/clipboard";
 import { SettingsButton, SettingsGroup, SettingsLink } from "./settings-ui";
 
 export function ProfileSettings() {
@@ -173,7 +174,7 @@ function PhonePairingSettings() {
         const result = await desktop(value);
         if (!result.ok) throw new Error(result.error || "Connection JSON could not be copied.");
       } else {
-        await navigator.clipboard.writeText(value);
+        await writeClipboardText(value);
       }
       setCopied(true);
       setPairingError("");

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -1,0 +1,45 @@
+type ClipboardWriter = Pick<Clipboard, "writeText">;
+
+type ClipboardWriteOptions = {
+  clipboard?: ClipboardWriter | null;
+  fallback?: (value: string) => boolean;
+};
+
+function copyWithSelection(value: string): boolean {
+  if (typeof document === "undefined" || !document.body) return false;
+  const previous = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  const textarea = document.createElement("textarea");
+  textarea.value = value;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  textarea.style.top = "0";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  textarea.setSelectionRange(0, value.length);
+  const copied = document.execCommand("copy");
+  textarea.remove();
+  previous?.focus();
+  return copied;
+}
+
+export async function writeClipboardText(
+  value: string,
+  options: ClipboardWriteOptions = {},
+): Promise<void> {
+  const clipboard =
+    options.clipboard === undefined
+      ? typeof navigator === "undefined"
+        ? null
+        : navigator.clipboard
+      : options.clipboard;
+  if (clipboard?.writeText) {
+    await clipboard.writeText(value);
+    return;
+  }
+  if (!(options.fallback ?? copyWithSelection)(value)) {
+    throw new Error("Clipboard access is unavailable in this browser.");
+  }
+}

--- a/services/agent-runtime/bun.lock
+++ b/services/agent-runtime/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "@local-studio/agent-runtime",
       "dependencies": {
-        "@earendil-works/pi-ai": "0.80.8",
-        "@earendil-works/pi-coding-agent": "0.80.8",
+        "@earendil-works/pi-ai": "0.83.0",
+        "@earendil-works/pi-coding-agent": "0.83.0",
         "@hono/node-server": "^2.0.12",
         "@lydell/node-pty": "1.2.0-beta.12",
         "@modelcontextprotocol/sdk": "1.30.0",
@@ -75,13 +75,13 @@
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.80.10", "", { "dependencies": { "@earendil-works/pi-ai": "^0.80.10", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-nwnOR3SuLYGRFfyQm8ri4Nj5VGVAvAM9GuqQd3u7BUQj0d6hmD2F8w7OHAAjThE3CuySIdM+v8E22QJG6/RfCg=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.83.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.83.0", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, "sha512-RorGp9OH5l3ElpuC5a5ZQ2eWcchZGXflXRzVGkV99y3y6tT+LLNyxoYIdVKvTKWEObwhExeQbTH0fI2tE4iX4g=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.8", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-GkiMUP3PB0hwBhj7qNppCa6z1U+CnwBf4gcxC+fg2PWdNrliaJQQNp4DUERiZqS7MJBLEu56kwpdrG7Tjymonw=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.83.0", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.80.8", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.80.8", "@earendil-works/pi-ai": "^0.80.8", "@earendil-works/pi-tui": "^0.80.8", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-oal0jK9E221Imhrj4Q4wXOhWmhzZEzbt9gmbVHs3UR4+KaClg+Ki1vH2FTVY7hntga89koPFSq4kQ6XV/HoSng=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.83.0", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.83.0", "@earendil-works/pi-ai": "^0.83.0", "@earendil-works/pi-tui": "^0.83.0", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.3.7", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-uYhF+FsZxogoSX/AxBcUdiY+ZklubwaXyAoEGA2eQwsHcyEAhUYIKh/WLXe/a8+k8eTCmxb+ZN2Zo9mzQtzbWw=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.80.10", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.83.0", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-IoYrb0rORjELmEpNtoCA/U8je3KopMkRAVJRdSzvXRvgb+Huo1gNh8Q5CSZvNOiYtDxJdj2tYZZHZ4B3+IN3hA=="],
 
     "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
@@ -487,7 +487,7 @@
 
     "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
-    "typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
+    "typebox": ["typebox@1.3.7", "", {}, "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg=="],
 
     "undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
 
@@ -518,8 +518,6 @@
     "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1092.0", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/nested-clients": "^3.997.34", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-hBYUAr6iBLNFcsiWTgtBb0stdSw39VOUq4Sp4A5caCNf66BAZplWN4FleKrVpJx5li2YgdnK2DqoFSMWC642FQ=="],
 
     "@aws-sdk/nested-clients/@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.9", "", { "dependencies": { "@smithy/core": "^3.29.7", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-xVBZ3hptB99iNO9XyWqEhC7KD9bP9UPXhuy3h5Y2ItCfBv160D9IIC/Fmmp3EbnWwit4C+KVqlSE+E29Nk/pPg=="],
-
-    "@earendil-works/pi-agent-core/@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.10", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA=="],
 
     "@earendil-works/pi-coding-agent/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 

--- a/services/agent-runtime/package.json
+++ b/services/agent-runtime/package.json
@@ -16,10 +16,10 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.80.8",
-    "@lydell/node-pty": "1.2.0-beta.12",
-    "@earendil-works/pi-coding-agent": "0.80.8",
+    "@earendil-works/pi-ai": "0.83.0",
+    "@earendil-works/pi-coding-agent": "0.83.0",
     "@hono/node-server": "^2.0.12",
+    "@lydell/node-pty": "1.2.0-beta.12",
     "@modelcontextprotocol/sdk": "1.30.0",
     "chromium-bidi": "0.12.0",
     "effect": "4.0.0-beta.90",

--- a/services/agent-runtime/src/pi-runtime.ts
+++ b/services/agent-runtime/src/pi-runtime.ts
@@ -91,6 +91,11 @@ type QueueTransport = {
   followUp: (message: string, images?: AgentImageInput[]) => Promise<void>;
 };
 
+type InterruptTransport = QueueTransport & {
+  abort: () => Promise<void>;
+  waitForIdle: () => Promise<void>;
+};
+
 export async function restoreQueuedMessages(
   session: QueueTransport,
   cleared: { steering: readonly string[]; followUp: readonly string[] },
@@ -100,6 +105,17 @@ export async function restoreQueuedMessages(
   for (const queued of cleared.steering) await session.steer(queued);
   if (mutation?.promoted) await session.steer(mutation.promoted, images);
   for (const queued of mutation?.followUp ?? cleared.followUp) await session.followUp(queued);
+}
+
+export async function interruptWithPrompt(
+  session: InterruptTransport,
+  queued: { steering: readonly string[]; followUp: readonly string[] },
+  launchPrompt: () => void,
+): Promise<void> {
+  await session.abort();
+  await session.waitForIdle();
+  launchPrompt();
+  await restoreQueuedMessages(session, queued, null);
 }
 
 type DurableSessionManager = Pick<
@@ -587,7 +603,18 @@ class PiSdkSession extends EventEmitter implements PiAgentSession {
   steer(message: string, images: AgentImageInput[] = []): Promise<void> {
     return Effect.runPromise(
       Effect.tryPromise({
-        try: () => this.requireSession().steer(message, images),
+        try: async () => {
+          const session = this.requireSession();
+          this.queueEventBufferDepth += 1;
+          try {
+            const cleared = session.clearQueue();
+            await interruptWithPrompt(session, cleared, () => {
+              void this.prompt(message, () => undefined, { images }).catch(() => undefined);
+            });
+          } finally {
+            this.flushBufferedQueueEvent();
+          }
+        },
         catch: (error) => error,
       }),
     );
@@ -616,14 +643,21 @@ class PiSdkSession extends EventEmitter implements PiAgentSession {
               await restoreQueuedMessages(session, cleared, null);
               throw new Error("Queued follow-up is no longer pending.");
             }
-            await restoreQueuedMessages(session, cleared, mutation, images);
-          } finally {
-            this.queueEventBufferDepth -= 1;
-            if (this.queueEventBufferDepth === 0 && this.bufferedQueueEvent) {
-              const event = this.bufferedQueueEvent;
-              this.bufferedQueueEvent = null;
-              this.recordEvent(event);
+            if (mutation.promoted) {
+              await interruptWithPrompt(
+                session,
+                { steering: cleared.steering, followUp: mutation.followUp },
+                () => {
+                  void this.prompt(mutation.promoted!, () => undefined, { images }).catch(
+                    () => undefined,
+                  );
+                },
+              );
+            } else {
+              await restoreQueuedMessages(session, cleared, mutation, images);
             }
+          } finally {
+            this.flushBufferedQueueEvent();
           }
         },
         catch: (error) => error,
@@ -854,6 +888,14 @@ class PiSdkSession extends EventEmitter implements PiAgentSession {
     if (this.eventLog.length > 2_000) this.eventLog.splice(0, this.eventLog.length - 2_000);
     this.emit("loggedEvent", logged);
     this.emit("event", event);
+  }
+
+  private flushBufferedQueueEvent() {
+    this.queueEventBufferDepth -= 1;
+    if (this.queueEventBufferDepth !== 0 || !this.bufferedQueueEvent) return;
+    const event = this.bufferedQueueEvent;
+    this.bufferedQueueEvent = null;
+    this.recordEvent(event);
   }
 }
 

--- a/services/agent-runtime/test/queue-promotion.test.ts
+++ b/services/agent-runtime/test/queue-promotion.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { parseAgentTurnRequest } from "../../../shared/agent/agent-turn";
 import {
+  interruptWithPrompt,
   planQueuedFollowUpMutation,
   restoreQueuedMessages,
   takeQueuedFollowUp,
@@ -76,6 +77,28 @@ test("restores queued messages in delivery order", async () => {
   expect(calls).toEqual([
     "steer:already steering",
     "steer:promote",
+    "follow:first",
+    "follow:last",
+  ]);
+});
+
+test("interrupts before launching the steered prompt and restores the queue", async () => {
+  const calls: string[] = [];
+  await interruptWithPrompt(
+    {
+      abort: async () => void calls.push("abort"),
+      waitForIdle: async () => void calls.push("idle"),
+      steer: async (message) => void calls.push(`steer:${message}`),
+      followUp: async (message) => void calls.push(`follow:${message}`),
+    },
+    { steering: ["already steering"], followUp: ["first", "last"] },
+    () => void calls.push("prompt:promoted"),
+  );
+  expect(calls).toEqual([
+    "abort",
+    "idle",
+    "prompt:promoted",
+    "steer:already steering",
     "follow:first",
     "follow:last",
   ]);


### PR DESCRIPTION
## What changed

- replace Pi SDK steer queuing with an explicit abort, idle wait, replacement prompt, and queue restoration
- update all Pi SDK packages to 0.83.0
- add a secure-context-aware clipboard helper so pairing JSON and other copy actions work on HTTP tailnet pages
- cover queued-message promotion order and clipboard fallback behavior

## Why

Pi SDK steer was appending a message without reliably interrupting an active turn, and `navigator.clipboard` is unavailable on non-secure HTTP tailnet origins. The app now owns the interruption boundary and uses a selection-based clipboard fallback when the Clipboard API is unavailable.

## Validation

- `npm run check`
- `npm run test:integration`
- `npm --prefix frontend run desktop:dist:dev`
- installed with `scripts/install-desktop-app.sh dev`; health endpoints passed and embedded runtime hash matched the build
- installed-app `/goal` literal message passed
- installed-app Enter queue ordering passed (`ACTIVE_QUEUE_DONE` before `QUEUE_ORDER_OK`)
- installed-app Steer interrupted active output; durable Pi session recorded `stopReason: aborted` before `DIRECT_STEER_OK`
- installed-app pairing JSON copied and validated without exposing its token
- active task indicator visually shows the green dot without a timestamp
