### PR TITLE
fix(controller): encode Docker GPU selections

### DIFF
--- a/controller/src/modules/compute/engines/devices.ts
+++ b/controller/src/modules/compute/engines/devices.ts
@@ -50,7 +50,7 @@ export const dockerFlagsFor = (
   if (devices.length === 0) return { args: [], groupAdd: [] };
   switch (accelerator) {
     case "cuda":
-      return { args: ["--gpus", `device=${joined(devices)}`], groupAdd: [] };
+      return { args: ["--gpus", `"device=${joined(devices)}"`], groupAdd: [] };
     case "rocm":
       return {
         args: ["--device", "/dev/kfd", "--device", "/dev/dri", "--security-opt", "seccomp=unconfined"],

--- a/controller/src/modules/system/gpu-leases.ts
+++ b/controller/src/modules/system/gpu-leases.ts
@@ -244,7 +244,8 @@ export function resolveRecipeGpuUuids(
 
   const selector = directVisibilitySelector(recipe) ?? environmentVisibilitySelector(recipe);
   if (selector === null) {
-    return { source: "all", selector, uuids: allUuids, unresolvedTokens: [] };
+    const required = Math.max(1, recipe.tensor_parallel_size * recipe.pipeline_parallel_size);
+    return { source: "all", selector, uuids: allUuids.slice(0, required), unresolvedTokens: [] };
   }
 
   const uuids: string[] = [];

--- a/controller/tests/compute-engine-plan.test.ts
+++ b/controller/tests/compute-engine-plan.test.ts
@@ -216,7 +216,10 @@ describe("device translation", () => {
   });
 
   test("docker flags differ from process env", () => {
-    expect(dockerFlagsFor("cuda", devices).args).toEqual(["--gpus", "device=GPU-aaa,GPU-bbb"]);
+    expect(dockerFlagsFor("cuda", devices).args).toEqual([
+      "--gpus",
+      '"device=GPU-aaa,GPU-bbb"',
+    ]);
     expect(dockerFlagsFor("rocm", devices).args).toContain("/dev/kfd");
     expect(dockerFlagsFor("rocm", devices).groupAdd).toEqual(["video", "render"]);
   });


### PR DESCRIPTION
## Summary
- encode comma-separated CUDA UUIDs for Docker's device request parser
- implicitly lease only the ranks required by tensor and pipeline parallelism
- preserve explicit recipe visibility selectors

## Validation
- full controller suite: 86 tests
- Docker device-request inspection with two real GPU UUIDs
- installed app retry selected one GPU for a TP1 recipe and started the vLLM container