### PR TITLE
fix(controller): honor recipe launch runtimes

### DIFF
--- a/controller/src/modules/compute/bridge.ts
+++ b/controller/src/modules/compute/bridge.ts
@@ -187,6 +187,14 @@ const resolveEngineBinary = (recipe: Recipe, config: Config): string | null => {
   }
 };
 
+const resolveRecipeBinary = (recipe: Recipe, config: Config): string | null => {
+  if (recipe.runtime.kind === "binary" || recipe.runtime.kind === "system") {
+    return recipe.runtime.ref;
+  }
+  if (recipe.runtime.kind === "docker") return null;
+  return resolveEngineBinary(recipe, config);
+};
+
 /* ── recipe -> launch input ────────────────────────────────────────────────── */
 
 export const recipeToLaunchInput = (
@@ -197,11 +205,12 @@ export const recipeToLaunchInput = (
   const override = launchCommandOverride(recipe);
   const toolCallParser = recipe.tool_call_parser ?? getDefaultToolCallParser(recipe) ?? null;
   const reasoningParser = recipe.reasoning_parser ?? getDefaultReasoningParser(recipe) ?? null;
+  const dockerImage = recipe.runtime.kind === "docker" ? recipe.runtime.ref : null;
   return {
     name: LLM_INSTANCE,
     engine: recipe.backend as EngineId,
     recipeId: recipe.id,
-    runtime: "process",
+    runtime: dockerImage ? "docker" : "process",
     deviceCount: devices.length,
     ...(devices.length > 0 ? { devices } : {}),
     portOverride: recipe.port || config.inference_port,
@@ -222,7 +231,8 @@ export const recipeToLaunchInput = (
     },
     extraArgs: serializeRecipeExtraArguments(recipe),
     env: recipe.env_vars ?? {},
-    binary: resolveEngineBinary(recipe, config),
+    dockerImage,
+    binary: resolveRecipeBinary(recipe, config),
     ...(override ? { commandOverride: override } : {}),
   };
 };

--- a/controller/src/modules/compute/contracts.ts
+++ b/controller/src/modules/compute/contracts.ts
@@ -140,6 +140,7 @@ export interface LaunchRequest {
   /** Verbatim recipe flags, appended last; any base flag they repeat is dropped. */
   readonly extraArgs: readonly string[];
   readonly env: Readonly<Record<string, string>>;
+  readonly dockerImage: string | null;
   /** Resolved executable for process launches; ignored for docker. */
   readonly binary: string;
 }

--- a/controller/src/modules/compute/devices/storage.ts
+++ b/controller/src/modules/compute/devices/storage.ts
@@ -1,4 +1,4 @@
-import { statfsSync } from "node:fs";
+import { statfsSync, statSync } from "node:fs";
 import { Effect } from "effect";
 import type { VolumeInfo } from "../contracts";
 import { neverFails, type DeviceProbe } from "./probe";
@@ -9,20 +9,24 @@ import { hostPlatform } from "./host";
  * per-OS parser. Disk model and rotational-ness do need vendor tools; they are reported
  * as null here rather than shelling out on every sample.
  */
-const readVolume = (mount: string): VolumeInfo | null => {
+const readVolume = (mount: string): { key: string; volume: VolumeInfo } | null => {
   try {
+    const device = statSync(mount).dev;
     const stats = statfsSync(mount);
     const blockSize = Number(stats.bsize);
     const total = Number(stats.blocks) * blockSize;
     const free = Number(stats.bavail) * blockSize;
     if (!Number.isFinite(total) || total <= 0) return null;
     return {
-      mount,
-      totalBytes: total,
-      freeBytes: Number.isFinite(free) && free >= 0 ? free : 0,
-      filesystem: null,
-      model: null,
-      rotational: null,
+      key: String(device),
+      volume: {
+        mount,
+        totalBytes: total,
+        freeBytes: Number.isFinite(free) && free >= 0 ? free : 0,
+        filesystem: null,
+        model: null,
+        rotational: null,
+      },
     };
   } catch {
     return null;
@@ -36,12 +40,9 @@ export const systemRoot = (): string => (hostPlatform() === "win32" ? "C:\\" : "
 export const readVolumes = (paths: readonly string[]): readonly VolumeInfo[] => {
   const seen = new Map<string, VolumeInfo>();
   for (const path of [systemRoot(), ...paths]) {
-    const volume = readVolume(path);
-    if (!volume) continue;
-    // Paths on the same volume report identical totals and free space; keep the first,
-    // which is the shortest/most general mount we were asked about.
-    const key = `${volume.totalBytes}:${volume.freeBytes}`;
-    if (!seen.has(key)) seen.set(key, volume);
+    const reading = readVolume(path);
+    if (!reading) continue;
+    if (!seen.has(reading.key)) seen.set(reading.key, reading.volume);
   }
   return [...seen.values()];
 };

--- a/controller/src/modules/compute/engines/shared.ts
+++ b/controller/src/modules/compute/engines/shared.ts
@@ -179,15 +179,18 @@ export const plan = (
     readonly image?: string | null;
     readonly env?: Readonly<Record<string, string>>;
   },
-): LaunchPlan => ({
-  kind: request.runtime,
-  // A container image supplies its own executable; a process launch needs the binary.
-  argv: request.runtime === "docker" ? [...parts.args] : [request.binary, ...parts.args],
-  // An engine may always offer an image; only a container plan carries one.
-  ...(request.runtime === "docker" && parts.image ? { image: parts.image } : {}),
-  env: { ...request.env, ...(parts.env ?? {}) },
-  ports: [{ container: parts.listenPort, host: request.port }],
-  mounts: modelMounts(request),
-  devices: request.devices,
-  health: parts.health,
-});
+): LaunchPlan => {
+  const image = request.dockerImage ?? parts.image;
+  return {
+    kind: request.runtime,
+    // A container image supplies its own executable; a process launch needs the binary.
+    argv: request.runtime === "docker" ? [...parts.args] : [request.binary, ...parts.args],
+    // An engine may always offer an image; only a container plan carries one.
+    ...(request.runtime === "docker" && image ? { image } : {}),
+    env: { ...request.env, ...(parts.env ?? {}) },
+    ports: [{ container: parts.listenPort, host: request.port }],
+    mounts: modelMounts(request),
+    devices: request.devices,
+    health: parts.health,
+  };
+};

--- a/controller/src/modules/compute/lifecycle.ts
+++ b/controller/src/modules/compute/lifecycle.ts
@@ -58,6 +58,7 @@ export interface ComputeLaunchInput {
   readonly options: ServingOptions;
   readonly extraArgs: readonly string[];
   readonly env: Readonly<Record<string, string>>;
+  readonly dockerImage: string | null;
   readonly binary: string | null;
 }
 
@@ -228,6 +229,7 @@ export const makeComputeService = (deps: ComputeDeps): ComputeService => {
               mounts: [],
               devices: record.devices,
               health: spec.health,
+              ...(input.dockerImage ? { image: input.dockerImage } : {}),
             },
             host.accelerator,
           )
@@ -242,6 +244,7 @@ export const makeComputeService = (deps: ComputeDeps): ComputeService => {
             options: input.options,
             extraArgs: input.extraArgs,
             env: input.env,
+            dockerImage: input.dockerImage,
             binary: input.binary ?? spec.defaultBinary,
           });
 

--- a/controller/src/modules/compute/routes.ts
+++ b/controller/src/modules/compute/routes.ts
@@ -34,6 +34,7 @@ const LaunchRequestSchema = Schema.Struct({
   options: Schema.optional(OptionsSchema),
   extraArgs: Schema.optional(Schema.Array(Schema.String)),
   env: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+  dockerImage: Schema.optional(Schema.String),
   binary: Schema.optional(Schema.String),
 });
 
@@ -114,6 +115,7 @@ export const registerComputeRoutes = defineRoutes((app, context) =>
               options: mergeOptions(parsed.options ?? {}),
               extraArgs: parsed.extraArgs ?? [],
               env: parsed.env ?? {},
+              dockerImage: parsed.dockerImage ?? null,
               binary: parsed.binary ?? null,
             })
             .pipe(Effect.mapError(toHttp));

--- a/controller/tests/compute-bridge-runtime.test.ts
+++ b/controller/tests/compute-bridge-runtime.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import type { Config } from "../src/config/env";
+import { recipeToLaunchInput } from "../src/modules/compute/bridge";
+import type { Recipe } from "../src/modules/models/types";
+
+const config = {
+  inference_port: 8000,
+} as Config;
+
+const recipe = (runtime: Recipe["runtime"]): Recipe =>
+  ({
+    id: "deepseek-v4",
+    name: "DeepSeek V4",
+    model_path: "/models/deepseek-v4",
+    backend: "sglang",
+    runtime,
+    port: 8000,
+    tensor_parallel_size: 2,
+    pipeline_parallel_size: 1,
+    max_model_len: 131072,
+    gpu_memory_utilization: 0.9,
+    max_num_seqs: 16,
+    kv_cache_dtype: "auto",
+    trust_remote_code: true,
+    extra_args: {},
+  }) as Recipe;
+
+describe("recipe runtime launch mapping", () => {
+  test("system and binary runtimes launch their selected executable", () => {
+    const system = recipeToLaunchInput(
+      recipe({ kind: "system", ref: "/opt/local-studio/launch-sglang" }),
+      config,
+      [],
+    );
+    const binary = recipeToLaunchInput(
+      recipe({ kind: "binary", ref: "/opt/sglang/bin/sglang" }),
+      config,
+      [],
+    );
+
+    expect(system.runtime).toBe("process");
+    expect(system.binary).toBe("/opt/local-studio/launch-sglang");
+    expect(system.dockerImage).toBeNull();
+    expect(binary.runtime).toBe("process");
+    expect(binary.binary).toBe("/opt/sglang/bin/sglang");
+  });
+
+  test("docker runtime launches the selected image", () => {
+    const image = "registry.example/sglang:deepseek-v4";
+    const input = recipeToLaunchInput(recipe({ kind: "docker", ref: image }), config, []);
+
+    expect(input.runtime).toBe("docker");
+    expect(input.dockerImage).toBe(image);
+    expect(input.binary).toBeNull();
+  });
+});

--- a/controller/tests/compute-engine-plan.test.ts
+++ b/controller/tests/compute-engine-plan.test.ts
@@ -50,6 +50,7 @@ const request = (overrides: Partial<LaunchRequest> = {}): LaunchRequest => ({
   options: options(),
   extraArgs: [],
   env: {},
+  dockerImage: null,
   binary: "/venv/bin/vllm",
   ...overrides,
 });
@@ -177,6 +178,15 @@ describe("docker vs process", () => {
     expect(asDocker.argv[asDocker.argv.indexOf("--host") + 1]).toBe("0.0.0.0");
     // The container sees the model at the mount point, not the host path.
     expect(asDocker.argv).toContain("/models");
+  });
+
+  test("a recipe-selected container image overrides the engine default", () => {
+    const customImage = "registry.example/sglang:deepseek-v4";
+    const asDocker = planLaunch(
+      request({ engine: "sglang", runtime: "docker", dockerImage: customImage }),
+    );
+
+    expect(asDocker.image).toBe(customImage);
   });
 });
 

--- a/controller/tests/compute-lifecycle.test.ts
+++ b/controller/tests/compute-lifecycle.test.ts
@@ -69,6 +69,7 @@ const input = (overrides: Partial<ComputeLaunchInput> = {}): ComputeLaunchInput 
   options,
   extraArgs: [],
   env: {},
+  dockerImage: null,
   binary: "llama-server",
   ...overrides,
 });


### PR DESCRIPTION
## Summary
- carry canonical recipe runtime selection into the compute launch contract
- execute selected system and binary runtimes instead of silently falling back to host engines
- honor recipe-selected Docker images in engine and custom launch plans
- cover system, binary, and Docker runtime mapping

## Validation
- npm run check
- npm run test:integration
