### PR TITLE
feat(agent): define realtime mobile session contract

### DIFF
--- a/docs/realtime-mobile-contract.md
+++ b/docs/realtime-mobile-contract.md
@@ -1,0 +1,83 @@
+# Realtime mobile contract
+
+Status: contract version 1, not yet exposed by the agent-runtime gateway.
+
+The realtime contract extends `litter-bridge/v1`; it does not create another endpoint or authentication model. Local Studio owns provider credentials, capability discovery, session creation, and teardown. Alleycat forwards authenticated control messages. Litter keeps native WebRTC peer connections and platform audio processing. Media does not traverse Alleycat in version 1.
+
+The canonical Effect schemas and TypeScript types live in `shared/agent/litter-bridge.ts`. `shared/agent/litter-bridge-realtime-v1.fixture.json` is the language-neutral conformance vector for TypeScript and Rust consumers.
+
+## Version negotiation
+
+`protocolVersion` remains `1`. Realtime evolves independently through `contractVersion` so older controller operations remain stable. A client begins with `realtime_capabilities_request` and sends every realtime contract version it can decode. Version 1 accepts only `[1]`. A controller that cannot select a version returns `unsupported_version` and does not create a session.
+
+The gateway advertises `realtime.session` only after the broker implementation is installed and usable. Merely compiling the contract does not advertise availability.
+
+## Capability discovery
+
+Each returned capability binds a provider adapter and model to:
+
+- input and output modalities;
+- signaling transport;
+- supported voices;
+- update and reconnect support;
+- session lifetime and signaling payload bounds;
+- explicit availability or one typed unavailability reason.
+
+`provider_native` means Local Studio negotiates a provider-native realtime session. `local_pipeline` means Local Studio owns an STT to LLM to TTS pipeline behind the same lifecycle. Clients must not infer support from model names or silently substitute one provider for another.
+
+## Lifecycle
+
+The version 1 happy path is:
+
+1. `realtime_capabilities_request` selects the contract and capability.
+2. `realtime_session_create_request` carries a client-generated session identifier and native WebRTC offer.
+3. `realtime_session_created` returns the authoritative broker session and answer.
+4. `realtime_signal_request` carries bounded ICE updates when required.
+5. `realtime_session_update_request` changes only typed mutable configuration.
+6. `realtime_session_status` reports ordered authoritative state.
+7. `realtime_session_close_request` tears down provider and broker resources.
+
+Create, signal, update, and close are mutations and require an idempotency key. Retrying the same authenticated request and body returns the stored result. Reusing an idempotency key with different bytes fails with `integrity_failed`. Closing an already-closed session returns the same terminal session rather than creating an error-only cleanup loop.
+
+The broker binds `sessionId`, `clientSessionId`, `deviceId`, and `capabilityId`. A session may only be read or changed by the authenticated device grant that created it. Requests for another device, controller, or capability fail closed without confirming whether the target exists.
+
+## Reconnect and expiry
+
+The broker may return a short-lived opaque reconnect token. It is scoped to one controller, device, and session and expires no later than the session. The token never replaces signed device authentication. A reconnect returns the existing authoritative session or an explicit `closed`, `expired`, or `failed` state; it must never create another provider session implicitly.
+
+Expired sessions reject mutations with `realtime_session_expired`. Invalid state transitions use `realtime_state_conflict`. Controller shutdown closes or expires all owned sessions within the broker's documented cleanup bound.
+
+## Security and logging
+
+Long-lived provider keys never cross the bridge. Contract schemas reject excess properties, including an accidental provider API key. WebRTC SDP, ICE credentials, reconnect tokens, signatures, and controller secrets are sensitive and must be redacted from logs and crash reports.
+
+The broker records only safe correlation fields and timings: request ID, hashed session correlation, state transition, result code, broker latency, and media connection latency. Broker latency ends when the session answer is available. Media connection latency ends when native WebRTC reports a connected peer; the two values must not be combined.
+
+Requests retain the existing Litter bridge controls:
+
+- Ed25519 device signatures and body hashes;
+- a maximum 60-second request lifetime;
+- nonce replay detection;
+- device capability authorization;
+- bounded bodies, signals, outstanding operations, and replay storage;
+- idempotent mutation storage.
+
+## Errors
+
+Realtime operations reuse the typed Litter bridge error envelope. The contract adds:
+
+- `realtime_unavailable`: the selected capability cannot create a session;
+- `realtime_session_expired`: the authoritative session lifetime ended;
+- `realtime_state_conflict`: the operation is invalid for the authoritative state.
+
+Authentication, authorization, version, replay, integrity, payload, rate, controller, and internal failures continue to use the existing error codes. Public messages must not contain provider response bodies or credentials.
+
+## Implementation sequence
+
+1. Land this schema, documentation, and conformance fixture.
+2. Add a Local Studio broker with a fake-provider lifecycle test before advertising `realtime.session`.
+3. Consume the exact fixture and version identifier in Alleycat and Litter.
+4. Expose the broker through the packaged Local Studio runtime and prove the installed application contract.
+5. Add the optional local STT to LLM to TTS adapter behind `local_pipeline`.
+
+Until steps 2 and 4 land, the contract is intentionally inert and existing controller, session, and model-serving behavior is unchanged.

--- a/shared/agent/litter-bridge-realtime-v1.fixture.json
+++ b/shared/agent/litter-bridge-realtime-v1.fixture.json
@@ -1,0 +1,211 @@
+{
+  "contractVersion": 1,
+  "capabilitiesRequest": {
+    "type": "realtime_capabilities_request",
+    "protocolVersion": 1,
+    "auth": {
+      "device": {
+        "deviceId": "device-1",
+        "keyId": "device-key-1",
+        "algorithm": "ed25519"
+      },
+      "requestId": "request-capabilities-1",
+      "issuedAt": "2026-08-04T12:00:00.000Z",
+      "expiresAt": "2026-08-04T12:01:00.000Z",
+      "nonce": "nonce_capabilities_1",
+      "bodyHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "signature": "ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss",
+      "capability": "realtime.session"
+    },
+    "controllerId": "controller-1",
+    "acceptedContractVersions": [1]
+  },
+  "capabilitiesResult": {
+    "type": "realtime_capabilities",
+    "protocolVersion": 1,
+    "contractVersion": 1,
+    "requestId": "request-capabilities-1",
+    "controllerId": "controller-1",
+    "generatedAt": "2026-08-04T12:00:00.010Z",
+    "capabilities": [
+      {
+        "capabilityId": "openai-realtime-gpt-4o",
+        "provider": "provider_native",
+        "modelId": "gpt-4o-realtime-preview",
+        "available": true,
+        "unavailableReason": null,
+        "inputModalities": ["audio", "text"],
+        "outputModalities": ["audio", "text"],
+        "signaling": "webrtc_offer_answer",
+        "voices": [
+          {
+            "id": "alloy",
+            "label": "Alloy"
+          }
+        ],
+        "supportsReconnect": true,
+        "supportsUpdate": true,
+        "sessionTtlSeconds": 600,
+        "maxSignalBytes": 65536
+      },
+      {
+        "capabilityId": "local-pipeline-default",
+        "provider": "local_pipeline",
+        "modelId": "local-model",
+        "available": false,
+        "unavailableReason": "speech_plugin_unavailable",
+        "inputModalities": ["audio"],
+        "outputModalities": ["audio"],
+        "signaling": "local_websocket",
+        "voices": [],
+        "supportsReconnect": false,
+        "supportsUpdate": false,
+        "sessionTtlSeconds": 300,
+        "maxSignalBytes": 16384
+      }
+    ]
+  },
+  "createRequest": {
+    "type": "realtime_session_create_request",
+    "protocolVersion": 1,
+    "contractVersion": 1,
+    "auth": {
+      "device": {
+        "deviceId": "device-1",
+        "keyId": "device-key-1",
+        "algorithm": "ed25519"
+      },
+      "requestId": "request-create-1",
+      "issuedAt": "2026-08-04T12:00:01.000Z",
+      "expiresAt": "2026-08-04T12:01:01.000Z",
+      "nonce": "nonce_create_123456",
+      "bodyHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "signature": "ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss",
+      "capability": "realtime.session",
+      "idempotencyKey": "create-session-1"
+    },
+    "controllerId": "controller-1",
+    "clientSessionId": "mobile-session-1",
+    "capabilityId": "openai-realtime-gpt-4o",
+    "voiceId": "alloy",
+    "offer": {
+      "type": "webrtc_offer",
+      "sdp": "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\n"
+    }
+  },
+  "createResult": {
+    "type": "realtime_session_created",
+    "protocolVersion": 1,
+    "contractVersion": 1,
+    "requestId": "request-create-1",
+    "idempotencyKey": "create-session-1",
+    "session": {
+      "sessionId": "provider-session-1",
+      "clientSessionId": "mobile-session-1",
+      "capabilityId": "openai-realtime-gpt-4o",
+      "deviceId": "device-1",
+      "state": "negotiating",
+      "createdAt": "2026-08-04T12:00:01.010Z",
+      "expiresAt": "2026-08-04T12:10:01.010Z",
+      "reconnectToken": "fake-reconnect-token-1"
+    },
+    "answer": {
+      "type": "webrtc_answer",
+      "sdp": "v=0\r\no=- 2 2 IN IP4 127.0.0.1\r\n"
+    },
+    "brokerLatencyMs": 10
+  },
+  "signalRequest": {
+    "type": "realtime_signal_request",
+    "protocolVersion": 1,
+    "contractVersion": 1,
+    "auth": {
+      "device": {
+        "deviceId": "device-1",
+        "keyId": "device-key-1",
+        "algorithm": "ed25519"
+      },
+      "requestId": "request-signal-1",
+      "issuedAt": "2026-08-04T12:00:02.000Z",
+      "expiresAt": "2026-08-04T12:01:02.000Z",
+      "nonce": "nonce_signal_123456",
+      "bodyHash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "signature": "ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss",
+      "capability": "realtime.session",
+      "idempotencyKey": "signal-session-1"
+    },
+    "sessionId": "provider-session-1",
+    "signal": {
+      "type": "ice_candidate",
+      "candidate": "candidate:1 1 UDP 2122260223 192.0.2.1 54321 typ host",
+      "sdpMid": "audio",
+      "sdpMLineIndex": 0
+    }
+  },
+  "updateRequest": {
+    "type": "realtime_session_update_request",
+    "protocolVersion": 1,
+    "contractVersion": 1,
+    "auth": {
+      "device": {
+        "deviceId": "device-1",
+        "keyId": "device-key-1",
+        "algorithm": "ed25519"
+      },
+      "requestId": "request-update-1",
+      "issuedAt": "2026-08-04T12:00:03.000Z",
+      "expiresAt": "2026-08-04T12:01:03.000Z",
+      "nonce": "nonce_update_123456",
+      "bodyHash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "signature": "ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss",
+      "capability": "realtime.session",
+      "idempotencyKey": "update-session-1"
+    },
+    "sessionId": "provider-session-1",
+    "voiceId": "alloy",
+    "instructions": "Answer concisely."
+  },
+  "closeRequest": {
+    "type": "realtime_session_close_request",
+    "protocolVersion": 1,
+    "contractVersion": 1,
+    "auth": {
+      "device": {
+        "deviceId": "device-1",
+        "keyId": "device-key-1",
+        "algorithm": "ed25519"
+      },
+      "requestId": "request-close-1",
+      "issuedAt": "2026-08-04T12:00:04.000Z",
+      "expiresAt": "2026-08-04T12:01:04.000Z",
+      "nonce": "nonce_close_123456",
+      "bodyHash": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "signature": "ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss",
+      "capability": "realtime.session",
+      "idempotencyKey": "close-session-1"
+    },
+    "sessionId": "provider-session-1",
+    "reason": "user"
+  },
+  "status": {
+    "type": "realtime_session_status",
+    "protocolVersion": 1,
+    "contractVersion": 1,
+    "eventId": "event-1",
+    "sequence": 1,
+    "observedAt": "2026-08-04T12:00:05.000Z",
+    "session": {
+      "sessionId": "provider-session-1",
+      "clientSessionId": "mobile-session-1",
+      "capabilityId": "openai-realtime-gpt-4o",
+      "deviceId": "device-1",
+      "state": "active",
+      "createdAt": "2026-08-04T12:00:01.010Z",
+      "expiresAt": "2026-08-04T12:10:01.010Z",
+      "reconnectToken": "fake-reconnect-token-1"
+    },
+    "brokerLatencyMs": 10,
+    "mediaConnectionLatencyMs": 340,
+    "error": null
+  }
+}

--- a/shared/agent/litter-bridge.test.ts
+++ b/shared/agent/litter-bridge.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { describe, test } from "node:test";
 import { Schema } from "effect";
 import {
@@ -8,6 +9,14 @@ import {
   LitterBridgeControllerActionRequestSchema,
   LitterBridgeControllerActionSchema,
   LitterBridgeControllerSnapshotSchema,
+  LitterBridgeRealtimeCapabilitiesRequestSchema,
+  LitterBridgeRealtimeCapabilitiesResultSchema,
+  LitterBridgeRealtimeSessionCloseRequestSchema,
+  LitterBridgeRealtimeSessionCreateRequestSchema,
+  LitterBridgeRealtimeSessionCreateResultSchema,
+  LitterBridgeRealtimeSessionStatusSchema,
+  LitterBridgeRealtimeSessionUpdateRequestSchema,
+  LitterBridgeRealtimeSignalRequestSchema,
   LitterBridgeSessionListPageSchema,
   LitterBridgeSessionListRequestSchema,
   LitterBridgeSessionPageSchema,
@@ -15,6 +24,10 @@ import {
   LitterBridgeSessionTransferEnvelopeSchema,
   LitterBridgeSessionTransferResultSchema,
 } from "./litter-bridge";
+
+const realtimeFixture = JSON.parse(
+  readFileSync(new URL("./litter-bridge-realtime-v1.fixture.json", import.meta.url), "utf8"),
+) as Record<string, unknown>;
 
 const timestamp = "2026-07-20T12:30:45.000Z";
 const hash = "a".repeat(64);
@@ -128,6 +141,53 @@ const transfer = {
 };
 
 describe("Litter bridge contracts", () => {
+  test("accepts the realtime v1 conformance vectors", () => {
+    const vectors = [
+      [LitterBridgeRealtimeCapabilitiesRequestSchema, "capabilitiesRequest"],
+      [LitterBridgeRealtimeCapabilitiesResultSchema, "capabilitiesResult"],
+      [LitterBridgeRealtimeSessionCreateRequestSchema, "createRequest"],
+      [LitterBridgeRealtimeSessionCreateResultSchema, "createResult"],
+      [LitterBridgeRealtimeSignalRequestSchema, "signalRequest"],
+      [LitterBridgeRealtimeSessionUpdateRequestSchema, "updateRequest"],
+      [LitterBridgeRealtimeSessionCloseRequestSchema, "closeRequest"],
+      [LitterBridgeRealtimeSessionStatusSchema, "status"],
+    ] as const;
+
+    for (const [schema, key] of vectors) {
+      assert.doesNotThrow(() => Schema.decodeUnknownSync(schema)(realtimeFixture[key]));
+    }
+  });
+
+  test("rejects incompatible realtime versions and contradictory availability", () => {
+    const request = structuredClone(realtimeFixture.capabilitiesRequest) as Record<string, unknown>;
+    request.acceptedContractVersions = [2];
+    assert.throws(() =>
+      Schema.decodeUnknownSync(LitterBridgeRealtimeCapabilitiesRequestSchema)(request),
+    );
+
+    const result = structuredClone(realtimeFixture.capabilitiesResult) as {
+      capabilities: Array<Record<string, unknown>>;
+    };
+    result.capabilities[0] = {
+      ...result.capabilities[0],
+      available: false,
+      unavailableReason: null,
+    };
+    assert.throws(() =>
+      Schema.decodeUnknownSync(LitterBridgeRealtimeCapabilitiesResultSchema)(result),
+    );
+  });
+
+  test("rejects provider secrets outside the typed realtime boundary", () => {
+    const request = {
+      ...(structuredClone(realtimeFixture.createRequest) as Record<string, unknown>),
+      providerApiKey: "must-not-cross-the-bridge",
+    };
+    assert.throws(() =>
+      Schema.decodeUnknownSync(LitterBridgeRealtimeSessionCreateRequestSchema)(request),
+    );
+  });
+
   test("accepts only the versioned capability vocabulary", () => {
     const manifest = Schema.decodeUnknownSync(LitterBridgeCapabilitiesManifestSchema)({
       type: "capabilities",

--- a/shared/agent/litter-bridge.ts
+++ b/shared/agent/litter-bridge.ts
@@ -7,7 +7,9 @@ export const LITTER_BRIDGE_CAPABILITIES = [
   "sessions.read",
   "sessions.write",
   "agent.turn",
+  "realtime.session",
 ] as const;
+export const LITTER_BRIDGE_REALTIME_CONTRACT_VERSION = 1 as const;
 
 export const LitterBridgeParseOptions = {
   errors: "all",
@@ -118,6 +120,15 @@ const AgentTurnAuthSchema = Schema.Struct({
   capability: Schema.Literal("agent.turn"),
   idempotencyKey: IdentifierSchema,
 }).pipe(strict);
+const RealtimeSessionReadAuthSchema = Schema.Struct({
+  ...RequestAuthFields,
+  capability: Schema.Literal("realtime.session"),
+}).pipe(strict);
+const RealtimeSessionMutationAuthSchema = Schema.Struct({
+  ...RequestAuthFields,
+  capability: Schema.Literal("realtime.session"),
+  idempotencyKey: IdentifierSchema,
+}).pipe(strict);
 
 export const LitterBridgeSectionNameSchema = Schema.Literals([
   "health",
@@ -143,6 +154,9 @@ export const LitterBridgeErrorCodeSchema = Schema.Literals([
   "controller_unavailable",
   "section_unavailable",
   "agent_runtime_unavailable",
+  "realtime_unavailable",
+  "realtime_session_expired",
+  "realtime_state_conflict",
   "internal",
 ]);
 
@@ -263,6 +277,213 @@ export const LitterBridgeCapabilitiesManifestSchema = Schema.Struct({
   issuedAt: TimestampSchema,
   capabilities: Schema.Array(LitterBridgeCapabilitySchema).pipe(Schema.check(Schema.isUnique())),
 }).pipe(strict);
+
+export const LitterBridgeRealtimeContractVersionSchema = Schema.Literal(
+  LITTER_BRIDGE_REALTIME_CONTRACT_VERSION,
+);
+export const LitterBridgeRealtimeProviderSchema = Schema.Literals([
+  "provider_native",
+  "local_pipeline",
+]);
+export const LitterBridgeRealtimeModalitySchema = Schema.Literals(["audio", "text"]);
+export const LitterBridgeRealtimeSignalingSchema = Schema.Literals([
+  "webrtc_offer_answer",
+  "local_websocket",
+]);
+export const LitterBridgeRealtimeSessionStateSchema = Schema.Literals([
+  "creating",
+  "negotiating",
+  "active",
+  "reconnecting",
+  "closing",
+  "closed",
+  "expired",
+  "failed",
+]);
+export const LitterBridgeRealtimeUnavailableReasonSchema = Schema.Literals([
+  "provider_not_configured",
+  "model_not_loaded",
+  "model_unsupported",
+  "speech_plugin_unavailable",
+  "runtime_unavailable",
+]);
+
+export const LitterBridgeRealtimeVoiceSchema = Schema.Struct({
+  id: IdentifierSchema,
+  label: IdentifierSchema,
+}).pipe(strict);
+
+export const LitterBridgeRealtimeCapabilitySchema = Schema.Struct({
+  capabilityId: IdentifierSchema,
+  provider: LitterBridgeRealtimeProviderSchema,
+  modelId: IdentifierSchema,
+  available: Schema.Boolean,
+  unavailableReason: Schema.NullOr(LitterBridgeRealtimeUnavailableReasonSchema),
+  inputModalities: Schema.Array(LitterBridgeRealtimeModalitySchema).pipe(
+    Schema.check(Schema.isUnique()),
+  ),
+  outputModalities: Schema.Array(LitterBridgeRealtimeModalitySchema).pipe(
+    Schema.check(Schema.isUnique()),
+  ),
+  signaling: LitterBridgeRealtimeSignalingSchema,
+  voices: Schema.Array(LitterBridgeRealtimeVoiceSchema),
+  supportsReconnect: Schema.Boolean,
+  supportsUpdate: Schema.Boolean,
+  sessionTtlSeconds: PositiveIntegerSchema,
+  maxSignalBytes: PositiveIntegerSchema,
+}).pipe(
+  Schema.check(
+    Schema.makeFilter((input) =>
+      input.available === (input.unavailableReason === null)
+        ? undefined
+        : "Availability and unavailableReason must agree",
+    ),
+  ),
+  strict,
+);
+
+export const LitterBridgeRealtimeCapabilitiesRequestSchema = Schema.Struct({
+  type: Schema.Literal("realtime_capabilities_request"),
+  protocolVersion: LitterBridgeProtocolVersionSchema,
+  auth: RealtimeSessionReadAuthSchema,
+  controllerId: IdentifierSchema,
+  acceptedContractVersions: Schema.Array(LitterBridgeRealtimeContractVersionSchema).pipe(
+    Schema.check(Schema.isNonEmpty()),
+    Schema.check(Schema.isUnique()),
+  ),
+}).pipe(strict);
+
+export const LitterBridgeRealtimeCapabilitiesResultSchema = Schema.Struct({
+  type: Schema.Literal("realtime_capabilities"),
+  protocolVersion: LitterBridgeProtocolVersionSchema,
+  contractVersion: LitterBridgeRealtimeContractVersionSchema,
+  requestId: IdentifierSchema,
+  controllerId: IdentifierSchema,
+  generatedAt: TimestampSchema,
+  capabilities: Schema.Array(LitterBridgeRealtimeCapabilitySchema),
+}).pipe(strict);
+
+export const LitterBridgeRealtimeOfferSchema = Schema.Struct({
+  type: Schema.Literal("webrtc_offer"),
+  sdp: WireTextSchema,
+}).pipe(strict);
+
+export const LitterBridgeRealtimeAnswerSchema = Schema.Struct({
+  type: Schema.Literal("webrtc_answer"),
+  sdp: WireTextSchema,
+}).pipe(strict);
+
+export const LitterBridgeRealtimeSessionSchema = Schema.Struct({
+  sessionId: IdentifierSchema,
+  clientSessionId: IdentifierSchema,
+  capabilityId: IdentifierSchema,
+  deviceId: IdentifierSchema,
+  state: LitterBridgeRealtimeSessionStateSchema,
+  createdAt: TimestampSchema,
+  expiresAt: TimestampSchema,
+  reconnectToken: Schema.NullOr(OpaqueTokenSchema),
+}).pipe(strict);
+
+export const LitterBridgeRealtimeSessionCreateRequestSchema = Schema.Struct({
+  type: Schema.Literal("realtime_session_create_request"),
+  protocolVersion: LitterBridgeProtocolVersionSchema,
+  contractVersion: LitterBridgeRealtimeContractVersionSchema,
+  auth: RealtimeSessionMutationAuthSchema,
+  controllerId: IdentifierSchema,
+  clientSessionId: IdentifierSchema,
+  capabilityId: IdentifierSchema,
+  voiceId: Schema.NullOr(IdentifierSchema),
+  offer: LitterBridgeRealtimeOfferSchema,
+}).pipe(strict);
+
+export const LitterBridgeRealtimeSessionCreateResultSchema = Schema.Struct({
+  type: Schema.Literal("realtime_session_created"),
+  protocolVersion: LitterBridgeProtocolVersionSchema,
+  contractVersion: LitterBridgeRealtimeContractVersionSchema,
+  requestId: IdentifierSchema,
+  idempotencyKey: IdentifierSchema,
+  session: LitterBridgeRealtimeSessionSchema,
+  answer: LitterBridgeRealtimeAnswerSchema,
+  brokerLatencyMs: NonNegativeNumberSchema,
+}).pipe(strict);
+
+export const LitterBridgeRealtimeSignalSchema = Schema.Union([
+  Schema.Struct({
+    type: Schema.Literal("ice_candidate"),
+    candidate: WireTextSchema,
+    sdpMid: Schema.NullOr(IdentifierSchema),
+    sdpMLineIndex: Schema.NullOr(NonNegativeIntegerSchema),
+  }).pipe(strict),
+  Schema.Struct({
+    type: Schema.Literal("ice_complete"),
+  }).pipe(strict),
+]).pipe(strict);
+
+export const LitterBridgeRealtimeSignalRequestSchema = Schema.Struct({
+  type: Schema.Literal("realtime_signal_request"),
+  protocolVersion: LitterBridgeProtocolVersionSchema,
+  contractVersion: LitterBridgeRealtimeContractVersionSchema,
+  auth: RealtimeSessionMutationAuthSchema,
+  sessionId: IdentifierSchema,
+  signal: LitterBridgeRealtimeSignalSchema,
+}).pipe(strict);
+
+export const LitterBridgeRealtimeSessionUpdateRequestSchema = Schema.Struct({
+  type: Schema.Literal("realtime_session_update_request"),
+  protocolVersion: LitterBridgeProtocolVersionSchema,
+  contractVersion: LitterBridgeRealtimeContractVersionSchema,
+  auth: RealtimeSessionMutationAuthSchema,
+  sessionId: IdentifierSchema,
+  voiceId: Schema.NullOr(IdentifierSchema),
+  instructions: Schema.NullOr(ShortTextSchema),
+}).pipe(strict);
+
+export const LitterBridgeRealtimeSessionCloseRequestSchema = Schema.Struct({
+  type: Schema.Literal("realtime_session_close_request"),
+  protocolVersion: LitterBridgeProtocolVersionSchema,
+  contractVersion: LitterBridgeRealtimeContractVersionSchema,
+  auth: RealtimeSessionMutationAuthSchema,
+  sessionId: IdentifierSchema,
+  reason: Schema.Literals(["user", "handoff", "timeout", "shutdown"]),
+}).pipe(strict);
+
+export const LitterBridgeRealtimeSessionStatusSchema = Schema.Struct({
+  type: Schema.Literal("realtime_session_status"),
+  protocolVersion: LitterBridgeProtocolVersionSchema,
+  contractVersion: LitterBridgeRealtimeContractVersionSchema,
+  eventId: IdentifierSchema,
+  sequence: NonNegativeIntegerSchema,
+  observedAt: TimestampSchema,
+  session: LitterBridgeRealtimeSessionSchema,
+  brokerLatencyMs: Schema.NullOr(NonNegativeNumberSchema),
+  mediaConnectionLatencyMs: Schema.NullOr(NonNegativeNumberSchema),
+  error: Schema.NullOr(LitterBridgeErrorSchema),
+}).pipe(strict);
+
+export const LitterBridgeRealtimeMutationAckSchema = Schema.Struct({
+  type: Schema.Literal("realtime_mutation_ack"),
+  protocolVersion: LitterBridgeProtocolVersionSchema,
+  contractVersion: LitterBridgeRealtimeContractVersionSchema,
+  requestId: IdentifierSchema,
+  idempotencyKey: IdentifierSchema,
+  session: LitterBridgeRealtimeSessionSchema,
+}).pipe(strict);
+
+export const LitterBridgeRealtimeRequestSchema = Schema.Union([
+  LitterBridgeRealtimeCapabilitiesRequestSchema,
+  LitterBridgeRealtimeSessionCreateRequestSchema,
+  LitterBridgeRealtimeSignalRequestSchema,
+  LitterBridgeRealtimeSessionUpdateRequestSchema,
+  LitterBridgeRealtimeSessionCloseRequestSchema,
+]).pipe(strict);
+
+export const LitterBridgeRealtimeResultSchema = Schema.Union([
+  LitterBridgeRealtimeCapabilitiesResultSchema,
+  LitterBridgeRealtimeSessionCreateResultSchema,
+  LitterBridgeRealtimeSessionStatusSchema,
+  LitterBridgeRealtimeMutationAckSchema,
+  LitterBridgeErrorResultSchema,
+]).pipe(strict);
 
 export const LitterBridgeControllerSnapshotRequestSchema = Schema.Struct({
   type: Schema.Literal("controller_snapshot_request"),
@@ -660,6 +881,37 @@ export type LitterBridgeMetrics = typeof LitterBridgeMetricsSchema.Type;
 export type LitterBridgeAgentRuntimeStats = typeof LitterBridgeAgentRuntimeStatsSchema.Type;
 export type LitterBridgeControllerSnapshot = typeof LitterBridgeControllerSnapshotSchema.Type;
 export type LitterBridgeCapabilitiesManifest = typeof LitterBridgeCapabilitiesManifestSchema.Type;
+export type LitterBridgeRealtimeContractVersion =
+  typeof LitterBridgeRealtimeContractVersionSchema.Type;
+export type LitterBridgeRealtimeProvider = typeof LitterBridgeRealtimeProviderSchema.Type;
+export type LitterBridgeRealtimeModality = typeof LitterBridgeRealtimeModalitySchema.Type;
+export type LitterBridgeRealtimeSignaling = typeof LitterBridgeRealtimeSignalingSchema.Type;
+export type LitterBridgeRealtimeSessionState = typeof LitterBridgeRealtimeSessionStateSchema.Type;
+export type LitterBridgeRealtimeUnavailableReason =
+  typeof LitterBridgeRealtimeUnavailableReasonSchema.Type;
+export type LitterBridgeRealtimeVoice = typeof LitterBridgeRealtimeVoiceSchema.Type;
+export type LitterBridgeRealtimeCapability = typeof LitterBridgeRealtimeCapabilitySchema.Type;
+export type LitterBridgeRealtimeCapabilitiesRequest =
+  typeof LitterBridgeRealtimeCapabilitiesRequestSchema.Type;
+export type LitterBridgeRealtimeCapabilitiesResult =
+  typeof LitterBridgeRealtimeCapabilitiesResultSchema.Type;
+export type LitterBridgeRealtimeOffer = typeof LitterBridgeRealtimeOfferSchema.Type;
+export type LitterBridgeRealtimeAnswer = typeof LitterBridgeRealtimeAnswerSchema.Type;
+export type LitterBridgeRealtimeSession = typeof LitterBridgeRealtimeSessionSchema.Type;
+export type LitterBridgeRealtimeSessionCreateRequest =
+  typeof LitterBridgeRealtimeSessionCreateRequestSchema.Type;
+export type LitterBridgeRealtimeSessionCreateResult =
+  typeof LitterBridgeRealtimeSessionCreateResultSchema.Type;
+export type LitterBridgeRealtimeSignal = typeof LitterBridgeRealtimeSignalSchema.Type;
+export type LitterBridgeRealtimeSignalRequest = typeof LitterBridgeRealtimeSignalRequestSchema.Type;
+export type LitterBridgeRealtimeSessionUpdateRequest =
+  typeof LitterBridgeRealtimeSessionUpdateRequestSchema.Type;
+export type LitterBridgeRealtimeSessionCloseRequest =
+  typeof LitterBridgeRealtimeSessionCloseRequestSchema.Type;
+export type LitterBridgeRealtimeSessionStatus = typeof LitterBridgeRealtimeSessionStatusSchema.Type;
+export type LitterBridgeRealtimeMutationAck = typeof LitterBridgeRealtimeMutationAckSchema.Type;
+export type LitterBridgeRealtimeRequest = typeof LitterBridgeRealtimeRequestSchema.Type;
+export type LitterBridgeRealtimeResult = typeof LitterBridgeRealtimeResultSchema.Type;
 export type LitterBridgeControllerSnapshotRequest =
   typeof LitterBridgeControllerSnapshotRequestSchema.Type;
 export type LitterBridgeControllerAction = typeof LitterBridgeControllerActionSchema.Type;
@@ -693,8 +945,7 @@ export type LitterBridgeConflictResult = typeof LitterBridgeConflictResultSchema
 export type LitterBridgeForkResult = typeof LitterBridgeForkResultSchema.Type;
 export type LitterBridgeSessionTransferResult = typeof LitterBridgeSessionTransferResultSchema.Type;
 export type LitterBridgeAgentTurnResult = typeof LitterBridgeAgentTurnResultSchema.Type;
-export type LitterBridgeSessionCreateRequest =
-  typeof LitterBridgeSessionCreateRequestSchema.Type;
+export type LitterBridgeSessionCreateRequest = typeof LitterBridgeSessionCreateRequestSchema.Type;
 export type LitterBridgeSessionCreateAck = typeof LitterBridgeSessionCreateAckSchema.Type;
 export type LitterBridgeSessionCreateResult = typeof LitterBridgeSessionCreateResultSchema.Type;
 export type LitterBridgeRequest = typeof LitterBridgeRequestSchema.Type;


### PR DESCRIPTION
## Purpose

Start #346 with one versioned, typed realtime contract inside the existing `litter-bridge/v1` boundary. This PR is intentionally contract-only: it does not advertise or expose realtime until the broker implementation exists.

## Key changes

- add the `realtime.session` capability vocabulary and contract version 1
- define strict capability, create, signal, update, close, status, and error schemas
- bind session identity to controller, client session, capability, and authenticated device
- distinguish provider-native WebRTC from the future local STT→LLM→TTS pipeline
- add a language-neutral golden fixture for TypeScript/Rust consumers
- document version negotiation, lifecycle, idempotency, reconnect, expiry, redaction, and latency boundaries
- reject contradictory availability and provider-secret excess fields

## Verification

- `npm run check` passes end to end
- shared realtime contract suite: 12 tests pass
- frontend: lint/typecheck/tests/build/standalone package pass
- controller: standards and 90 tests pass
- agent runtime: build and 97 tests pass
- pre-commit and pre-push repository hooks pass

## Follow-up

The next PR adds the fake-provider broker lifecycle and only then advertises `realtime.session`. Alleycat and Litter consumer PRs must use the checked-in fixture/version rather than copy provider-specific payloads.

Part of #346.