### PR TITLE
ci: refresh actions and avoid duplicate browser build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22.19.0
       - name: Conventional commit gate
@@ -40,7 +40,7 @@ jobs:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
@@ -63,7 +63,7 @@ jobs:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
@@ -80,8 +80,8 @@ jobs:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 22.19.0
       - uses: oven-sh/setup-bun@v2
@@ -97,14 +97,14 @@ jobs:
         run: npx playwright install --with-deps chromium
       - name: Browser acceptance tests
         working-directory: ./frontend
-        run: npm run test:e2e
+        run: npm run test:e2e:controller && npm run test:e2e:providers
 
   desktop-package:
     if: github.event_name != 'schedule'
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 22.19.0
       - uses: oven-sh/setup-bun@v2
@@ -130,7 +130,7 @@ jobs:
           ditto -c -k --keepParent
           "frontend/dist-desktop/mac-arm64/Local Studio.app"
           "local-studio-${{ github.sha }}-arm64.zip"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: local-studio-${{ github.sha }}-arm64
           path: local-studio-${{ github.sha }}-arm64.zip
@@ -141,11 +141,11 @@ jobs:
     name: Secret Scanning (TruffleHog)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Run TruffleHog
-        uses: trufflesecurity/trufflehog@v3.95.5
+        uses: trufflesecurity/trufflehog@v3.96.0
         with:
           path: ./
           base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
@@ -161,12 +161,12 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v3
+      - uses: actions/checkout@v7
+      - uses: github/codeql-action/init@v4
         with:
           languages: javascript, typescript
-      - uses: github/codeql-action/autobuild@v3
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/autobuild@v4
+      - uses: github/codeql-action/analyze@v4
         with:
           category: "/language:javascript-typescript"
 
@@ -175,8 +175,8 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/checkout@v7
+      - uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: moderate
           deny-licenses: GPL-3.0, AGPL-3.0

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -31,7 +31,7 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (inputs.task == 'all' || inputs.task == 'labels'))
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: EndBug/label-sync@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -43,7 +43,7 @@ jobs:
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (inputs.task == 'all' || inputs.task == 'promotion'))
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Open or refresh the dev to main PR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha }}
@@ -32,7 +32,7 @@ jobs:
       - name: Reject stale release revision
         run: node scripts/project.mjs assert-release-main --commit "$RELEASE_SHA"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22.19.0
 
@@ -79,7 +79,7 @@ jobs:
           "frontend/dist-desktop/mac-arm64/Local Studio.app"
           "local-studio-unsigned-${{ github.event.workflow_run.head_sha }}.zip"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: steps.next-release.outputs.version != ''
         with:
           name: local-studio-unsigned-${{ github.event.workflow_run.head_sha }}
@@ -96,7 +96,7 @@ jobs:
     env:
       RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha }}
@@ -107,7 +107,7 @@ jobs:
       - name: Reject stale release revision
         run: node scripts/project.mjs assert-release-main --commit "$RELEASE_SHA"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22.19.0
 
@@ -115,7 +115,7 @@ jobs:
         working-directory: ./frontend
         run: npm ci --ignore-scripts --legacy-peer-deps
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: local-studio-unsigned-${{ github.event.workflow_run.head_sha }}
           path: ${{ runner.temp }}/unsigned-release
@@ -148,7 +148,7 @@ jobs:
           --version ${{ needs.build.outputs.release_version }}
           --commit "$RELEASE_SHA"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: local-studio-release-assets-${{ github.event.workflow_run.head_sha }}
           path: release-staging/*
@@ -164,7 +164,7 @@ jobs:
     env:
       RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha }}
@@ -175,11 +175,11 @@ jobs:
       - name: Reject stale release revision
         run: node scripts/project.mjs assert-release-main --commit "$RELEASE_SHA"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22.19.0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: local-studio-release-assets-${{ github.event.workflow_run.head_sha }}
           path: release-staging


### PR DESCRIPTION
## Summary
- update every first-party GitHub action to its current Node 24 release line
- update CodeQL to v4 and dependency review to v5
- update TruffleHog to 3.96.0
- run the already-built Playwright suites directly in CI instead of rebuilding the frontend a second time

## Validation
- parsed every workflow with Psych
- Prettier workflow check
- exact three-script automation audit
- repository pre-push static, dead-code, duplicate, and standalone checks

The PR CI run is the compatibility acceptance test for the refreshed actions.