### PR TITLE
test(frontend): keep provider acceptance offline

### DIFF
--- a/frontend/e2e/provider-hub.config.ts
+++ b/frontend/e2e/provider-hub.config.ts
@@ -56,6 +56,7 @@ export default defineConfig({
         `LOCAL_STUDIO_DATA_DIR=${dataDir}`,
         `LOCAL_STUDIO_E2E_PROVIDERS=${providersModule}`,
         `LOCAL_STUDIO_E2E_FAKE_CLOUD=http://127.0.0.1:${cloudPort}`,
+        "PI_OFFLINE=1",
         `node ${projectScript} start`,
       ].join(" "),
       url: `${baseURL}/api/desktop-health`,


### PR DESCRIPTION
## Summary
- run provider browser acceptance with pi network refresh disabled
- keep the hermetic fake provider pipeline independent of external catalog latency

## Validation
- `npm --prefix frontend run test:e2e:providers`
- `npm run check`