### PR TITLE
fix(controller): harden launch and install lifecycle

### DIFF
--- a/controller/src/modules/compute/engines/vllm.ts
+++ b/controller/src/modules/compute/engines/vllm.ts
@@ -64,7 +64,7 @@ export const vllm: ComputeEngineSpec = {
       args: serverArguments(
         request,
         {
-          subcommand: ["serve"],
+          subcommand: request.runtime === "docker" ? [] : ["serve"],
           modelFlag: null,
           servedNameFlag: "--served-model-name",
           spelling,

--- a/controller/src/modules/compute/launchers/process.ts
+++ b/controller/src/modules/compute/launchers/process.ts
@@ -80,7 +80,7 @@ export const makeProcessLauncher = (logPathFor: (name: string) => string): Launc
       const [binary, ...args] = plan.argv;
       if (!binary) return yield* spawnFailed("plan.argv is empty");
       const logFd = yield* Effect.try({
-        try: () => openSync(logPathFor(record.name), "a"),
+        try: () => openSync(logPathFor(record.name), "w"),
         catch: (error) => error,
       }).pipe(
         Effect.catch((error) =>

--- a/controller/tests/compute-engine-plan.test.ts
+++ b/controller/tests/compute-engine-plan.test.ts
@@ -168,11 +168,13 @@ describe("docker vs process", () => {
     const asDocker = planLaunch(request({ runtime: "docker" }));
 
     expect(asProcess.argv[0]).toBe("/venv/bin/vllm");
+    expect(asProcess.argv[1]).toBe("serve");
     expect(asProcess.image).toBeUndefined();
     expect(asProcess.mounts).toEqual([]);
     expect(asProcess.argv[asProcess.argv.indexOf("--host") + 1]).toBe("127.0.0.1");
 
     expect(asDocker.argv[0]).not.toBe("/venv/bin/vllm");
+    expect(asDocker.argv).not.toContain("serve");
     expect(asDocker.image).toBe("vllm/vllm-openai:latest");
     expect(asDocker.mounts).toEqual([{ from: "/models/qwen", to: "/models", readOnly: true }]);
     expect(asDocker.argv[asDocker.argv.indexOf("--host") + 1]).toBe("0.0.0.0");

--- a/controller/tests/process-launcher.test.ts
+++ b/controller/tests/process-launcher.test.ts
@@ -1,0 +1,51 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Effect } from "effect";
+import type { InstanceRecord, LaunchPlan } from "../src/modules/compute/contracts";
+import { makeProcessLauncher } from "../src/modules/compute/launchers/process";
+
+const root = mkdtempSync(join(tmpdir(), "process-launcher-test-"));
+const logPath = join(root, "model.log");
+
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+const record: InstanceRecord = {
+  name: "model",
+  nodeId: "self",
+  engine: "vllm",
+  recipeId: "recipe",
+  runtime: "process",
+  ref: null,
+  port: 8000,
+  devices: [],
+  nonce: "nonce",
+  startedAt: new Date(0).toISOString(),
+  readyDeadlineAt: new Date(60_000).toISOString(),
+};
+
+const plan: LaunchPlan = {
+  kind: "process",
+  argv: ["/bin/sh", "-c", "printf fresh"],
+  env: {},
+  ports: [],
+  mounts: [],
+  devices: [],
+  health: { path: "/health", readyDeadlineMs: 60_000, intervalMs: 100 },
+};
+
+describe("process launcher logs", () => {
+  test("a new launch cannot inherit a previous failure", async () => {
+    writeFileSync(logPath, "stale failure\n");
+    const launcher = makeProcessLauncher(() => logPath);
+    const reference = await Effect.runPromise(launcher.start(plan, record));
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      if (!(await Effect.runPromise(launcher.alive(reference)))) break;
+      await Bun.sleep(10);
+    }
+    const tail = await Effect.runPromise(launcher.logTail(reference, record));
+    expect(tail).toBe("fresh");
+    expect(readFileSync(logPath, "utf8")).toBe("fresh");
+  });
+});

--- a/scripts/install-controller.sh
+++ b/scripts/install-controller.sh
@@ -163,6 +163,8 @@ EnvironmentFile=$ENV_FILE
 ExecStart=$BUN $DIR/controller/src/main.ts
 Restart=on-failure
 RestartSec=3
+KillMode=mixed
+TimeoutStopSec=15
 StandardOutput=append:$DATA_DIR/controller.log
 StandardError=append:$DATA_DIR/controller.log
 
@@ -185,18 +187,35 @@ fi
 
 # --- health ------------------------------------------------------------------
 log "waiting for controller on :$PORT…"
+HEALTH_HOST="$HOST"
+case "$HEALTH_HOST" in
+  ""|"0.0.0.0"|"::") HEALTH_HOST="127.0.0.1" ;;
+esac
+HEALTH_URL_HOST="$HEALTH_HOST"
+case "$HEALTH_URL_HOST" in
+  *:*) HEALTH_URL_HOST="[$HEALTH_URL_HOST]" ;;
+esac
 for _ in $(seq 1 30); do
-  if curl -fsS --max-time 2 "http://127.0.0.1:$PORT/health" >/dev/null 2>&1; then
-    HOST_ADDR=""
-    if command -v tailscale >/dev/null 2>&1; then
-      HOST_ADDR="$(tailscale ip -4 2>/dev/null | head -1 || true)"
-    fi
-    if [ -z "$HOST_ADDR" ]; then
-      HOST_ADDR="$(hostname -I 2>/dev/null | awk '{print $1}' || true)"
-    fi
+  if curl -fsS --max-time 2 "http://$HEALTH_URL_HOST:$PORT/health" >/dev/null 2>&1; then
+    HOST_ADDR="$HOST"
+    case "$HOST_ADDR" in
+      ""|"0.0.0.0"|"::")
+        HOST_ADDR=""
+        if command -v tailscale >/dev/null 2>&1; then
+          HOST_ADDR="$(tailscale ip -4 2>/dev/null | head -1 || true)"
+        fi
+        if [ -z "$HOST_ADDR" ]; then
+          HOST_ADDR="$(hostname -I 2>/dev/null | awk '{print $1}' || true)"
+        fi
+        ;;
+    esac
     [ -n "$HOST_ADDR" ] || HOST_ADDR="$(hostname)"
+    HOST_URL_ADDR="$HOST_ADDR"
+    case "$HOST_URL_ADDR" in
+      *:*) HOST_URL_ADDR="[$HOST_URL_ADDR]" ;;
+    esac
     log "controller healthy ($started)"
-    printf 'LOCAL_STUDIO_CONTROLLER {"url":"http://%s:%s","api_key":"%s"}\n' "$HOST_ADDR" "$PORT" "$API_KEY"
+    printf 'LOCAL_STUDIO_CONTROLLER {"url":"http://%s:%s","api_key":"%s"}\n' "$HOST_URL_ADDR" "$PORT" "$API_KEY"
     exit 0
   fi
   sleep 2

--- a/scripts/install-controller.sh
+++ b/scripts/install-controller.sh
@@ -17,6 +17,10 @@
 set -euo pipefail
 
 OS_NAME="$(uname -s)"
+HOST_WAS_SET="${LOCAL_STUDIO_HOST+x}"
+PORT_WAS_SET="${LOCAL_STUDIO_PORT+x}"
+DATA_DIR_WAS_SET="${LOCAL_STUDIO_DATA_DIR+x}"
+MODELS_DIR_WAS_SET="${LOCAL_STUDIO_MODELS_DIR+x}"
 if [ "$OS_NAME" = "Darwin" ]; then
   DEFAULT_DIR="$HOME/Library/Application Support/Local Studio/controller-source"
   DEFAULT_DATA_DIR="$HOME/Library/Application Support/Local Studio/controller-data"
@@ -64,6 +68,16 @@ ENV_FILE="$DIR/.env"
 read_env_value() {
   grep "^$1=" "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2-
 }
+write_env_value() {
+  key="$1"
+  value="$2"
+  if grep -q "^$key=" "$ENV_FILE" 2>/dev/null; then
+    awk -v key="$key" -v value="$value" 'index($0, key "=") == 1 { if (!written) print key "=" value; written=1; next } { print }' "$ENV_FILE" > "$ENV_FILE.tmp"
+    mv "$ENV_FILE.tmp" "$ENV_FILE"
+  else
+    printf '%s=%s\n' "$key" "$value" >> "$ENV_FILE"
+  fi
+}
 if [ -f "$ENV_FILE" ] && grep -q '^LOCAL_STUDIO_API_KEY=' "$ENV_FILE"; then
   API_KEY="$(read_env_value LOCAL_STUDIO_API_KEY)"
   log "reusing existing API key from .env"
@@ -73,25 +87,29 @@ else
   else
     API_KEY="$(head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')"
   fi
-  {
-    echo "LOCAL_STUDIO_PORT=$PORT"
-    # A deployed controller exists to be reached from other machines; the API
-    # key is the access control.
-    echo "LOCAL_STUDIO_HOST=$HOST"
-    echo "LOCAL_STUDIO_API_KEY=$API_KEY"
-    echo "LOCAL_STUDIO_DATA_DIR=$DATA_DIR"
-    echo "LOCAL_STUDIO_MODELS_DIR=$MODELS_DIR"
-  } >> "$ENV_FILE"
+  printf 'LOCAL_STUDIO_API_KEY=%s\n' "$API_KEY" >> "$ENV_FILE"
   log "wrote $ENV_FILE"
 fi
-grep -q '^LOCAL_STUDIO_HOST=' "$ENV_FILE" || echo "LOCAL_STUDIO_HOST=$HOST" >> "$ENV_FILE"
-grep -q '^LOCAL_STUDIO_PORT=' "$ENV_FILE" || echo "LOCAL_STUDIO_PORT=$PORT" >> "$ENV_FILE"
-grep -q '^LOCAL_STUDIO_DATA_DIR=' "$ENV_FILE" || echo "LOCAL_STUDIO_DATA_DIR=$DATA_DIR" >> "$ENV_FILE"
-grep -q '^LOCAL_STUDIO_MODELS_DIR=' "$ENV_FILE" || echo "LOCAL_STUDIO_MODELS_DIR=$MODELS_DIR" >> "$ENV_FILE"
-if [ -z "${LOCAL_STUDIO_HOST:-}" ]; then HOST="$(read_env_value LOCAL_STUDIO_HOST)"; fi
-if [ -z "${LOCAL_STUDIO_PORT:-}" ]; then PORT="$(read_env_value LOCAL_STUDIO_PORT)"; fi
-if [ -z "${LOCAL_STUDIO_DATA_DIR:-}" ]; then DATA_DIR="$(read_env_value LOCAL_STUDIO_DATA_DIR)"; fi
-if [ -z "${LOCAL_STUDIO_MODELS_DIR:-}" ]; then MODELS_DIR="$(read_env_value LOCAL_STUDIO_MODELS_DIR)"; fi
+if [ -z "$HOST_WAS_SET" ] && grep -q '^LOCAL_STUDIO_HOST=' "$ENV_FILE"; then HOST="$(read_env_value LOCAL_STUDIO_HOST)"; fi
+if [ -z "$PORT_WAS_SET" ] && grep -q '^LOCAL_STUDIO_PORT=' "$ENV_FILE"; then PORT="$(read_env_value LOCAL_STUDIO_PORT)"; fi
+if [ -z "$DATA_DIR_WAS_SET" ]; then
+  if grep -q '^LOCAL_STUDIO_DATA_DIR=' "$ENV_FILE"; then
+    DATA_DIR="$(read_env_value LOCAL_STUDIO_DATA_DIR)"
+  elif [ -d "$DIR/data" ]; then
+    DATA_DIR="$DIR/data"
+  fi
+fi
+if [ -z "$MODELS_DIR_WAS_SET" ]; then
+  if grep -q '^LOCAL_STUDIO_MODELS_DIR=' "$ENV_FILE"; then
+    MODELS_DIR="$(read_env_value LOCAL_STUDIO_MODELS_DIR)"
+  else
+    MODELS_DIR="$DATA_DIR/models"
+  fi
+fi
+write_env_value LOCAL_STUDIO_HOST "$HOST"
+write_env_value LOCAL_STUDIO_PORT "$PORT"
+write_env_value LOCAL_STUDIO_DATA_DIR "$DATA_DIR"
+write_env_value LOCAL_STUDIO_MODELS_DIR "$MODELS_DIR"
 mkdir -p "$DATA_DIR" "$MODELS_DIR"
 
 # --- service -----------------------------------------------------------------


### PR DESCRIPTION
## Summary
- isolate process logs per launch so typed failures contain only the current attempt
- respect official vLLM container entrypoints instead of duplicating the `serve` command
- probe the configured controller bind address and emit valid IPv6 connection URLs
- preserve existing controller data/model paths during installer upgrades and persist explicit overrides
- bound systemd shutdown when a GPU telemetry subprocess stalls

## Validation
- `npm run check` (117 frontend, 86 controller, 96 agent-runtime tests)
- `npm run test:integration` (96 agent-runtime tests)
- clean isolated PopOS install on a specific tailnet bind
- legacy PopOS upgrade with missing path keys preserves `source/data`
- live vLLM Docker launch reached healthy with CUDA graphs enabled and served a completion
- live controller restart reduced from the prior 90-second timeout to 17.5 seconds