### PR TITLE
fix(security): pin Bun setup action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           node-version: 22.19.0
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: 1.3.14
 


### PR DESCRIPTION
Pins the remaining release-workflow setup action to the immutable v2 commit.\n\nValidated with 
> local-studio@2.1.0 check:release
> node scripts/project.mjs self-test

✔ migrates every legacy Local Studio bundle into non-app rollback archives (1461.677958ms)
✔ installs through a hidden staging path and archives the outgoing app (1707.496959ms)
✔ restores the original app when final signature verification fails (1076.318583ms)
✔ restores the original stable app when Gatekeeper rejects the replacement (1096.456041ms)
✔ preserves the current app when creating its rollback archive fails (822.859125ms)
✔ no-backup install removes stale archives and discoverable legacy bundles (1074.439958ms)
✔ tracked operational scripts cannot create discoverable app backups (22.214333ms)
✔ uses App Store Connect API credentials when the full trio is present (0.186667ms)
✔ uses Apple ID credentials when API credentials are unavailable (0.079125ms)
✔ rejects partial notarization credential sets (0.334209ms)
✔ release signing packaging never publishes implicitly (0.077584ms)
✔ release signing notarizes and staples the app before packaging (0.101542ms)
ℹ tests 12
ℹ suites 0
ℹ pass 12
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 7266.292667; full CI required before merge.