### PR TITLE
fix(desktop): preserve packaged Pi provider data

### DIFF
--- a/frontend/desktop/electron-builder.yml
+++ b/frontend/desktop/electron-builder.yml
@@ -62,7 +62,8 @@ extraResources:
     to: app/frontend/.next/standalone
     filter:
       - "**/*"
-      - "!**/data/**"
+      - "!data/**"
+      - "!frontend/data/**"
       - "!**/dist-desktop/**"
       - "!**/*.log"
   - from: .next/static

--- a/frontend/desktop/project.mjs
+++ b/frontend/desktop/project.mjs
@@ -84,6 +84,7 @@ var init_assert_standalone_build = __esm(() => {
     "node_modules/@earendil-works/pi-coding-agent/package.json",
     "node_modules/@earendil-works/pi-coding-agent/dist/index.js",
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/package.json",
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/providers/data/amazon-bedrock.json",
     "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox/build/value/shared/union_priority_sort.mjs"
   ];
   if (!candidates.some((candidate) => existsSync2(candidate)))
@@ -2184,7 +2185,8 @@ async function afterPack(context) {
   `));
   let standaloneRoot = path.dirname(standaloneServer), missingRuntimeFile = [
     path.join(standaloneRoot, "node_modules", "@earendil-works", "pi-coding-agent", "dist", "index.js"),
-    path.join(standaloneRoot, "node_modules", "@earendil-works", "pi-coding-agent", "node_modules", "@earendil-works", "pi-ai", "package.json")
+    path.join(standaloneRoot, "node_modules", "@earendil-works", "pi-coding-agent", "node_modules", "@earendil-works", "pi-ai", "package.json"),
+    path.join(standaloneRoot, "node_modules", "@earendil-works", "pi-coding-agent", "node_modules", "@earendil-works", "pi-ai", "dist", "providers", "data", "amazon-bedrock.json")
   ].find((file) => !existsSync(file));
   if (missingRuntimeFile)
     throw Error(`Packaged app is missing a Pi runtime dependency: ${missingRuntimeFile}`);


### PR DESCRIPTION
## Purpose

Prevent the packaged Local Studio Pi runtime from exiting on startup because its provider metadata was removed by the desktop resource filter.

## Changes

- narrow the standalone data exclusions to Local Studio project data only
- require a representative Pi provider data file during standalone and packaged-app validation

## Verification

- `npm run check`: frontend 123, controller 90, agent runtime 97; all passed
- `npm run test:integration`: 97 passed
- `npm --prefix frontend run desktop:pack`
- `npm --prefix frontend run desktop:smoke`
- deep code-sign verification
- packaged Pi 0.83.0 RPC `get_state`
- Litter phone-equivalent Local Studio E2E: 20 passed, 0 failed
  - start, streaming, reasoning, tools/filesystem
  - reconnect, two-way session visibility, compaction, and hydration
