### PR TITLE
fix: validate large rollback archives without SIGPIPE

### DIFF
--- a/frontend/desktop/project.mjs
+++ b/frontend/desktop/project.mjs
@@ -2807,6 +2807,9 @@ function prePush() {
   run3("npm", ["run", "check:static"], path11.join(root5, "frontend")), run3("npm", ["run", "check:cleanup"], path11.join(root5, "frontend")), run3(process.execPath, [path11.join(root5, "scripts/project.mjs"), "assert-standalone"]);
 }
 function setupHooks() {
+  let worktree = spawnSync4("git", ["rev-parse", "--is-inside-work-tree"], { cwd: root5, encoding: "utf8" });
+  if (worktree.status !== 0 || worktree.stdout.trim() !== "true")
+    return console.log("Skipping Git hook setup outside a worktree");
   git(["rev-parse", "--git-dir"]), git(["config", "core.hooksPath", ".githooks"]);
   for (let name of readdirSync10(path11.join(root5, ".githooks")))
     chmodSync2(path11.join(root5, ".githooks", name), 493);

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -65,6 +65,7 @@ const nextConfig: NextConfig = {
       "./tsconfig*.json",
       "./tsconfig*.tsbuildinfo",
       "../controller/**/*",
+      "../data/**/*",
       "../scripts/**/*",
       "../services/**/*",
       "../shared/**/*",

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -65,7 +65,6 @@ const nextConfig: NextConfig = {
       "./tsconfig*.json",
       "./tsconfig*.tsbuildinfo",
       "../controller/**/*",
-      "../data/**/*",
       "../scripts/**/*",
       "../services/**/*",
       "../shared/**/*",

--- a/scripts/install-desktop-app.sh
+++ b/scripts/install-desktop-app.sh
@@ -89,7 +89,7 @@ archive_is_valid() {
   local archive="$1"
   [[ -f "$archive" ]] || return 1
   unzip -tqq "$archive" || return 1
-  unzip -Z1 "$archive" | grep -Eq '^(Contents|Local Studio( Dev)?\.app[^/]*/Contents)/Info\.plist$'
+  unzip -Z1 "$archive" | awk '$0 == "Contents/Info.plist" || ($0 ~ /^Local Studio( Dev)?\.app/ && $0 ~ /\/Contents\/Info\.plist$/) { found = 1 } END { exit found ? 0 : 1 }'
 }
 
 legacy_bundles() {

--- a/services/agent-runtime/src/data-dir.ts
+++ b/services/agent-runtime/src/data-dir.ts
@@ -26,20 +26,38 @@ let cachedDataDir: string | null = null;
 let cachedDataDirEnv: string | undefined;
 let migrated = false;
 
-function legacyDataDirCandidates(): string[] {
+function legacySettingsFileCandidates(): string[] {
   return [
-    path.join(process.cwd(), "data"),
-    path.join(process.cwd(), "..", "data"),
-    path.join(process.cwd(), "frontend", "data"),
-    path.join(homedir(), ".local-studio"),
-    path.join(homedir(), LEGACY_DOT_DIR),
-    path.join(tmpdir(), "local-studio"),
+    path.join(process.cwd(), "data", SETTINGS_FILENAME),
+    path.join(process.cwd(), "..", "data", SETTINGS_FILENAME),
+    path.join(process.cwd(), "frontend", "data", SETTINGS_FILENAME),
+    path.join(homedir(), ".local-studio", SETTINGS_FILENAME),
+    path.join(homedir(), LEGACY_DOT_DIR, SETTINGS_FILENAME),
+    path.join(tmpdir(), "local-studio", SETTINGS_FILENAME),
     // Past Electron userData siblings.
-    path.join(homedir(), "Library", "Application Support", "local-studio-app"),
-    path.join(homedir(), "Library", "Application Support", LEGACY_APP_DATA_SLUG),
-    path.join(homedir(), "Library", "Application Support", LEGACY_APP_DATA_DIR),
-    path.join(homedir(), "Library", "Application Support", "Electron"),
-    path.join(homedir(), "Library", "Application Support", "frontend"),
+    path.join(
+      homedir(),
+      "Library",
+      "Application Support",
+      "local-studio-app",
+      SETTINGS_FILENAME,
+    ),
+    path.join(
+      homedir(),
+      "Library",
+      "Application Support",
+      LEGACY_APP_DATA_SLUG,
+      SETTINGS_FILENAME,
+    ),
+    path.join(
+      homedir(),
+      "Library",
+      "Application Support",
+      LEGACY_APP_DATA_DIR,
+      SETTINGS_FILENAME,
+    ),
+    path.join(homedir(), "Library", "Application Support", "Electron", SETTINGS_FILENAME),
+    path.join(homedir(), "Library", "Application Support", "frontend", SETTINGS_FILENAME),
   ];
 }
 
@@ -73,9 +91,8 @@ function migrateLegacySettings(targetDir: string): void {
   const targetFile = path.join(targetDir, SETTINGS_FILENAME);
   if (existsSync(targetFile)) return;
 
-  for (const candidate of legacyDataDirCandidates()) {
-    if (path.resolve(candidate) === path.resolve(targetDir)) continue;
-    const legacyFile = path.join(candidate, SETTINGS_FILENAME);
+  for (const legacyFile of legacySettingsFileCandidates()) {
+    if (path.resolve(legacyFile) === path.resolve(targetFile)) continue;
     if (!existsSync(legacyFile)) continue;
     try {
       copyFileSync(legacyFile, targetFile);

--- a/services/agent-runtime/systemd/local-studio-agent-runtime.service
+++ b/services/agent-runtime/systemd/local-studio-agent-runtime.service
@@ -17,7 +17,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=@APP_DIR@/services/agent-runtime
-ExecStart=@NODE@ dist/server.js
+ExecStart=@NODE@ dist/standalone.mjs
 Environment=PORT=8081
 Environment=PI_CODING_AGENT_DIR=%h/.local-studio/pi-agent
 # Same data dir the frontend uses for api-settings.json, if customized:


### PR DESCRIPTION
## What changed

- make rollback archive validation consume the complete ZIP listing
- avoid `pipefail` treating `unzip` SIGPIPE as an incomplete archive when the matching plist appears early

## Validation

- `bash -n scripts/install-desktop-app.sh`
- `npm run check:release` (10/10)
- installed the merged dev build through `scripts/install-desktop-app.sh dev` with the 279 MB rollback archive enabled
- installed app signature, desktop health, runtime health, and embedded runtime hash passed
