### PR TITLE
fix: launch modern SGLang runtimes

### DIFF
--- a/controller/src/modules/compute/engines/sglang.ts
+++ b/controller/src/modules/compute/engines/sglang.ts
@@ -52,6 +52,7 @@ export const sglang: ComputeEngineSpec = {
       args: serverArguments(
         request,
         {
+          subcommand: ["serve"],
           modelFlag: "--model-path",
           servedNameFlag: "--served-model-name",
           spelling,

--- a/controller/tests/compute-engine-plan.test.ts
+++ b/controller/tests/compute-engine-plan.test.ts
@@ -84,7 +84,7 @@ describe("tuning knobs", () => {
     });
     const vllmArgs = planLaunch(request({ engine: "vllm", options: tuned })).argv;
     const sglangArgs = planLaunch(
-      request({ engine: "sglang", options: tuned, port: 30000 }),
+      request({ engine: "sglang", binary: "sglang", options: tuned, port: 30000 }),
     ).argv;
 
     expect(vllmArgs).toContain("--tensor-parallel-size");
@@ -94,6 +94,7 @@ describe("tuning knobs", () => {
     expect(vllmArgs).toContain("--enable-auto-tool-choice");
 
     expect(sglangArgs).toContain("--context-length");
+    expect(sglangArgs.slice(0, 2)).toEqual(["sglang", "serve"]);
     expect(sglangArgs).toContain("--mem-fraction-static");
     expect(sglangArgs).not.toContain("--enable-auto-tool-choice");
     expect(sglangArgs).not.toContain("--max-model-len");

--- a/frontend/src/features/dashboard/control-panel/control-panel.tsx
+++ b/frontend/src/features/dashboard/control-panel/control-panel.tsx
@@ -38,6 +38,7 @@ export function ControlPanel(props: DashboardLayoutProps) {
         benchmarkResult={props.benchmarkResult}
         recipes={recipes}
         lifecycleStatus={props.lifecycleStatus}
+        lifecycleError={props.lifecycleError}
         onLaunch={props.onLaunch}
         onNewRecipe={props.onNewRecipe}
         onViewAll={props.onViewAll}

--- a/frontend/src/features/dashboard/control-panel/status-section-parts.tsx
+++ b/frontend/src/features/dashboard/control-panel/status-section-parts.tsx
@@ -21,6 +21,7 @@ export function StatusHeader({
   isRunning,
   isStatusLoading,
   lifecycleStatus,
+  lifecycleError,
   modelName,
   onBenchmark,
   onLaunch,
@@ -39,6 +40,7 @@ export function StatusHeader({
   isRunning: boolean;
   isStatusLoading: boolean;
   lifecycleStatus: "idle" | "starting" | "ready" | "error";
+  lifecycleError?: string | null;
   modelName: string;
   onBenchmark: () => void;
   onLaunch?: (recipeId: string) => Promise<void>;
@@ -66,6 +68,11 @@ export function StatusHeader({
         >
           {modelName}
         </h1>
+        {lifecycleError ? (
+          <p className="mt-1 text-[length:var(--fs-sm)] text-(--err)" role="alert">
+            {lifecycleError}
+          </p>
+        ) : null}
       </div>
       <StatusHeaderActions
         benchmarking={benchmarking}

--- a/frontend/src/features/dashboard/control-panel/status-section.tsx
+++ b/frontend/src/features/dashboard/control-panel/status-section.tsx
@@ -20,6 +20,7 @@ interface StatusSectionProps {
   benchmarkResult: number | null;
   recipes?: RecipeWithStatus[];
   lifecycleStatus?: "idle" | "starting" | "ready" | "error";
+  lifecycleError?: string | null;
   onLaunch?: (recipeId: string) => Promise<void>;
   onNewRecipe?: () => void;
   onViewAll?: () => void;
@@ -40,6 +41,7 @@ export function StatusSection({
   benchmarkResult,
   recipes,
   lifecycleStatus = "idle",
+  lifecycleError,
   onLaunch,
   onNewRecipe,
   onViewAll,
@@ -67,6 +69,7 @@ export function StatusSection({
         isRunning={view.isRunning}
         isStatusLoading={isStatusLoading}
         lifecycleStatus={lifecycleStatus}
+        lifecycleError={lifecycleError}
         modelName={view.modelName}
         onBenchmark={onBenchmark}
         onLaunch={onLaunch}

--- a/frontend/src/features/dashboard/layout/dashboard-types.ts
+++ b/frontend/src/features/dashboard/layout/dashboard-types.ts
@@ -17,6 +17,7 @@ export interface DashboardLayoutProps {
   logs: string[];
   launching: boolean;
   lifecycleStatus: "idle" | "starting" | "ready" | "error";
+  lifecycleError: string | null;
   benchmarking: boolean;
   benchmarkResult: number | null;
   launchProgress: LaunchProgress | null;

--- a/frontend/src/features/dashboard/use-dashboard-data.ts
+++ b/frontend/src/features/dashboard/use-dashboard-data.ts
@@ -42,6 +42,7 @@ export function useDashboardData() {
     benchmarkResult: actions.benchmarkResult,
     launching: lifecycle.status === "starting",
     lifecycleStatus: lifecycle.status,
+    lifecycleError: lifecycle.error,
     onLaunch: lifecycle.start,
     onBenchmark: actions.onBenchmark,
     onNavigateLogs: navigate("/logs"),


### PR DESCRIPTION
Summary:
- launch SGLang through its required serve subcommand
- surface controller lifecycle errors in the dashboard instead of leaving failed launches silent
- lock the modern SGLang CLI shape in the compute-engine plan contract

Validation:
- npm run check
- npm run test:integration
- installed-app diagnosis against SGLang 0.5.8 on the configured PopOS controller reproduced the missing-subcommand failure