### PR TITLE
release: promote dev to main

### DIFF
--- a/controller/src/modules/engines/downloads/download-manager.test.ts
+++ b/controller/src/modules/engines/downloads/download-manager.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { DownloadFileInfo, ModelDownload } from "../types";
-import { findReusableDownload } from "./download-manager";
+import { findReusableDownload, normalizeDownloadTotalBytes } from "./download-manager";
 
 const file = (path: string): DownloadFileInfo => ({
   path,
@@ -49,5 +49,35 @@ describe("download reuse", () => {
       [file("model-Q1.gguf")],
     );
     expect(result).toBeNull();
+  });
+});
+
+describe("download totals", () => {
+  test("rejects a stale partial total smaller than downloaded bytes", () => {
+    const stale = download("stale", "canceled", [
+      { ...file("config.json"), size_bytes: 58, downloaded_bytes: 58, status: "completed" },
+      { ...file("model.safetensors"), size_bytes: null, downloaded_bytes: 12_000 },
+    ]);
+    stale.total_bytes = 58;
+    stale.downloaded_bytes = 12_058;
+
+    expect(normalizeDownloadTotalBytes(stale)).toBeNull();
+  });
+
+  test("sums a complete file manifest and preserves a credible stored total", () => {
+    const complete = download("complete", "completed", [
+      file("model-1.safetensors"),
+      file("model-2.safetensors"),
+    ]);
+    complete.downloaded_bytes = 200;
+    expect(normalizeDownloadTotalBytes(complete)).toBe(200);
+
+    const partial = download("partial", "downloading", [
+      file("config.json"),
+      { ...file("model.safetensors"), size_bytes: null },
+    ]);
+    partial.total_bytes = 1_000;
+    partial.downloaded_bytes = 100;
+    expect(normalizeDownloadTotalBytes(partial)).toBe(1_000);
   });
 });

--- a/controller/src/modules/engines/downloads/download-manager.ts
+++ b/controller/src/modules/engines/downloads/download-manager.ts
@@ -31,11 +31,21 @@ const sumDownloadedBytes = (files: DownloadFileInfo[]): number =>
   files.reduce((total, file) => total + (file.downloaded_bytes || 0), 0);
 
 const sumTotalBytes = (files: DownloadFileInfo[]): number | null => {
-  const known = files.filter((file) => typeof file.size_bytes === "number") as Array<
-    DownloadFileInfo & { size_bytes: number }
-  >;
-  return known.length === 0 ? null : known.reduce((total, file) => total + file.size_bytes, 0);
+  if (files.length === 0 || files.some((file) => typeof file.size_bytes !== "number")) return null;
+  return files.reduce((total, file) => total + (file.size_bytes ?? 0), 0);
 };
+
+export const normalizeDownloadTotalBytes = (download: ModelDownload): number | null => {
+  const completeTotal = sumTotalBytes(download.files);
+  if (completeTotal !== null) return completeTotal;
+  const storedTotal = download.total_bytes;
+  return storedTotal !== null && storedTotal >= download.downloaded_bytes ? storedTotal : null;
+};
+
+const normalizeDownload = (download: ModelDownload): ModelDownload => ({
+  ...download,
+  total_bytes: normalizeDownloadTotalBytes(download),
+});
 
 const sameFileSet = (first: DownloadFileInfo[], second: DownloadFileInfo[]): boolean => {
   const firstPaths = first.map((file) => file.path).sort();
@@ -180,11 +190,13 @@ export class DownloadManager {
   }
 
   public list(): Effect.Effect<ModelDownload[], EngineOperationError> {
-    return this.store.list();
+    return this.store.list().pipe(Effect.map((downloads) => downloads.map(normalizeDownload)));
   }
 
   public get(id: string): Effect.Effect<ModelDownload | null, EngineOperationError> {
-    return this.store.get(id);
+    return this.store
+      .get(id)
+      .pipe(Effect.map((download) => (download ? normalizeDownload(download) : null)));
   }
 
   public start(request: DownloadRequest): Effect.Effect<ModelDownload, EngineOperationError> {
@@ -386,7 +398,7 @@ export class DownloadManager {
         current.completed_at = allComplete ? toTimestamp() : null;
         current.error = allComplete ? null : (current.error ?? "Download incomplete");
         current.downloaded_bytes = sumDownloadedBytes(current.files);
-        current.total_bytes = current.total_bytes ?? sumTotalBytes(current.files);
+        current.total_bytes = normalizeDownloadTotalBytes(current);
         current.updated_at = toTimestamp();
         yield* manager.store.save(current);
         yield* manager.publishState(current, current.status);
@@ -586,9 +598,10 @@ export class DownloadManager {
         ...latest,
         files: updatedFiles,
         downloaded_bytes: sumDownloadedBytes(updatedFiles),
-        total_bytes: latest.total_bytes ?? sumTotalBytes(updatedFiles),
+        total_bytes: latest.total_bytes,
         updated_at: toTimestamp(),
       };
+      updated.total_bytes = normalizeDownloadTotalBytes(updated);
       yield* store.save(updated);
       return updated;
     });

--- a/controller/src/modules/system/logs-routes.ts
+++ b/controller/src/modules/system/logs-routes.ts
@@ -118,6 +118,7 @@ export const registerLogsRoutes = defineRoutes((app, context) => {
       maxOutputBytes: 10 * 1024 * 1024,
     }).pipe(
       Effect.map((result) => {
+        if (result.status !== 0 || result.timedOut) return [];
         const output = `${result.stdout || ""}${result.stderr || ""}`;
         if (!output.trim()) return [];
         const lines = output.split(/\r?\n/);
@@ -125,6 +126,12 @@ export const registerLogsRoutes = defineRoutes((app, context) => {
         return lines.slice(Math.max(0, lines.length - limit));
       }),
     );
+
+  const dockerContainerExists = (container: string): Effect.Effect<boolean> =>
+    runCommandAsyncEffect("docker", ["inspect", "--type", "container", container], {
+      timeoutMs: 5_000,
+      maxOutputBytes: 64 * 1024,
+    }).pipe(Effect.map((result) => result.status === 0 && !result.timedOut));
 
   const streamDockerLogLines = (
     container: string,
@@ -342,7 +349,11 @@ export const registerLogsRoutes = defineRoutes((app, context) => {
           const path = yield* Effect.sync(() =>
             resolveExistingLogPath(context.config.data_dir, sessionId),
           );
-          const dockerContainer = yield* getDockerContainerForSession(sessionId);
+          const configuredDockerContainer = yield* getDockerContainerForSession(sessionId);
+          const dockerContainer =
+            configuredDockerContainer && (yield* dockerContainerExists(configuredDockerContainer))
+              ? configuredDockerContainer
+              : null;
           const signal = ctx.req.raw.signal;
           const frameForLine = (line: string): string =>
             new Event(CONTROLLER_EVENTS.LOG, {

--- a/controller/tests/http-app.test.ts
+++ b/controller/tests/http-app.test.ts
@@ -1,10 +1,12 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { AppContextService } from "../src/app-context";
+import { delimiter, join } from "node:path";
+import { type AppContext, AppContextService } from "../src/app-context";
 import { createControllerRuntime, type ControllerRuntime } from "../src/core/effect-runtime";
+import { primaryLogPathFor } from "../src/core/log-files";
 import { createApp } from "../src/http/app";
+import { parseRecipe } from "../src/modules/models/recipes/recipe-serializer";
 
 const apiKey = "controller-contract-key";
 const allowedOrigin = "https://allowed.example";
@@ -16,6 +18,7 @@ const environmentKeys = [
   "LOCAL_STUDIO_API_KEY",
   "LOCAL_STUDIO_CORS_ORIGINS",
   "LOCAL_STUDIO_DISABLE_METRICS",
+  "PATH",
 ] as const;
 
 type EnvironmentKey = (typeof environmentKeys)[number];
@@ -24,6 +27,7 @@ type OpenApiDocument = { paths: Record<string, Record<string, unknown>> };
 const previousEnvironment = new Map<EnvironmentKey, string | undefined>();
 let temporaryDirectory = "";
 let runtime: ControllerRuntime;
+let context: AppContext;
 let app: ReturnType<typeof createApp>;
 
 beforeAll(async () => {
@@ -36,8 +40,14 @@ beforeAll(async () => {
   process.env["LOCAL_STUDIO_API_KEY"] = apiKey;
   process.env["LOCAL_STUDIO_CORS_ORIGINS"] = allowedOrigin;
   process.env["LOCAL_STUDIO_DISABLE_METRICS"] = "true";
+  const binaryDirectory = join(temporaryDirectory, "bin");
+  const dockerPath = join(binaryDirectory, "docker");
+  mkdirSync(binaryDirectory, { recursive: true });
+  writeFileSync(dockerPath, "#!/bin/sh\nprintf 'Error response from daemon: No such container\\n' >&2\nexit 1\n");
+  chmodSync(dockerPath, 0o755);
+  process.env["PATH"] = `${binaryDirectory}${delimiter}${process.env["PATH"] ?? ""}`;
   runtime = createControllerRuntime();
-  const context = await runtime.runPromise(AppContextService);
+  context = await runtime.runPromise(AppContextService);
   app = createApp(context, runtime);
 });
 
@@ -107,5 +117,41 @@ describe("controller HTTP application", () => {
       ),
     );
     expect([...documentedOperations].sort()).toEqual([...registeredOperations].sort());
+  });
+
+  test("falls back to persisted logs when a Docker container no longer exists", async () => {
+    const sessionId = "stale-docker-session";
+    await runtime.runPromise(
+      context.stores.recipeStore.save(
+        parseRecipe({
+          id: sessionId,
+          name: "Stale Docker Session",
+          model_path: "/models/stale",
+          backend: "vllm",
+          runtime: { kind: "docker", ref: "example.invalid/local-studio" },
+          extra_args: { "docker-container": sessionId },
+        }),
+      ),
+    );
+    writeFileSync(primaryLogPathFor(context.config.data_dir, sessionId), "persisted log line\n");
+
+    const response = await app.request(`/logs/${sessionId}`, {
+      headers: { "x-api-key": apiKey },
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      id: sessionId,
+      logs: ["persisted log line"],
+      content: "persisted log line",
+    });
+
+    const abortController = new AbortController();
+    const stream = await app.request(`/logs/${sessionId}/stream?tail=1`, {
+      headers: { "x-api-key": apiKey },
+      signal: abortController.signal,
+    });
+    const chunk = await stream.body?.getReader().read();
+    abortController.abort();
+    expect(new TextDecoder().decode(chunk?.value)).toContain("persisted log line");
   });
 });

--- a/frontend/e2e/controller-agent.spec.ts
+++ b/frontend/e2e/controller-agent.spec.ts
@@ -27,6 +27,12 @@ for (const route of [
     await page.waitForTimeout(500);
     expect(errors).toEqual([]);
     await expect(page.getByText(/application error/i)).toHaveCount(0);
+    if (route === "/setup") {
+      await expect(page.getByRole("textbox", { name: "Where model weights live" })).toHaveValue(
+        "/models",
+      );
+      await expect(page.getByText(/controller is unreachable/i)).toHaveCount(0);
+    }
   });
 }
 
@@ -69,17 +75,20 @@ test("Pi defaults to the active controller and reveals other models on request",
 
 test("messages containing /goal reach Pi as ordinary text", async ({ page }) => {
   const composer = await openControllerChat(page, "Goal text chat");
+  const transcript = page.getByRole("article");
   const opening = "/goal is ordinary text before the Pi session exists";
   await composer.fill(opening);
   await composer.press("Enter");
-  await expect(page.getByText(opening, { exact: true })).toBeVisible();
-  await expect(page.getByText("Controller scoped Pi reply.")).toBeVisible({ timeout: 60_000 });
+  await expect(transcript.getByText(opening, { exact: true })).toBeVisible();
+  await expect(transcript.getByText("Controller scoped Pi reply.")).toBeVisible({
+    timeout: 60_000,
+  });
 
   const embedded = "Please explain what /goal means without running it";
   await composer.fill(embedded);
   await composer.press("Enter");
-  await expect(page.getByText(embedded, { exact: true })).toBeVisible();
-  await expect(page.getByText("Controller scoped Pi reply.")).toHaveCount(2, {
+  await expect(transcript.getByText(embedded, { exact: true })).toBeVisible();
+  await expect(transcript.getByText("Controller scoped Pi reply.")).toHaveCount(2, {
     timeout: 60_000,
   });
 });

--- a/frontend/e2e/fixtures/fake-controller.mjs
+++ b/frontend/e2e/fixtures/fake-controller.mjs
@@ -75,6 +75,67 @@ async function streamCompletion(request, response) {
 const server = createServer(async (request, response) => {
   const url = new URL(request.url ?? "/", `http://127.0.0.1:${port}`);
   if (url.pathname === "/health") return json(response, 200, { ok: true });
+  if (url.pathname === "/studio/settings" && request.method === "GET") {
+    return json(response, 200, {
+      config_path: "/tmp/local-studio/config.json",
+      persisted: { models_dir: "/models" },
+      effective: { models_dir: "/models" },
+    });
+  }
+  if (url.pathname === "/studio/diagnostics") {
+    return json(response, 200, {
+      app_version: "test",
+      timestamp: new Date().toISOString(),
+      platform: "darwin",
+      arch: "arm64",
+      release: "test",
+      cpu_model: "Test CPU",
+      cpu_cores: 8,
+      memory_total: 68_719_476_736,
+      memory_free: 34_359_738_368,
+      gpus: [{ name: "Test GPU", memory_total_mb: 65_536 }],
+      runtime: {
+        vllm_installed: false,
+        vllm_version: null,
+        python_path: null,
+        vllm_bin: null,
+      },
+      disks: [],
+      config: {
+        host: "127.0.0.1",
+        port,
+        inference_port: port,
+        api_key_configured: false,
+        models_dir: "/models",
+        data_dir: "/tmp/local-studio",
+        db_path: "/tmp/local-studio/test.db",
+        sglang_python: null,
+        llama_bin: null,
+        mlx_python: null,
+      },
+    });
+  }
+  if (url.pathname === "/studio/presets") {
+    return json(response, 200, { presets: [], max_vram_gb: 64 });
+  }
+  if (url.pathname === "/studio/downloads") {
+    return json(response, 200, { downloads: [] });
+  }
+  if (url.pathname === "/runtime/targets") {
+    return json(response, 200, { targets: [] });
+  }
+  if (url.pathname === "/runtime/jobs") {
+    return json(response, 200, { jobs: [] });
+  }
+  if (url.pathname === "/events") {
+    response.writeHead(200, {
+      "content-type": "text/event-stream",
+      "cache-control": "no-store",
+      connection: "keep-alive",
+    });
+    response.write(": connected\n\n");
+    return;
+  }
   if (url.pathname === "/v1/models") {
     return json(response, 200, {
       object: "list",

--- a/frontend/src/features/recipes/recipes-content/launch-reconciliation.test.ts
+++ b/frontend/src/features/recipes/recipes-content/launch-reconciliation.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { RecipeWithStatus } from "@/lib/types";
+import { isRecipeActive } from "./launch-reconciliation";
+
+const recipe = (id: string, status: RecipeWithStatus["status"]): RecipeWithStatus =>
+  ({ id, status }) as RecipeWithStatus;
+
+describe("launch reconciliation", () => {
+  test("accepts the requested recipe when the controller reports it active", () => {
+    assert.equal(isRecipeActive([recipe("test", "starting")], "test"), true);
+    assert.equal(isRecipeActive([recipe("test", "running")], "test"), true);
+  });
+
+  test("rejects stopped and unrelated recipes", () => {
+    assert.equal(isRecipeActive([recipe("test", "stopped")], "test"), false);
+    assert.equal(isRecipeActive([recipe("other", "running")], "test"), false);
+  });
+});

--- a/frontend/src/features/recipes/recipes-content/launch-reconciliation.ts
+++ b/frontend/src/features/recipes/recipes-content/launch-reconciliation.ts
@@ -1,0 +1,7 @@
+import type { RecipeWithStatus } from "@/lib/types";
+
+export const isRecipeActive = (recipes: RecipeWithStatus[], recipeId: string): boolean =>
+  recipes.some(
+    (recipe) =>
+      recipe.id === recipeId && (recipe.status === "starting" || recipe.status === "running"),
+  );

--- a/frontend/src/features/recipes/recipes-content/recipes-content-model.ts
+++ b/frontend/src/features/recipes/recipes-content/recipes-content-model.ts
@@ -13,6 +13,7 @@ import { prepareRecipeForSave } from "@/features/recipes/prepare-recipe";
 import { DEFAULT_RECIPE } from "./default-recipe";
 import type { RecipesTableProps } from "./types";
 import { useRecipesDerived } from "./use-recipes-derived";
+import { isRecipeActive } from "./launch-reconciliation";
 
 export type RecipesContentTab = "picks" | "get" | "serves" | "downloads";
 
@@ -66,7 +67,7 @@ export function useRecipesContentModel() {
     });
   }, []);
 
-  const loadRecipes = useCallback(async () => {
+  const loadRecipes = useCallback(async (): Promise<RecipeWithStatus[]> => {
     try {
       const [recipesData, modelsData, runtimeData] = await Promise.all([
         api.getRecipes().catch(() => ({ recipes: [] as RecipeWithStatus[] })),
@@ -81,8 +82,10 @@ export function useRecipesContentModel() {
       setRunningRecipeId(running);
       setAvailableModels(modelsData.models || []);
       setRuntimeTargets(runtimeData.targets || []);
+      return recipesList;
     } catch (e) {
       console.error("Failed to load recipes:", e);
+      return [];
     }
   }, []);
 
@@ -182,7 +185,10 @@ export function useRecipesContentModel() {
         await api.launchRecipe(recipeId);
         await loadRecipes();
       } catch (e) {
-        alert("Failed to launch: " + (e as Error).message);
+        const reconciled = await loadRecipes();
+        if (!isRecipeActive(reconciled, recipeId)) {
+          alert("Failed to launch: " + (e as Error).message);
+        }
       } finally {
         setLaunching(false);
       }


### PR DESCRIPTION
## Summary

- promote the fully validated `dev` branch to `main`
- include reliable controller log and download state handling
- include frontend launch reconciliation after long controller starts
- include repeatable Pi queue, Steer, literal `/goal`, and mobile pairing acceptance coverage

## Validation

- `npm run check`
- `npm run test:integration`
- `npm run test:e2e` (24/24)
- desktop package and launch smoke
- rebuilt and reinstalled `Local Studio Dev.app`
- live LFM inference, streaming, tool call, Pi queue/Steer, literal `/goal`
- desktop and Tailnet-hosted mobile pairing JSON copy

All nine checks on PR #338 passed before its merge into `dev`.