### PR TITLE
release: promote stable install verification

### DIFF
--- a/controller/src/modules/engines/downloads/download-manager.test.ts
+++ b/controller/src/modules/engines/downloads/download-manager.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { DownloadFileInfo, ModelDownload } from "../types";
-import { findReusableDownload } from "./download-manager";
+import { findReusableDownload, normalizeDownloadTotalBytes } from "./download-manager";
 
 const file = (path: string): DownloadFileInfo => ({
   path,
@@ -49,5 +49,35 @@ describe("download reuse", () => {
       [file("model-Q1.gguf")],
     );
     expect(result).toBeNull();
+  });
+});
+
+describe("download totals", () => {
+  test("rejects a stale partial total smaller than downloaded bytes", () => {
+    const stale = download("stale", "canceled", [
+      { ...file("config.json"), size_bytes: 58, downloaded_bytes: 58, status: "completed" },
+      { ...file("model.safetensors"), size_bytes: null, downloaded_bytes: 12_000 },
+    ]);
+    stale.total_bytes = 58;
+    stale.downloaded_bytes = 12_058;
+
+    expect(normalizeDownloadTotalBytes(stale)).toBeNull();
+  });
+
+  test("sums a complete file manifest and preserves a credible stored total", () => {
+    const complete = download("complete", "completed", [
+      file("model-1.safetensors"),
+      file("model-2.safetensors"),
+    ]);
+    complete.downloaded_bytes = 200;
+    expect(normalizeDownloadTotalBytes(complete)).toBe(200);
+
+    const partial = download("partial", "downloading", [
+      file("config.json"),
+      { ...file("model.safetensors"), size_bytes: null },
+    ]);
+    partial.total_bytes = 1_000;
+    partial.downloaded_bytes = 100;
+    expect(normalizeDownloadTotalBytes(partial)).toBe(1_000);
   });
 });

--- a/controller/src/modules/engines/downloads/download-manager.ts
+++ b/controller/src/modules/engines/downloads/download-manager.ts
@@ -31,11 +31,21 @@ const sumDownloadedBytes = (files: DownloadFileInfo[]): number =>
   files.reduce((total, file) => total + (file.downloaded_bytes || 0), 0);
 
 const sumTotalBytes = (files: DownloadFileInfo[]): number | null => {
-  const known = files.filter((file) => typeof file.size_bytes === "number") as Array<
-    DownloadFileInfo & { size_bytes: number }
-  >;
-  return known.length === 0 ? null : known.reduce((total, file) => total + file.size_bytes, 0);
+  if (files.length === 0 || files.some((file) => typeof file.size_bytes !== "number")) return null;
+  return files.reduce((total, file) => total + (file.size_bytes ?? 0), 0);
 };
+
+export const normalizeDownloadTotalBytes = (download: ModelDownload): number | null => {
+  const completeTotal = sumTotalBytes(download.files);
+  if (completeTotal !== null) return completeTotal;
+  const storedTotal = download.total_bytes;
+  return storedTotal !== null && storedTotal >= download.downloaded_bytes ? storedTotal : null;
+};
+
+const normalizeDownload = (download: ModelDownload): ModelDownload => ({
+  ...download,
+  total_bytes: normalizeDownloadTotalBytes(download),
+});
 
 const sameFileSet = (first: DownloadFileInfo[], second: DownloadFileInfo[]): boolean => {
   const firstPaths = first.map((file) => file.path).sort();
@@ -180,11 +190,13 @@ export class DownloadManager {
   }
 
   public list(): Effect.Effect<ModelDownload[], EngineOperationError> {
-    return this.store.list();
+    return this.store.list().pipe(Effect.map((downloads) => downloads.map(normalizeDownload)));
   }
 
   public get(id: string): Effect.Effect<ModelDownload | null, EngineOperationError> {
-    return this.store.get(id);
+    return this.store
+      .get(id)
+      .pipe(Effect.map((download) => (download ? normalizeDownload(download) : null)));
   }
 
   public start(request: DownloadRequest): Effect.Effect<ModelDownload, EngineOperationError> {
@@ -386,7 +398,7 @@ export class DownloadManager {
         current.completed_at = allComplete ? toTimestamp() : null;
         current.error = allComplete ? null : (current.error ?? "Download incomplete");
         current.downloaded_bytes = sumDownloadedBytes(current.files);
-        current.total_bytes = current.total_bytes ?? sumTotalBytes(current.files);
+        current.total_bytes = normalizeDownloadTotalBytes(current);
         current.updated_at = toTimestamp();
         yield* manager.store.save(current);
         yield* manager.publishState(current, current.status);
@@ -586,9 +598,10 @@ export class DownloadManager {
         ...latest,
         files: updatedFiles,
         downloaded_bytes: sumDownloadedBytes(updatedFiles),
-        total_bytes: latest.total_bytes ?? sumTotalBytes(updatedFiles),
+        total_bytes: latest.total_bytes,
         updated_at: toTimestamp(),
       };
+      updated.total_bytes = normalizeDownloadTotalBytes(updated);
       yield* store.save(updated);
       return updated;
     });

--- a/controller/src/modules/system/logs-routes.ts
+++ b/controller/src/modules/system/logs-routes.ts
@@ -118,6 +118,7 @@ export const registerLogsRoutes = defineRoutes((app, context) => {
       maxOutputBytes: 10 * 1024 * 1024,
     }).pipe(
       Effect.map((result) => {
+        if (result.status !== 0 || result.timedOut) return [];
         const output = `${result.stdout || ""}${result.stderr || ""}`;
         if (!output.trim()) return [];
         const lines = output.split(/\r?\n/);
@@ -125,6 +126,12 @@ export const registerLogsRoutes = defineRoutes((app, context) => {
         return lines.slice(Math.max(0, lines.length - limit));
       }),
     );
+
+  const dockerContainerExists = (container: string): Effect.Effect<boolean> =>
+    runCommandAsyncEffect("docker", ["inspect", "--type", "container", container], {
+      timeoutMs: 5_000,
+      maxOutputBytes: 64 * 1024,
+    }).pipe(Effect.map((result) => result.status === 0 && !result.timedOut));
 
   const streamDockerLogLines = (
     container: string,
@@ -342,7 +349,11 @@ export const registerLogsRoutes = defineRoutes((app, context) => {
           const path = yield* Effect.sync(() =>
             resolveExistingLogPath(context.config.data_dir, sessionId),
           );
-          const dockerContainer = yield* getDockerContainerForSession(sessionId);
+          const configuredDockerContainer = yield* getDockerContainerForSession(sessionId);
+          const dockerContainer =
+            configuredDockerContainer && (yield* dockerContainerExists(configuredDockerContainer))
+              ? configuredDockerContainer
+              : null;
           const signal = ctx.req.raw.signal;
           const frameForLine = (line: string): string =>
             new Event(CONTROLLER_EVENTS.LOG, {

--- a/controller/tests/http-app.test.ts
+++ b/controller/tests/http-app.test.ts
@@ -1,10 +1,12 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { AppContextService } from "../src/app-context";
+import { delimiter, join } from "node:path";
+import { type AppContext, AppContextService } from "../src/app-context";
 import { createControllerRuntime, type ControllerRuntime } from "../src/core/effect-runtime";
+import { primaryLogPathFor } from "../src/core/log-files";
 import { createApp } from "../src/http/app";
+import { parseRecipe } from "../src/modules/models/recipes/recipe-serializer";
 
 const apiKey = "controller-contract-key";
 const allowedOrigin = "https://allowed.example";
@@ -16,6 +18,7 @@ const environmentKeys = [
   "LOCAL_STUDIO_API_KEY",
   "LOCAL_STUDIO_CORS_ORIGINS",
   "LOCAL_STUDIO_DISABLE_METRICS",
+  "PATH",
 ] as const;
 
 type EnvironmentKey = (typeof environmentKeys)[number];
@@ -24,6 +27,7 @@ type OpenApiDocument = { paths: Record<string, Record<string, unknown>> };
 const previousEnvironment = new Map<EnvironmentKey, string | undefined>();
 let temporaryDirectory = "";
 let runtime: ControllerRuntime;
+let context: AppContext;
 let app: ReturnType<typeof createApp>;
 
 beforeAll(async () => {
@@ -36,8 +40,14 @@ beforeAll(async () => {
   process.env["LOCAL_STUDIO_API_KEY"] = apiKey;
   process.env["LOCAL_STUDIO_CORS_ORIGINS"] = allowedOrigin;
   process.env["LOCAL_STUDIO_DISABLE_METRICS"] = "true";
+  const binaryDirectory = join(temporaryDirectory, "bin");
+  const dockerPath = join(binaryDirectory, "docker");
+  mkdirSync(binaryDirectory, { recursive: true });
+  writeFileSync(dockerPath, "#!/bin/sh\nprintf 'Error response from daemon: No such container\\n' >&2\nexit 1\n");
+  chmodSync(dockerPath, 0o755);
+  process.env["PATH"] = `${binaryDirectory}${delimiter}${process.env["PATH"] ?? ""}`;
   runtime = createControllerRuntime();
-  const context = await runtime.runPromise(AppContextService);
+  context = await runtime.runPromise(AppContextService);
   app = createApp(context, runtime);
 });
 
@@ -107,5 +117,41 @@ describe("controller HTTP application", () => {
       ),
     );
     expect([...documentedOperations].sort()).toEqual([...registeredOperations].sort());
+  });
+
+  test("falls back to persisted logs when a Docker container no longer exists", async () => {
+    const sessionId = "stale-docker-session";
+    await runtime.runPromise(
+      context.stores.recipeStore.save(
+        parseRecipe({
+          id: sessionId,
+          name: "Stale Docker Session",
+          model_path: "/models/stale",
+          backend: "vllm",
+          runtime: { kind: "docker", ref: "example.invalid/local-studio" },
+          extra_args: { "docker-container": sessionId },
+        }),
+      ),
+    );
+    writeFileSync(primaryLogPathFor(context.config.data_dir, sessionId), "persisted log line\n");
+
+    const response = await app.request(`/logs/${sessionId}`, {
+      headers: { "x-api-key": apiKey },
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      id: sessionId,
+      logs: ["persisted log line"],
+      content: "persisted log line",
+    });
+
+    const abortController = new AbortController();
+    const stream = await app.request(`/logs/${sessionId}/stream?tail=1`, {
+      headers: { "x-api-key": apiKey },
+      signal: abortController.signal,
+    });
+    const chunk = await stream.body?.getReader().read();
+    abortController.abort();
+    expect(new TextDecoder().decode(chunk?.value)).toContain("persisted log line");
   });
 });

--- a/frontend/desktop/project.mjs
+++ b/frontend/desktop/project.mjs
@@ -1213,6 +1213,9 @@ if (args[0] === "-Z1") process.stdout.write(fs.readFileSync(archive));
 `), writeExecutable(path8.join(commands, "codesign"), `#!/usr/bin/env node
 const target = process.argv.at(-1);
 if (process.env.LOCAL_STUDIO_TEST_FAIL_CODESIGN === target) process.exit(1);
+`), writeExecutable(path8.join(commands, "spctl"), `#!/usr/bin/env node
+const target = process.argv.at(-1);
+if (process.env.LOCAL_STUDIO_TEST_FAIL_SPCTL === target) process.exit(1);
 `), writeExecutable(path8.join(commands, "plist-buddy"), `#!/usr/bin/env node
 const fs = require("node:fs");
 const text = fs.readFileSync(process.argv.at(-1), "utf8");
@@ -1274,6 +1277,15 @@ var init_install_desktop_app_test = __esm(() => {
     let result = runInstaller(harness, ["stable"], {
       LOCAL_STUDIO_BUILT_APP: built,
       LOCAL_STUDIO_TEST_FAIL_CODESIGN: target
+    });
+    assert.notEqual(result.status, 0), assert.equal(installedMarker(harness.applications, "Local Studio"), "old"), assert.deepEqual(readdirSync6(harness.applications), ["Local Studio.app"]);
+  });
+  test("restores the original stable app when Gatekeeper rejects the replacement", (t) => {
+    let harness = createHarness(t), built = path8.join(harness.root, "built", "Local Studio.app"), target = path8.join(harness.applications, "Local Studio.app");
+    createBundle(built, "Local Studio", "org.local.studio.desktop", "new"), createBundle(target, "Local Studio", "org.local.studio.desktop", "old");
+    let result = runInstaller(harness, ["stable"], {
+      LOCAL_STUDIO_BUILT_APP: built,
+      LOCAL_STUDIO_TEST_FAIL_SPCTL: target
     });
     assert.notEqual(result.status, 0), assert.equal(installedMarker(harness.applications, "Local Studio"), "old"), assert.deepEqual(readdirSync6(harness.applications), ["Local Studio.app"]);
   });
@@ -1393,6 +1405,17 @@ var init_release_package_arguments_test = __esm(() => {
     });
     assert3.deepEqual(args3.slice(-2), ["--publish", "never"]), assert3.deepEqual(args3.slice(0, 2), ["--prepackaged", "/tmp/Local Studio.app"]);
   });
+  test3("release signing notarizes and staples the app before packaging", () => {
+    let calls = [];
+    notarizeApplication("/tmp/Local Studio.app", "/tmp/Local Studio.zip", ["--key", "/tmp/key"], (command, args3) => calls.push([command, args3]));
+    assert3.deepEqual(calls, [
+      ["ditto", ["-c", "-k", "--keepParent", "/tmp/Local Studio.app", "/tmp/Local Studio.zip"]],
+      ["xcrun", ["notarytool", "submit", "/tmp/Local Studio.zip", "--key", "/tmp/key", "--wait", "--output-format", "json"]],
+      ["xcrun", ["stapler", "staple", "/tmp/Local Studio.app"]],
+      ["xcrun", ["stapler", "validate", "/tmp/Local Studio.app"]],
+      ["spctl", ["--assess", "--type", "execute", "--verbose=4", "/tmp/Local Studio.app"]]
+    ]);
+  });
 });
 
 var exports_sign_desktop_release = {};
@@ -1449,6 +1472,23 @@ function writeCertificate(link, destination) {
   let encoded = value2.replace(/^data:[^;]+;base64,/, "");
   writeFileSync6(destination, Buffer.from(encoded, "base64"), { mode: 384, flag: "wx" });
 }
+function notarizeApplication(app, archive, credentials, execute = run2) {
+  execute("ditto", ["-c", "-k", "--keepParent", app, archive]), execute("xcrun", [
+    "notarytool",
+    "submit",
+    archive,
+    ...credentials,
+    "--wait",
+    "--output-format",
+    "json"
+  ]), execute("xcrun", ["stapler", "staple", app]), execute("xcrun", ["stapler", "validate", app]), execute("spctl", [
+    "--assess",
+    "--type",
+    "execute",
+    "--verbose=4",
+    app
+  ]);
+}
 async function refreshUpdateMetadata(output3, version) {
   let { buildBlockMap } = require4(path9.join(frontend, "node_modules", "app-builder-lib", "out", "targets", "blockmap", "blockmap.js")), YAML = require4(path9.join(frontend, "node_modules", "yaml")), zipName = `Local Studio-${version}-arm64-mac.zip`, dmgName = `Local Studio-${version}-arm64.dmg`, zipInfo = await buildBlockMap(path9.join(output3, zipName), "gzip", path9.join(output3, `${zipName}.blockmap`)), dmgInfo = await buildBlockMap(path9.join(output3, dmgName), "gzip", path9.join(output3, `${dmgName}.blockmap`)), updatePath = path9.join(output3, "latest-mac.yml"), current = YAML.parse(readFileSync12(updatePath, "utf8"));
   writeFileSync6(updatePath, YAML.stringify({
@@ -1478,7 +1518,7 @@ async function signDesktopRelease(args3 = process.argv.slice(2)) {
     throw Error("--commit must be a full Git commit SHA");
   if (!prepackaged || !existsSync10(prepackaged))
     throw Error("--prepackaged must point to an unsigned app bundle");
-  let certificate = requireValue("CSC_LINK"), certificatePassword = requireValue("CSC_KEY_PASSWORD"), temporary = path9.join(os3.tmpdir(), `local-studio-release-${process.pid}`), apiKeyPath = path9.join(temporary, "AuthKey_notary.p8"), notaryCredentials = resolveNotarytoolCredentials(process.env, apiKeyPath), certificatePath = path9.join(temporary, "developer-id.p12"), keychainPath = path9.join(temporary, "release-signing.keychain-db"), keychainPassword = randomBytes(32).toString("hex"), originalKeychains = keychainList(), output3 = path9.join(frontend, "dist-desktop"), dmg = path9.join(output3, `Local Studio-${version}-arm64.dmg`), resolvedApp = path9.resolve(prepackaged), entitlements = path9.join(frontend, "desktop", "resources", "entitlements.mac.plist");
+  let certificate = requireValue("CSC_LINK"), certificatePassword = requireValue("CSC_KEY_PASSWORD"), temporary = path9.join(os3.tmpdir(), `local-studio-release-${process.pid}`), apiKeyPath = path9.join(temporary, "AuthKey_notary.p8"), notaryCredentials = resolveNotarytoolCredentials(process.env, apiKeyPath), certificatePath = path9.join(temporary, "developer-id.p12"), keychainPath = path9.join(temporary, "release-signing.keychain-db"), keychainPassword = randomBytes(32).toString("hex"), originalKeychains = keychainList(), output3 = path9.join(frontend, "dist-desktop"), dmg = path9.join(output3, `Local Studio-${version}-arm64.dmg`), resolvedApp = path9.resolve(prepackaged), appNotaryArchive = path9.join(temporary, "Local Studio.app.zip"), entitlements = path9.join(frontend, "desktop", "resources", "entitlements.mac.plist");
   try {
     if (rmSync8(temporary, { recursive: !0, force: !0 }), mkdirSync5(temporary, { recursive: !0, mode: 448 }), notaryCredentials.kind === "api-key")
       writeFileSync6(apiKeyPath, Buffer.from(notaryCredentials.apiKey, "base64"), {
@@ -1535,7 +1575,7 @@ async function signDesktopRelease(args3 = process.argv.slice(2)) {
       "--keychain",
       keychainPath,
       resolvedApp
-    ]), run2("codesign", ["--verify", "--deep", "--strict", "--verbose=4", resolvedApp]), process.env.LOCAL_STUDIO_RELEASE_VERSION = version, process.env.LOCAL_STUDIO_RELEASE_COMMIT = commit, process.env.CSC_IDENTITY_AUTO_DISCOVERY = "false", run2(path9.join(frontend, "node_modules", ".bin", "electron-builder"), releasePackageArguments({ app: resolvedApp, version, commit }), { cwd: frontend }), run2("codesign", [
+    ]), run2("codesign", ["--verify", "--deep", "--strict", "--verbose=4", resolvedApp]), notarizeApplication(resolvedApp, appNotaryArchive, notaryCredentials.args), process.env.LOCAL_STUDIO_RELEASE_VERSION = version, process.env.LOCAL_STUDIO_RELEASE_COMMIT = commit, process.env.CSC_IDENTITY_AUTO_DISCOVERY = "false", run2(path9.join(frontend, "node_modules", ".bin", "electron-builder"), releasePackageArguments({ app: resolvedApp, version, commit }), { cwd: frontend }), run2("codesign", [
       "--force",
       "--timestamp",
       "--sign",

--- a/frontend/e2e/controller-agent.spec.ts
+++ b/frontend/e2e/controller-agent.spec.ts
@@ -27,6 +27,12 @@ for (const route of [
     await page.waitForTimeout(500);
     expect(errors).toEqual([]);
     await expect(page.getByText(/application error/i)).toHaveCount(0);
+    if (route === "/setup") {
+      await expect(page.getByRole("textbox", { name: "Where model weights live" })).toHaveValue(
+        "/models",
+      );
+      await expect(page.getByText(/controller is unreachable/i)).toHaveCount(0);
+    }
   });
 }
 
@@ -69,17 +75,20 @@ test("Pi defaults to the active controller and reveals other models on request",
 
 test("messages containing /goal reach Pi as ordinary text", async ({ page }) => {
   const composer = await openControllerChat(page, "Goal text chat");
+  const transcript = page.getByRole("article");
   const opening = "/goal is ordinary text before the Pi session exists";
   await composer.fill(opening);
   await composer.press("Enter");
-  await expect(page.getByText(opening, { exact: true })).toBeVisible();
-  await expect(page.getByText("Controller scoped Pi reply.")).toBeVisible({ timeout: 60_000 });
+  await expect(transcript.getByText(opening, { exact: true })).toBeVisible();
+  await expect(transcript.getByText("Controller scoped Pi reply.")).toBeVisible({
+    timeout: 60_000,
+  });
 
   const embedded = "Please explain what /goal means without running it";
   await composer.fill(embedded);
   await composer.press("Enter");
-  await expect(page.getByText(embedded, { exact: true })).toBeVisible();
-  await expect(page.getByText("Controller scoped Pi reply.")).toHaveCount(2, {
+  await expect(transcript.getByText(embedded, { exact: true })).toBeVisible();
+  await expect(transcript.getByText("Controller scoped Pi reply.")).toHaveCount(2, {
     timeout: 60_000,
   });
 });

--- a/frontend/e2e/fixtures/fake-controller.mjs
+++ b/frontend/e2e/fixtures/fake-controller.mjs
@@ -75,6 +75,67 @@ async function streamCompletion(request, response) {
 const server = createServer(async (request, response) => {
   const url = new URL(request.url ?? "/", `http://127.0.0.1:${port}`);
   if (url.pathname === "/health") return json(response, 200, { ok: true });
+  if (url.pathname === "/studio/settings" && request.method === "GET") {
+    return json(response, 200, {
+      config_path: "/tmp/local-studio/config.json",
+      persisted: { models_dir: "/models" },
+      effective: { models_dir: "/models" },
+    });
+  }
+  if (url.pathname === "/studio/diagnostics") {
+    return json(response, 200, {
+      app_version: "test",
+      timestamp: new Date().toISOString(),
+      platform: "darwin",
+      arch: "arm64",
+      release: "test",
+      cpu_model: "Test CPU",
+      cpu_cores: 8,
+      memory_total: 68_719_476_736,
+      memory_free: 34_359_738_368,
+      gpus: [{ name: "Test GPU", memory_total_mb: 65_536 }],
+      runtime: {
+        vllm_installed: false,
+        vllm_version: null,
+        python_path: null,
+        vllm_bin: null,
+      },
+      disks: [],
+      config: {
+        host: "127.0.0.1",
+        port,
+        inference_port: port,
+        api_key_configured: false,
+        models_dir: "/models",
+        data_dir: "/tmp/local-studio",
+        db_path: "/tmp/local-studio/test.db",
+        sglang_python: null,
+        llama_bin: null,
+        mlx_python: null,
+      },
+    });
+  }
+  if (url.pathname === "/studio/presets") {
+    return json(response, 200, { presets: [], max_vram_gb: 64 });
+  }
+  if (url.pathname === "/studio/downloads") {
+    return json(response, 200, { downloads: [] });
+  }
+  if (url.pathname === "/runtime/targets") {
+    return json(response, 200, { targets: [] });
+  }
+  if (url.pathname === "/runtime/jobs") {
+    return json(response, 200, { jobs: [] });
+  }
+  if (url.pathname === "/events") {
+    response.writeHead(200, {
+      "content-type": "text/event-stream",
+      "cache-control": "no-store",
+      connection: "keep-alive",
+    });
+    response.write(": connected\n\n");
+    return;
+  }
   if (url.pathname === "/v1/models") {
     return json(response, 200, {
       object: "list",

--- a/frontend/src/features/recipes/recipes-content/launch-reconciliation.test.ts
+++ b/frontend/src/features/recipes/recipes-content/launch-reconciliation.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { RecipeWithStatus } from "@/lib/types";
+import { isRecipeActive } from "./launch-reconciliation";
+
+const recipe = (id: string, status: RecipeWithStatus["status"]): RecipeWithStatus =>
+  ({ id, status }) as RecipeWithStatus;
+
+describe("launch reconciliation", () => {
+  test("accepts the requested recipe when the controller reports it active", () => {
+    assert.equal(isRecipeActive([recipe("test", "starting")], "test"), true);
+    assert.equal(isRecipeActive([recipe("test", "running")], "test"), true);
+  });
+
+  test("rejects stopped and unrelated recipes", () => {
+    assert.equal(isRecipeActive([recipe("test", "stopped")], "test"), false);
+    assert.equal(isRecipeActive([recipe("other", "running")], "test"), false);
+  });
+});

--- a/frontend/src/features/recipes/recipes-content/launch-reconciliation.ts
+++ b/frontend/src/features/recipes/recipes-content/launch-reconciliation.ts
@@ -1,0 +1,7 @@
+import type { RecipeWithStatus } from "@/lib/types";
+
+export const isRecipeActive = (recipes: RecipeWithStatus[], recipeId: string): boolean =>
+  recipes.some(
+    (recipe) =>
+      recipe.id === recipeId && (recipe.status === "starting" || recipe.status === "running"),
+  );

--- a/frontend/src/features/recipes/recipes-content/recipes-content-model.ts
+++ b/frontend/src/features/recipes/recipes-content/recipes-content-model.ts
@@ -13,6 +13,7 @@ import { prepareRecipeForSave } from "@/features/recipes/prepare-recipe";
 import { DEFAULT_RECIPE } from "./default-recipe";
 import type { RecipesTableProps } from "./types";
 import { useRecipesDerived } from "./use-recipes-derived";
+import { isRecipeActive } from "./launch-reconciliation";
 
 export type RecipesContentTab = "picks" | "get" | "serves" | "downloads";
 
@@ -66,7 +67,7 @@ export function useRecipesContentModel() {
     });
   }, []);
 
-  const loadRecipes = useCallback(async () => {
+  const loadRecipes = useCallback(async (): Promise<RecipeWithStatus[]> => {
     try {
       const [recipesData, modelsData, runtimeData] = await Promise.all([
         api.getRecipes().catch(() => ({ recipes: [] as RecipeWithStatus[] })),
@@ -81,8 +82,10 @@ export function useRecipesContentModel() {
       setRunningRecipeId(running);
       setAvailableModels(modelsData.models || []);
       setRuntimeTargets(runtimeData.targets || []);
+      return recipesList;
     } catch (e) {
       console.error("Failed to load recipes:", e);
+      return [];
     }
   }, []);
 
@@ -182,7 +185,10 @@ export function useRecipesContentModel() {
         await api.launchRecipe(recipeId);
         await loadRecipes();
       } catch (e) {
-        alert("Failed to launch: " + (e as Error).message);
+        const reconciled = await loadRecipes();
+        if (!isRecipeActive(reconciled, recipeId)) {
+          alert("Failed to launch: " + (e as Error).message);
+        }
       } finally {
         setLaunching(false);
       }

--- a/scripts/install-desktop-app.sh
+++ b/scripts/install-desktop-app.sh
@@ -7,6 +7,9 @@ ROLLBACK_ROOT="${LOCAL_STUDIO_ROLLBACK_ROOT:-$HOME/Library/Application Support/L
 LSREGISTER="${LOCAL_STUDIO_LSREGISTER:-/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister}"
 PLIST_BUDDY="${LOCAL_STUDIO_PLIST_BUDDY:-/usr/libexec/PlistBuddy}"
 SKIP_RUNTIME_CLEANUP="${LOCAL_STUDIO_SKIP_RUNTIME_CLEANUP:-0}"
+RELEASE_DMG_URL="${LOCAL_STUDIO_RELEASE_DMG_URL:-https://github.com/sybil-solutions/local-studio/releases/latest/download/Local-Studio-arm64.dmg}"
+RELEASE_TEMP=""
+RELEASE_MOUNT=""
 
 channel="stable"
 keep_backup=1
@@ -38,7 +41,7 @@ if [[ "$channel" == "dev" ]]; then
 else
   APP_NAME="Local Studio"
   APP_ID="org.local.studio.desktop"
-  BUILT="${LOCAL_STUDIO_BUILT_APP:-$REPO_ROOT/frontend/dist-desktop/mac-arm64/$APP_NAME.app}"
+  BUILT="${LOCAL_STUDIO_BUILT_APP:-}"
 fi
 
 TARGET="$INSTALL_ROOT/$APP_NAME.app"
@@ -154,6 +157,16 @@ cleanup_temporary_paths() {
   elif [[ "${SWAP_VERIFIED:-0}" == "0" && "${TARGET_INSTALLED:-0}" == "1" ]]; then
     rm -rf "$TARGET"
   fi
+  cleanup_release_source
+}
+
+cleanup_release_source() {
+  if [[ -n "$RELEASE_MOUNT" ]]; then
+    hdiutil detach "$RELEASE_MOUNT" -quiet || hdiutil detach "$RELEASE_MOUNT" -force -quiet || true
+  fi
+  [[ -z "$RELEASE_TEMP" ]] || rm -rf "$RELEASE_TEMP"
+  RELEASE_MOUNT=""
+  RELEASE_TEMP=""
 }
 
 if [[ "$mode" == "migrate" ]]; then
@@ -162,11 +175,34 @@ if [[ "$mode" == "migrate" ]]; then
   exit 0
 fi
 
+HAD_TARGET=0
+SWAP_VERIFIED=0
+TARGET_INSTALLED=0
+trap cleanup_temporary_paths EXIT
+
+if [[ "$channel" == "stable" && -z "$BUILT" ]]; then
+  RELEASE_TEMP="$(mktemp -d "${TMPDIR:-/tmp}/local-studio-release.XXXXXX")"
+  RELEASE_MOUNT="$RELEASE_TEMP/mount"
+  release_dmg="$RELEASE_TEMP/Local-Studio-arm64.dmg"
+  mkdir -p "$RELEASE_MOUNT"
+  echo "==> downloading latest stable release"
+  curl --fail --location --silent --show-error "$RELEASE_DMG_URL" --output "$release_dmg"
+  xcrun stapler validate "$release_dmg"
+  spctl --assess --type open --context context:primary-signature "$release_dmg"
+  hdiutil attach -readonly -nobrowse -mountpoint "$RELEASE_MOUNT" "$release_dmg" >/dev/null
+  BUILT="$RELEASE_MOUNT/$APP_NAME.app"
+fi
+
 if [[ ! -d "$BUILT" ]]; then
   echo "error: no built bundle at $BUILT" >&2
   hint="desktop:dist"
   [[ "$channel" == "dev" ]] && hint="desktop:dist:dev"
   echo "       run: npm --prefix frontend run $hint" >&2
+  exit 1
+fi
+
+if [[ "$(bundle_id "$BUILT" || true)" != "$APP_ID" ]]; then
+  echo "error: built bundle identifier does not match $APP_ID" >&2
   exit 1
 fi
 
@@ -181,15 +217,15 @@ if [[ "$BUILT" != /* ]]; then
 fi
 
 codesign --verify --deep --strict "$BUILT"
+if [[ "$channel" == "stable" ]]; then
+  spctl --assess --type execute "$BUILT"
+fi
 mkdir -p "$INSTALL_ROOT" "$ROLLBACK_ROOT"
 rm -rf "$STAGED" "$REPLACED"
-trap cleanup_temporary_paths EXIT
-HAD_TARGET=0
-SWAP_VERIFIED=0
-TARGET_INSTALLED=0
 
 ditto "$BUILT" "$STAGED"
 codesign --verify --deep --strict "$STAGED"
+cleanup_release_source
 
 if [[ -d "$TARGET" && "$keep_backup" == "1" ]]; then
   echo "==> archiving current install -> $ROLLBACK"
@@ -229,6 +265,9 @@ fi
 mv "$STAGED" "$TARGET"
 TARGET_INSTALLED=1
 codesign --verify --deep --strict "$TARGET"
+if [[ "$channel" == "stable" ]]; then
+  spctl --assess --type execute "$TARGET"
+fi
 SWAP_VERIFIED=1
 rm -rf "$REPLACED"
 


### PR DESCRIPTION
## Summary

- promote the stable installer and app-stapling fix to `main`
- prevent stale local builds from being installed as Stable
- require release ticket, bundle identity, signature, and Gatekeeper verification
- notarize and staple the app before generating update assets

## Validation

- full `npm run check`
- release self-tests 12/12
- PR #340 all checks green
- real isolated install from v2.9.5 produced version 2.9.5 and Gatekeeper `Notarized Developer ID`