### PR TITLE
fix(agent): use current vLLM completion field

### DIFF
--- a/controller/tests/chat-completions-stream.test.ts
+++ b/controller/tests/chat-completions-stream.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { Server } from "bun";
+import { Effect } from "effect";
+import { buildChatCompletionsStreamResponse } from "../src/modules/proxy/chat-completions-stream";
+
+const encoder = new TextEncoder();
+const servers: Server<undefined>[] = [];
+
+afterEach(() => {
+  for (const server of servers.splice(0)) server.stop(true);
+});
+
+describe("chat completions streaming proxy", () => {
+  test("keeps the upstream response body alive after fetch resolves", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch: () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            async start(controller) {
+              controller.enqueue(encoder.encode(": upstream\n\n"));
+              await Bun.sleep(25);
+              controller.enqueue(
+                encoder.encode(
+                  'data: {"choices":[{"index":0,"delta":{"content":"READY"}}]}\n\n',
+                ),
+              );
+              controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+              controller.close();
+            },
+          }),
+          { headers: { "content-type": "text/event-stream" } },
+        ),
+    });
+    servers.push(server);
+
+    const response = buildChatCompletionsStreamResponse({
+      upstreamUrl: `${server.url}v1/chat/completions`,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ stream: true }),
+      clientSignal: new AbortController().signal,
+      matchedRecipe: null,
+      sourceHeader: "test",
+      sessionId: null,
+      recordedModel: "test-model",
+      recordedProvider: "local",
+      requestStart: performance.now(),
+      requestProvider: "local-studio",
+      providerRouting: null,
+      context: {
+        logger: {
+          debug: () => undefined,
+          info: () => undefined,
+          warn: () => undefined,
+          error: () => undefined,
+          shutdown: () => Effect.void,
+        },
+        stores: {} as never,
+      },
+      keepaliveIntervalMs: 1_000,
+    });
+
+    expect(await response.text()).toContain('"content":"READY"');
+  });
+});

--- a/services/agent-runtime/src/pi-runtime-models.ts
+++ b/services/agent-runtime/src/pi-runtime-models.ts
@@ -434,7 +434,7 @@ const VLLM_OPENAI_COMPAT: OpenAICompletionsCompat = {
   supportsReasoningEffort: true,
   supportsStrictMode: false,
   supportsUsageInStreaming: true,
-  maxTokensField: "max_tokens",
+  maxTokensField: "max_completion_tokens",
 };
 
 export function modelsToPiModels(models: AgentModel[]) {

--- a/services/agent-runtime/test/pi-runtime-litter.test.ts
+++ b/services/agent-runtime/test/pi-runtime-litter.test.ts
@@ -112,6 +112,22 @@ test("Pi model catalog preserves the controller's active model", () => {
   assert.equal(modelsToPiModels([model])[0]?.active, true);
 });
 
+test("Pi uses the current completion token field for vLLM controllers", () => {
+  const model: AgentModel = {
+    id: "model-current-tokens",
+    rawId: "model-current-tokens",
+    providerId: "local-studio",
+    name: "Current token field",
+    provider: "local-studio",
+    contextWindow: 128_000,
+    maxTokens: 16_000,
+    reasoning: false,
+    vision: false,
+    active: true,
+  };
+  assert.equal(modelsToPiModels([model])[0]?.compat.maxTokensField, "max_completion_tokens");
+});
+
 test("Pi preserves reasoning, skills, templates, and tools when restart options are omitted", () => {
   const current = {
     thinkingLevel: "xhigh" as const,


### PR DESCRIPTION
## Summary
- send `max_completion_tokens` for vLLM/SGLang-backed Pi models instead of legacy `max_tokens`
- cover delayed upstream SSE bodies so controller streaming stays regression-tested

## Validation
- `npm run check`
- `npm run test:integration`
- installed Local Studio Dev: `/goal`, queue promotion, and native Pi Steer all exercised against live LFM2.5
- tailnet desktop and 390px mobile pairing JSON copy both verified
- live vLLM chat streaming verified through the controller