### PR TITLE
fix(release): install and staple stable builds

### DIFF
--- a/frontend/desktop/project.mjs
+++ b/frontend/desktop/project.mjs
@@ -1213,6 +1213,9 @@ if (args[0] === "-Z1") process.stdout.write(fs.readFileSync(archive));
 `), writeExecutable(path8.join(commands, "codesign"), `#!/usr/bin/env node
 const target = process.argv.at(-1);
 if (process.env.LOCAL_STUDIO_TEST_FAIL_CODESIGN === target) process.exit(1);
+`), writeExecutable(path8.join(commands, "spctl"), `#!/usr/bin/env node
+const target = process.argv.at(-1);
+if (process.env.LOCAL_STUDIO_TEST_FAIL_SPCTL === target) process.exit(1);
 `), writeExecutable(path8.join(commands, "plist-buddy"), `#!/usr/bin/env node
 const fs = require("node:fs");
 const text = fs.readFileSync(process.argv.at(-1), "utf8");
@@ -1274,6 +1277,15 @@ var init_install_desktop_app_test = __esm(() => {
     let result = runInstaller(harness, ["stable"], {
       LOCAL_STUDIO_BUILT_APP: built,
       LOCAL_STUDIO_TEST_FAIL_CODESIGN: target
+    });
+    assert.notEqual(result.status, 0), assert.equal(installedMarker(harness.applications, "Local Studio"), "old"), assert.deepEqual(readdirSync6(harness.applications), ["Local Studio.app"]);
+  });
+  test("restores the original stable app when Gatekeeper rejects the replacement", (t) => {
+    let harness = createHarness(t), built = path8.join(harness.root, "built", "Local Studio.app"), target = path8.join(harness.applications, "Local Studio.app");
+    createBundle(built, "Local Studio", "org.local.studio.desktop", "new"), createBundle(target, "Local Studio", "org.local.studio.desktop", "old");
+    let result = runInstaller(harness, ["stable"], {
+      LOCAL_STUDIO_BUILT_APP: built,
+      LOCAL_STUDIO_TEST_FAIL_SPCTL: target
     });
     assert.notEqual(result.status, 0), assert.equal(installedMarker(harness.applications, "Local Studio"), "old"), assert.deepEqual(readdirSync6(harness.applications), ["Local Studio.app"]);
   });
@@ -1393,6 +1405,17 @@ var init_release_package_arguments_test = __esm(() => {
     });
     assert3.deepEqual(args3.slice(-2), ["--publish", "never"]), assert3.deepEqual(args3.slice(0, 2), ["--prepackaged", "/tmp/Local Studio.app"]);
   });
+  test3("release signing notarizes and staples the app before packaging", () => {
+    let calls = [];
+    notarizeApplication("/tmp/Local Studio.app", "/tmp/Local Studio.zip", ["--key", "/tmp/key"], (command, args3) => calls.push([command, args3]));
+    assert3.deepEqual(calls, [
+      ["ditto", ["-c", "-k", "--keepParent", "/tmp/Local Studio.app", "/tmp/Local Studio.zip"]],
+      ["xcrun", ["notarytool", "submit", "/tmp/Local Studio.zip", "--key", "/tmp/key", "--wait", "--output-format", "json"]],
+      ["xcrun", ["stapler", "staple", "/tmp/Local Studio.app"]],
+      ["xcrun", ["stapler", "validate", "/tmp/Local Studio.app"]],
+      ["spctl", ["--assess", "--type", "execute", "--verbose=4", "/tmp/Local Studio.app"]]
+    ]);
+  });
 });
 
 var exports_sign_desktop_release = {};
@@ -1449,6 +1472,23 @@ function writeCertificate(link, destination) {
   let encoded = value2.replace(/^data:[^;]+;base64,/, "");
   writeFileSync6(destination, Buffer.from(encoded, "base64"), { mode: 384, flag: "wx" });
 }
+function notarizeApplication(app, archive, credentials, execute = run2) {
+  execute("ditto", ["-c", "-k", "--keepParent", app, archive]), execute("xcrun", [
+    "notarytool",
+    "submit",
+    archive,
+    ...credentials,
+    "--wait",
+    "--output-format",
+    "json"
+  ]), execute("xcrun", ["stapler", "staple", app]), execute("xcrun", ["stapler", "validate", app]), execute("spctl", [
+    "--assess",
+    "--type",
+    "execute",
+    "--verbose=4",
+    app
+  ]);
+}
 async function refreshUpdateMetadata(output3, version) {
   let { buildBlockMap } = require4(path9.join(frontend, "node_modules", "app-builder-lib", "out", "targets", "blockmap", "blockmap.js")), YAML = require4(path9.join(frontend, "node_modules", "yaml")), zipName = `Local Studio-${version}-arm64-mac.zip`, dmgName = `Local Studio-${version}-arm64.dmg`, zipInfo = await buildBlockMap(path9.join(output3, zipName), "gzip", path9.join(output3, `${zipName}.blockmap`)), dmgInfo = await buildBlockMap(path9.join(output3, dmgName), "gzip", path9.join(output3, `${dmgName}.blockmap`)), updatePath = path9.join(output3, "latest-mac.yml"), current = YAML.parse(readFileSync12(updatePath, "utf8"));
   writeFileSync6(updatePath, YAML.stringify({
@@ -1478,7 +1518,7 @@ async function signDesktopRelease(args3 = process.argv.slice(2)) {
     throw Error("--commit must be a full Git commit SHA");
   if (!prepackaged || !existsSync10(prepackaged))
     throw Error("--prepackaged must point to an unsigned app bundle");
-  let certificate = requireValue("CSC_LINK"), certificatePassword = requireValue("CSC_KEY_PASSWORD"), temporary = path9.join(os3.tmpdir(), `local-studio-release-${process.pid}`), apiKeyPath = path9.join(temporary, "AuthKey_notary.p8"), notaryCredentials = resolveNotarytoolCredentials(process.env, apiKeyPath), certificatePath = path9.join(temporary, "developer-id.p12"), keychainPath = path9.join(temporary, "release-signing.keychain-db"), keychainPassword = randomBytes(32).toString("hex"), originalKeychains = keychainList(), output3 = path9.join(frontend, "dist-desktop"), dmg = path9.join(output3, `Local Studio-${version}-arm64.dmg`), resolvedApp = path9.resolve(prepackaged), entitlements = path9.join(frontend, "desktop", "resources", "entitlements.mac.plist");
+  let certificate = requireValue("CSC_LINK"), certificatePassword = requireValue("CSC_KEY_PASSWORD"), temporary = path9.join(os3.tmpdir(), `local-studio-release-${process.pid}`), apiKeyPath = path9.join(temporary, "AuthKey_notary.p8"), notaryCredentials = resolveNotarytoolCredentials(process.env, apiKeyPath), certificatePath = path9.join(temporary, "developer-id.p12"), keychainPath = path9.join(temporary, "release-signing.keychain-db"), keychainPassword = randomBytes(32).toString("hex"), originalKeychains = keychainList(), output3 = path9.join(frontend, "dist-desktop"), dmg = path9.join(output3, `Local Studio-${version}-arm64.dmg`), resolvedApp = path9.resolve(prepackaged), appNotaryArchive = path9.join(temporary, "Local Studio.app.zip"), entitlements = path9.join(frontend, "desktop", "resources", "entitlements.mac.plist");
   try {
     if (rmSync8(temporary, { recursive: !0, force: !0 }), mkdirSync5(temporary, { recursive: !0, mode: 448 }), notaryCredentials.kind === "api-key")
       writeFileSync6(apiKeyPath, Buffer.from(notaryCredentials.apiKey, "base64"), {
@@ -1535,7 +1575,7 @@ async function signDesktopRelease(args3 = process.argv.slice(2)) {
       "--keychain",
       keychainPath,
       resolvedApp
-    ]), run2("codesign", ["--verify", "--deep", "--strict", "--verbose=4", resolvedApp]), process.env.LOCAL_STUDIO_RELEASE_VERSION = version, process.env.LOCAL_STUDIO_RELEASE_COMMIT = commit, process.env.CSC_IDENTITY_AUTO_DISCOVERY = "false", run2(path9.join(frontend, "node_modules", ".bin", "electron-builder"), releasePackageArguments({ app: resolvedApp, version, commit }), { cwd: frontend }), run2("codesign", [
+    ]), run2("codesign", ["--verify", "--deep", "--strict", "--verbose=4", resolvedApp]), notarizeApplication(resolvedApp, appNotaryArchive, notaryCredentials.args), process.env.LOCAL_STUDIO_RELEASE_VERSION = version, process.env.LOCAL_STUDIO_RELEASE_COMMIT = commit, process.env.CSC_IDENTITY_AUTO_DISCOVERY = "false", run2(path9.join(frontend, "node_modules", ".bin", "electron-builder"), releasePackageArguments({ app: resolvedApp, version, commit }), { cwd: frontend }), run2("codesign", [
       "--force",
       "--timestamp",
       "--sign",

--- a/scripts/install-desktop-app.sh
+++ b/scripts/install-desktop-app.sh
@@ -7,6 +7,9 @@ ROLLBACK_ROOT="${LOCAL_STUDIO_ROLLBACK_ROOT:-$HOME/Library/Application Support/L
 LSREGISTER="${LOCAL_STUDIO_LSREGISTER:-/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister}"
 PLIST_BUDDY="${LOCAL_STUDIO_PLIST_BUDDY:-/usr/libexec/PlistBuddy}"
 SKIP_RUNTIME_CLEANUP="${LOCAL_STUDIO_SKIP_RUNTIME_CLEANUP:-0}"
+RELEASE_DMG_URL="${LOCAL_STUDIO_RELEASE_DMG_URL:-https://github.com/sybil-solutions/local-studio/releases/latest/download/Local-Studio-arm64.dmg}"
+RELEASE_TEMP=""
+RELEASE_MOUNT=""
 
 channel="stable"
 keep_backup=1
@@ -38,7 +41,7 @@ if [[ "$channel" == "dev" ]]; then
 else
   APP_NAME="Local Studio"
   APP_ID="org.local.studio.desktop"
-  BUILT="${LOCAL_STUDIO_BUILT_APP:-$REPO_ROOT/frontend/dist-desktop/mac-arm64/$APP_NAME.app}"
+  BUILT="${LOCAL_STUDIO_BUILT_APP:-}"
 fi
 
 TARGET="$INSTALL_ROOT/$APP_NAME.app"
@@ -154,6 +157,16 @@ cleanup_temporary_paths() {
   elif [[ "${SWAP_VERIFIED:-0}" == "0" && "${TARGET_INSTALLED:-0}" == "1" ]]; then
     rm -rf "$TARGET"
   fi
+  cleanup_release_source
+}
+
+cleanup_release_source() {
+  if [[ -n "$RELEASE_MOUNT" ]]; then
+    hdiutil detach "$RELEASE_MOUNT" -quiet || hdiutil detach "$RELEASE_MOUNT" -force -quiet || true
+  fi
+  [[ -z "$RELEASE_TEMP" ]] || rm -rf "$RELEASE_TEMP"
+  RELEASE_MOUNT=""
+  RELEASE_TEMP=""
 }
 
 if [[ "$mode" == "migrate" ]]; then
@@ -162,11 +175,34 @@ if [[ "$mode" == "migrate" ]]; then
   exit 0
 fi
 
+HAD_TARGET=0
+SWAP_VERIFIED=0
+TARGET_INSTALLED=0
+trap cleanup_temporary_paths EXIT
+
+if [[ "$channel" == "stable" && -z "$BUILT" ]]; then
+  RELEASE_TEMP="$(mktemp -d "${TMPDIR:-/tmp}/local-studio-release.XXXXXX")"
+  RELEASE_MOUNT="$RELEASE_TEMP/mount"
+  release_dmg="$RELEASE_TEMP/Local-Studio-arm64.dmg"
+  mkdir -p "$RELEASE_MOUNT"
+  echo "==> downloading latest stable release"
+  curl --fail --location --silent --show-error "$RELEASE_DMG_URL" --output "$release_dmg"
+  xcrun stapler validate "$release_dmg"
+  spctl --assess --type open --context context:primary-signature "$release_dmg"
+  hdiutil attach -readonly -nobrowse -mountpoint "$RELEASE_MOUNT" "$release_dmg" >/dev/null
+  BUILT="$RELEASE_MOUNT/$APP_NAME.app"
+fi
+
 if [[ ! -d "$BUILT" ]]; then
   echo "error: no built bundle at $BUILT" >&2
   hint="desktop:dist"
   [[ "$channel" == "dev" ]] && hint="desktop:dist:dev"
   echo "       run: npm --prefix frontend run $hint" >&2
+  exit 1
+fi
+
+if [[ "$(bundle_id "$BUILT" || true)" != "$APP_ID" ]]; then
+  echo "error: built bundle identifier does not match $APP_ID" >&2
   exit 1
 fi
 
@@ -181,15 +217,15 @@ if [[ "$BUILT" != /* ]]; then
 fi
 
 codesign --verify --deep --strict "$BUILT"
+if [[ "$channel" == "stable" ]]; then
+  spctl --assess --type execute "$BUILT"
+fi
 mkdir -p "$INSTALL_ROOT" "$ROLLBACK_ROOT"
 rm -rf "$STAGED" "$REPLACED"
-trap cleanup_temporary_paths EXIT
-HAD_TARGET=0
-SWAP_VERIFIED=0
-TARGET_INSTALLED=0
 
 ditto "$BUILT" "$STAGED"
 codesign --verify --deep --strict "$STAGED"
+cleanup_release_source
 
 if [[ -d "$TARGET" && "$keep_backup" == "1" ]]; then
   echo "==> archiving current install -> $ROLLBACK"
@@ -229,6 +265,9 @@ fi
 mv "$STAGED" "$TARGET"
 TARGET_INSTALLED=1
 codesign --verify --deep --strict "$TARGET"
+if [[ "$channel" == "stable" ]]; then
+  spctl --assess --type execute "$TARGET"
+fi
 SWAP_VERIFIED=1
 rm -rf "$REPLACED"
 


### PR DESCRIPTION
## Summary

- make the stable installer download the latest published DMG instead of using an arbitrary stale local build
- verify the release ticket, Gatekeeper acceptance, bundle identity, and signature before replacement
- restore the current app if final Gatekeeper verification fails
- notarize and staple the app bundle before creating update ZIP and DMG assets

## Validation

- `npm run check`
- `npm run check:release`
- `bash -n scripts/install-desktop-app.sh`
- isolated stable install from the v2.9.5 DMG alias
- installed version 2.9.5, signed bundle valid, Gatekeeper source `Notarized Developer ID`
- release DMG SHA-256 matched published asset digest