### PR TITLE
fix: preserve explicit Pi steering

### DIFF
--- a/frontend/e2e/controller-agent.spec.ts
+++ b/frontend/e2e/controller-agent.spec.ts
@@ -1,4 +1,12 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
+
+async function openControllerChat(page: Page, title: string) {
+  await page.goto(`/agent?new=${encodeURIComponent(title)}`);
+  await expect(page.getByRole("button", { name: /^Model:/ }).first()).toBeEnabled({
+    timeout: 60_000,
+  });
+  return page.getByPlaceholder(/Do anything|Ask for follow-up changes/).first();
+}
 
 for (const route of [
   "/",
@@ -57,6 +65,55 @@ test("Pi defaults to the active controller and reveals other models on request",
   await composer.fill("Reply from this controller.");
   await composer.press("Enter");
   await expect(page.getByText("Controller scoped Pi reply.")).toBeVisible({ timeout: 60_000 });
+});
+
+test("messages containing /goal reach Pi as ordinary text", async ({ page }) => {
+  const composer = await openControllerChat(page, "Goal text chat");
+  const opening = "/goal is ordinary text before the Pi session exists";
+  await composer.fill(opening);
+  await composer.press("Enter");
+  await expect(page.getByText(opening, { exact: true })).toBeVisible();
+  await expect(page.getByText("Controller scoped Pi reply.")).toBeVisible({ timeout: 60_000 });
+
+  const embedded = "Please explain what /goal means without running it";
+  await composer.fill(embedded);
+  await composer.press("Enter");
+  await expect(page.getByText(embedded, { exact: true })).toBeVisible();
+  await expect(page.getByText("Controller scoped Pi reply.")).toHaveCount(2, {
+    timeout: 60_000,
+  });
+});
+
+test("Enter queues while the explicit control steers the active Pi turn", async ({ page }) => {
+  const composer = await openControllerChat(page, "Queue and steer chat");
+  await composer.fill("slow-response-marker");
+  await composer.press("Enter");
+  await expect(page.getByRole("button", { name: "Stop" })).toBeEnabled({ timeout: 60_000 });
+
+  await composer.fill("queue-after-marker");
+  await composer.press("Enter");
+  const queue = page.getByTestId("queued-message-stack");
+  await expect(queue.getByText("queue-after-marker", { exact: true })).toBeVisible();
+
+  await composer.fill("interrupt-now-marker");
+  await page.getByRole("button", { name: "Steer current task now" }).click();
+  await expect(page.getByText("interrupt-now-marker", { exact: true })).toBeVisible();
+  await expect(page.getByText("Steered response acknowledged.")).toBeVisible({ timeout: 60_000 });
+  await expect(page.getByText("Queued response acknowledged.")).toBeVisible({ timeout: 60_000 });
+  await expect(queue).toHaveCount(0);
+});
+
+test("Alt+Enter steers instead of queueing", async ({ page }) => {
+  const composer = await openControllerChat(page, "Keyboard steer chat");
+  await composer.fill("slow-response-marker");
+  await composer.press("Enter");
+  await expect(page.getByRole("button", { name: "Stop" })).toBeEnabled({ timeout: 60_000 });
+
+  await composer.fill("interrupt-now-marker");
+  await composer.press("Alt+Enter");
+  await expect(page.getByText("interrupt-now-marker", { exact: true })).toBeVisible();
+  await expect(page.getByText("Steered response acknowledged.")).toBeVisible({ timeout: 60_000 });
+  await expect(page.getByTestId("queued-message-stack")).toHaveCount(0);
 });
 
 test("mobile navigation and composer remain usable at 390px", async ({ page }) => {

--- a/frontend/e2e/fixtures/fake-controller.mjs
+++ b/frontend/e2e/fixtures/fake-controller.mjs
@@ -7,19 +7,43 @@ function json(response, status, body) {
   response.end(JSON.stringify(body));
 }
 
-async function readBody(request) {
-  for await (const _chunk of request) void _chunk;
+async function readJson(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  const text = Buffer.concat(chunks).toString("utf8");
+  return text ? JSON.parse(text) : {};
+}
+
+function contentText(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content.map((part) => (typeof part?.text === "string" ? part.text : "")).join("");
+}
+
+function latestUserText(payload) {
+  const messages = Array.isArray(payload.messages) ? payload.messages : [];
+  return contentText(messages.filter((message) => message?.role === "user").at(-1)?.content);
+}
+
+function replyFor(text) {
+  if (text.includes("interrupt-now-marker")) return "Steered response acknowledged.";
+  if (text.includes("queue-after-marker")) return "Queued response acknowledged.";
+  if (text.includes("slow-response-marker")) return "Slow response complete.";
+  return "Controller scoped Pi reply.";
 }
 
 async function streamCompletion(request, response) {
-  await readBody(request);
+  const payload = await readJson(request);
+  const userText = latestUserText(payload);
+  const slow = userText.includes("slow-response-marker");
+  if (slow) await new Promise((resolve) => setTimeout(resolve, 1_500));
   response.writeHead(200, {
     "content-type": "text/event-stream",
     "cache-control": "no-store",
     connection: "keep-alive",
   });
   const id = `controller-${Date.now()}`;
-  const chunks = ["Controller", " scoped", " Pi", " reply."];
+  const chunks = replyFor(userText).match(/.{1,12}/g) ?? [];
   response.write(`data: ${JSON.stringify({
     id,
     object: "chat.completion.chunk",
@@ -35,6 +59,7 @@ async function streamCompletion(request, response) {
       model: "controller-model",
       choices: [{ index: 0, delta: { content }, finish_reason: null }],
     })}\n\n`);
+    if (slow) await new Promise((resolve) => setTimeout(resolve, 150));
   }
   response.write(`data: ${JSON.stringify({
     id,

--- a/frontend/src/features/agent/ui/chat-pane.tsx
+++ b/frontend/src/features/agent/ui/chat-pane.tsx
@@ -605,14 +605,6 @@ export function ChatPane({
         void runCommandInvocation(invocation);
         return;
       }
-      // While a turn is running, Enter queues (Codex behavior) — the queued
-      // row's own Steer control is the explicit interruption. queueMessage
-      // falls back to a fresh prompt if the run has actually ended.
-      if (running) {
-        event.preventDefault();
-        void queueMessage();
-        return;
-      }
       void sendMessage(event);
     },
     [
@@ -621,9 +613,7 @@ export function ChatPane({
       commandContext,
       commandRegistry,
       goalModeApi,
-      queueMessage,
       runCommandInvocation,
-      running,
       sendMessage,
     ],
   );


### PR DESCRIPTION
## Summary
- keep Enter as a queued Pi follow-up during an active turn
- route the explicit Steer control and Alt+Enter through the existing Pi-native steer path
- prove `/goal` text remains sendable before a Pi identity exists and when embedded in an ordinary message
- add real delayed-controller acceptance coverage for queue and steer ordering

## Validation
- `npm run check`
- `npm run test:integration`
- `npm --prefix frontend run test:e2e`
  - 19 controller/Pi/browser/pairing flows
  - 5 provider flows
- production standalone build and exact-three-script gate