### PR TITLE
fix: isolate dev app update channel

### DIFF
--- a/frontend/desktop/interfaces.ts
+++ b/frontend/desktop/interfaces.ts
@@ -95,6 +95,7 @@ export interface DesktopBridge {
     platform: NodeJS.Platform;
     appVersion: string;
     packaged: boolean;
+    releaseChannel: "dev" | "stable";
     chromeVersion: string;
     electronVersion: string;
   }>;

--- a/frontend/desktop/main.ts
+++ b/frontend/desktop/main.ts
@@ -1,4 +1,4 @@
-import "./app-identity";
+import { isDevChannelBuild } from "./app-identity";
 import {
   app,
   clipboard,
@@ -255,6 +255,7 @@ function registerIpcHandlers(): void {
     platform: process.platform,
     appVersion: app.getVersion(),
     packaged: app.isPackaged,
+    releaseChannel: isDevChannelBuild ? "dev" : "stable",
     chromeVersion: process.versions.chrome,
     electronVersion: process.versions.electron,
   }));

--- a/frontend/src/desktop-bridge.d.ts
+++ b/frontend/src/desktop-bridge.d.ts
@@ -3,7 +3,12 @@ interface Window {
     openExternal?(url: string): Promise<boolean>;
     revealPath?(target: string): Promise<boolean>;
     openPath?(target: string): Promise<boolean>;
-    getRuntime?(): Promise<{ appVersion: string; platform: string; packaged: boolean }>;
+    getRuntime?(): Promise<{
+      appVersion: string;
+      platform: string;
+      packaged: boolean;
+      releaseChannel: "dev" | "stable";
+    }>;
     getUpdateStatus?(): Promise<{ status: string; version?: string; message?: string }>;
     checkForUpdates?(): Promise<{ status: string; version?: string; message?: string }>;
     installUpdate?(): Promise<boolean>;

--- a/frontend/src/features/settings/app-version-section.tsx
+++ b/frontend/src/features/settings/app-version-section.tsx
@@ -11,17 +11,21 @@ export function AppVersionSection() {
   const update = useAppUpdate();
   // No installed-version signal (web build or dev run): offer the plain
   // download whenever the newest release is known.
-  const webDownload = !update.currentVersion && update.downloadUrl;
+  const webDownload =
+    update.releaseChannel === null && !update.currentVersion && update.downloadUrl;
+  const devChannel = update.releaseChannel === "dev";
   const onLatest = update.currentVersion && update.latestVersion && !update.updateAvailable;
-  const description = update.updateAvailable
-    ? update.phase === "ready"
-      ? `v${update.latestVersion} is downloaded — restart to finish updating.`
-      : `v${update.latestVersion} is available on GitHub.`
-    : onLatest
-      ? "You are on the latest version."
-      : update.latestVersion
-        ? `Latest release: v${update.latestVersion}.`
-        : "Release check unavailable.";
+  const description = devChannel
+    ? "Dev builds update through the local installer."
+    : update.updateAvailable
+      ? update.phase === "ready"
+        ? `v${update.latestVersion} is downloaded — restart to finish updating.`
+        : `v${update.latestVersion} is available on GitHub.`
+      : onLatest
+        ? "You are on the latest version."
+        : update.latestVersion
+          ? `Latest release: v${update.latestVersion}.`
+          : "Release check unavailable.";
   return (
     <SettingsGroup title="Application" description="Version and updates.">
       <SettingsRow

--- a/frontend/src/features/shell/use-app-update.test.ts
+++ b/frontend/src/features/shell/use-app-update.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
-import { isAppUpdateAvailable, isNewerVersion } from "./use-app-update";
+import { isAppUpdateAvailable, isNewerVersion, isReleaseUpdateAvailable } from "./use-app-update";
 
 describe("isNewerVersion", () => {
   test("orders numerically per segment, not lexically", () => {
@@ -31,5 +31,13 @@ describe("isAppUpdateAvailable", () => {
   test("stays hidden until both versions are known", () => {
     assert.equal(isAppUpdateAvailable(null, "2.8.1"), false);
     assert.equal(isAppUpdateAvailable("2.8.1", null), false);
+  });
+});
+
+describe("isReleaseUpdateAvailable", () => {
+  test("offers stable updates only to stable packaged builds", () => {
+    assert.equal(isReleaseUpdateAvailable("2.9.3", "2.1.0", "stable"), true);
+    assert.equal(isReleaseUpdateAvailable("2.9.3", "2.1.0", "dev"), false);
+    assert.equal(isReleaseUpdateAvailable("2.9.3", "2.1.0", null), false);
   });
 });

--- a/frontend/src/features/shell/use-app-update.ts
+++ b/frontend/src/features/shell/use-app-update.ts
@@ -8,6 +8,7 @@ export type AppUpdatePhase = "idle" | "working" | "ready" | "failed";
 export type AppUpdate = {
   /** Installed app version (desktop bridge); null on the plain web app. */
   currentVersion: string | null;
+  releaseChannel: "dev" | "stable" | null;
   /** Newest published release, when reachable. */
   latestVersion: string | null;
   downloadUrl: string | null;
@@ -38,6 +39,14 @@ export function isAppUpdateAvailable(
   return Boolean(latestVersion && currentVersion && isNewerVersion(latestVersion, currentVersion));
 }
 
+export function isReleaseUpdateAvailable(
+  latestVersion: string | null,
+  currentVersion: string | null,
+  releaseChannel: "dev" | "stable" | null,
+): boolean {
+  return releaseChannel === "stable" && isAppUpdateAvailable(latestVersion, currentVersion);
+}
+
 const bridge = () => window.localStudioDesktop ?? {};
 
 function phaseForStatus(status: string): AppUpdatePhase {
@@ -49,6 +58,7 @@ function phaseForStatus(status: string): AppUpdatePhase {
 
 export function useAppUpdate(): AppUpdate {
   const [currentVersion, setCurrentVersion] = useState<string | null>(null);
+  const [releaseChannel, setReleaseChannel] = useState<"dev" | "stable" | null>(null);
   const [latest, setLatest] = useState<{ version: string | null; url: string | null }>({
     version: null,
     url: null,
@@ -88,7 +98,10 @@ export function useAppUpdate(): AppUpdate {
       .then((runtime) => {
         // An unpackaged dev run reports the repo's package.json version, which
         // trails every published release — it must not claim an update.
-        if (!cancelled && runtime.packaged) setCurrentVersion(runtime.appVersion);
+        if (!cancelled && runtime.packaged) {
+          setCurrentVersion(runtime.appVersion);
+          setReleaseChannel(runtime.releaseChannel);
+        }
       })
       .catch(() => undefined);
     syncDesktopPhase();
@@ -98,7 +111,7 @@ export function useAppUpdate(): AppUpdate {
     };
   }, [syncDesktopPhase]);
 
-  const updateAvailable = isAppUpdateAvailable(latest.version, currentVersion);
+  const updateAvailable = isReleaseUpdateAvailable(latest.version, currentVersion, releaseChannel);
 
   const startUpdate = useCallback(() => {
     const desktop = bridge();
@@ -118,6 +131,7 @@ export function useAppUpdate(): AppUpdate {
 
   return {
     currentVersion,
+    releaseChannel,
     latestVersion: latest.version,
     downloadUrl: latest.url,
     updateAvailable,


### PR DESCRIPTION
Summary:
- report the packaged desktop release channel through the existing runtime bridge
- prevent Local Studio Dev from advertising or downloading stable releases
- keep stable desktop updates and plain web downloads unchanged

Validation:
- npm run check
- desktop and renderer type checks
- release-channel update contract test
- installed Local Studio Dev reproduced the false Update to v2.9.3 prompt while its main process correctly skipped the stable feed