### PR TITLE
test: isolate generated validation artifacts

### DIFF
--- a/frontend/desktop/project.mjs
+++ b/frontend/desktop/project.mjs
@@ -2196,6 +2196,7 @@ var project_entry_default = afterPack, root5 = path11.resolve(path11.dirname(fil
   ["link-services", () => Promise.resolve().then(() => (init_link_services_node_modules(), exports_link_services_node_modules))],
   ["perf", () => init_perf_audit().then(() => exports_perf_audit)],
   ["postbuild-agent-runtime", () => Promise.resolve().then(() => (init_postbuild(), exports_postbuild))],
+  ["prepare-agent-runtime", async () => rmSync6(path11.join(root5, "services", "agent-runtime", "dist"), { recursive: !0, force: !0 })],
   ["prepare-next", () => Promise.resolve().then(() => (init_prepare_next_build(), exports_prepare_next_build))],
   ["release-notes", () => Promise.resolve().then(() => (init_release_statement(), exports_release_statement))],
   ["self-test", async () => {

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -67,6 +67,7 @@ const eslintConfig = defineConfig([
     "build/**",
     "next-env.d.ts",
     "desktop/dist/**",
+    "desktop/project.mjs",
     "dist-desktop/**",
     "dist-desktop-dev/**",
   ]),

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,7 +39,7 @@
     "typecheck:desktop": "tsc -p desktop/tsconfig.json",
     "check:cycles": "madge --extensions ts,tsx --circular src",
     "check:static": "npm run lint && npm run typecheck && npm run typecheck:desktop && npm run typecheck:extensions && npm run check:cycles && npm run check:ui-structure",
-    "test": "bun test src desktop",
+    "test": "bun test src desktop --path-ignore-patterns \"dist-desktop*/**\"",
     "pretest:e2e": "npm run build && playwright install chromium",
     "test:e2e": "npm run test:e2e:controller && npm run test:e2e:providers",
     "test:e2e:controller": "playwright test --config e2e/controller-agent.config.ts",

--- a/services/agent-runtime/package.json
+++ b/services/agent-runtime/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "bundle": "node ../../scripts/project.mjs bundle-agent-runtime",
-    "build": "tsc -p tsconfig.build.json && node ../../scripts/project.mjs postbuild-agent-runtime",
+    "build": "node ../../scripts/project.mjs prepare-agent-runtime && tsc -p tsconfig.build.json && node ../../scripts/project.mjs postbuild-agent-runtime",
     "check": "bun run build && bun run test",
     "dev": "bun --watch src/server.ts",
     "start": "node dist/server.js",


### PR DESCRIPTION
## Summary
- delete stale agent-runtime output before every build
- keep copied desktop packages out of the source test discovery set
- lint source inputs rather than the generated three-script project bundle

## Evidence
- runtime output: 1,001 stale files -> 82 current files
- frontend tests: 116 source tests across 32 files, without 13 generated duplicates
- lint: zero generated-bundle warnings
- `npm run check`
- `npm run test:integration`