### PR TITLE
[Bug] Unify the visible browser pane and agent browser tools

### DIFF
--- a/frontend/desktop/logic/security.ts
+++ b/frontend/desktop/logic/security.ts
@@ -90,35 +90,6 @@ export function hardenWebContents(window: electron.BrowserWindow, appOrigin: str
   });
 }
 
-export function registerNavigationPolicy(appOrigin: string): void {
-  electron.app.on("web-contents-created", (_, contents: electron.WebContents) => {
-    contents.on("will-attach-webview", (_event, webPreferences, _params) => {
-      delete webPreferences.preload;
-      webPreferences.nodeIntegration = false;
-      webPreferences.contextIsolation = true;
-      webPreferences.sandbox = true;
-    });
-
-    contents.on("will-navigate", (event) => {
-      // Guest WebContents (the embedded browser webview plus cross-origin
-      // iframes / OOPIFs) must be able to perform their own navigations.
-      // Keep the app shell origin-locked, but do not turn the Computer browser
-      // into a single-load preview.
-      if (
-        contents.getType() === "webview" ||
-        electron.BrowserWindow.fromWebContents(contents) == null
-      ) {
-        return;
-      }
-      const targetUrl = event.url;
-      const targetOrigin = safeOrigin(targetUrl);
-      if (!targetOrigin || targetOrigin !== appOrigin) {
-        event.preventDefault();
-      }
-    });
-  });
-}
-
 function safeOrigin(input: string | undefined): string | null {
   if (!input) return null;
   try {

--- a/frontend/desktop/main.ts
+++ b/frontend/desktop/main.ts
@@ -16,7 +16,6 @@ import { writeJsonAtomic } from "./helpers/fs-json";
 import { log } from "./helpers/logger";
 import { isHttpUrl } from "./helpers/url";
 import { createMainWindow } from "./logic/window-manager";
-import { registerNavigationPolicy } from "./logic/security";
 import { startFrontendServer, stopFrontendServer, type ServerHandle } from "./logic/app-server";
 import {
   resolveFrontendRestartUrl,
@@ -87,7 +86,6 @@ async function processMemorySummary(): Promise<string> {
 async function bootstrap(): Promise<void> {
   if (!frontendServer) {
     frontendServer = await startFrontendServer({ onExit: handleFrontendServerExit });
-    registerNavigationPolicy(new URL(frontendServer.runtime.url).origin);
     startFrontendHealthMonitor();
   }
   if (!mainWindow) {

--- a/frontend/src/features/agent/tools/browser-url.ts
+++ b/frontend/src/features/agent/tools/browser-url.ts
@@ -1,51 +1,9 @@
-// Browser URL normalization for the embedded browser tool. Handles file://,
-// relative paths under the project cwd, http(s), localhost, and a search-engine
-// fallback for free-text input. Keep the fallback away from Google because the
-// embedded WebKit view can get trapped on Google bot-protection refresh loops.
-
-import { sanitizeLocalFileUrl } from "@/features/agent/sanitize-embedded-browser-url";
 import { DEFAULT_BROWSER_URL } from "@/features/agent/tools/persistence";
 
-function encodeFilePath(pathValue: string): string {
-  const normalized = pathValue.replace(/\\/g, "/");
-  const withLeadingSlash = normalized.startsWith("/") ? normalized : `/${normalized}`;
-  return `file://${withLeadingSlash.split("/").map(encodeURIComponent).join("/")}`;
-}
-
-function resolveRelativeFilePath(cwd: string, value: string): string {
-  const segments = `${cwd.replace(/\/+$/, "")}/${value}`.split("/");
-  const resolved: string[] = [];
-  for (const segment of segments) {
-    if (!segment || segment === ".") continue;
-    if (segment === "..") {
-      resolved.pop();
-      continue;
-    }
-    resolved.push(segment);
-  }
-  return `/${resolved.join("/")}`;
-}
-
-function expandHomeFilePath(cwd: string, value: string): string | null {
-  const homeMatch = cwd.match(/^(\/Users\/[^/]+|\/home\/[^/]+)(?:\/|$)/);
-  if (!homeMatch) return null;
-  return `${homeMatch[1]}${value.slice(1)}`;
-}
-
-export function normalizeBrowserInput(raw: string, cwd: string): string {
+export function normalizeBrowserInput(raw: string): string {
   const value = raw.trim();
   if (!value) return DEFAULT_BROWSER_URL;
-  if (/^file:\/\//i.test(value)) {
-    return sanitizeLocalFileUrl(value) ?? "";
-  }
-  if (value.startsWith("~/") && cwd) {
-    const expanded = expandHomeFilePath(cwd, value);
-    if (expanded) return encodeFilePath(expanded);
-  }
-  if (value.startsWith("/")) return encodeFilePath(value);
-  if ((value.startsWith("./") || value.startsWith("../")) && cwd) {
-    return encodeFilePath(resolveRelativeFilePath(cwd, value));
-  }
+  if (/^(?:file:\/\/|~\/|\.{1,2}\/|\/|[a-z]:[\\/])/i.test(value)) return "";
   if (/^https?:\/\//i.test(value)) return value;
   if (/^(localhost|127\.0\.0\.1|\[::1\])(:\d+)?([/?#].*)?$/i.test(value)) {
     return `http://${value}`;
@@ -56,8 +14,6 @@ export function normalizeBrowserInput(raw: string, cwd: string): string {
   if (/^[\w-]+(\.[\w-]+)+([/:?#].*)?$/.test(value)) {
     return `https://${value}`;
   }
-  if (value.includes("/") && cwd) {
-    return encodeFilePath(resolveRelativeFilePath(cwd, value));
-  }
+  if (value.includes("/") || value.includes("\\")) return "";
   return `https://duckduckgo.com/?q=${encodeURIComponent(value)}`;
 }

--- a/frontend/src/features/agent/ui/agent-browser-convergence.test.ts
+++ b/frontend/src/features/agent/ui/agent-browser-convergence.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { normalizeBrowserInput } from "@/features/agent/tools/browser-url";
+import { createBrowserHostCoordinator } from "@/features/agent/ui/agent-browser-effects";
+import { resolveWorkspaceFileOpenTarget } from "@/features/agent/ui/filesystem-panel-effects";
+
+const A = "https://page.test/a";
+const B = "https://page.test/b";
+const ok = { status: 200, body: { ok: true } };
+
+test("mutations serialize, settle fresh frames, and preserve fallback state", async () => {
+  const calls: string[] = [];
+  const requests: PromiseWithResolvers<{ status: number; body: unknown }>[] = [];
+  const transport = async (_path: string, body?: unknown) => {
+    calls.push(String((body as { url?: string } | undefined)?.url ?? ""));
+    const request = Promise.withResolvers<{ status: number; body: unknown }>();
+    requests.push(request);
+    return request.promise;
+  };
+  const host = createBrowserHostCoordinator(transport);
+  const navigateA = host.mutate("navigate", { url: A });
+  const navigateB = host.mutate("navigate", { url: B });
+  await delay(0);
+  assert.deepEqual(calls, [A]);
+  assert.equal(host.locationIsAuthoritative(host.beginFrame()), false);
+  requests[0]?.resolve(ok);
+  await navigateA;
+  await delay(0);
+  assert.deepEqual(calls, [A, B]);
+  const staleFrame = host.beginFrame();
+  requests[1]?.resolve(ok);
+  await navigateB;
+  assert.equal(host.locationIsAuthoritative(staleFrame), false);
+  assert.equal(host.locationIsAuthoritative(host.beginFrame()), true);
+  const fallbackData = { url: B, readingMode: true };
+  const fallback = createBrowserHostCoordinator(async () => ({
+    status: 200,
+    body: { ok: true, data: { ...fallbackData, title: "Reader" } },
+  }));
+  assert.deepEqual(await fallback.mutate("navigate", { url: A }), { error: null, ...fallbackData });
+});
+
+test("browser input never turns project paths into browser URLs", () => {
+  for (const value of "file:///tmp/secret.txt|/tmp/secret.txt|./src/index.ts|../secret.txt|~/secret.txt|C:\\secret.txt|src/index.ts".split(
+    "|",
+  )) {
+    assert.equal(normalizeBrowserInput(value), "");
+  }
+  assert.equal(normalizeBrowserInput("example.com"), "https://example.com");
+  assert.equal(normalizeBrowserInput("localhost:3000"), "http://localhost:3000");
+  assert.equal(
+    normalizeBrowserInput("shared browser"),
+    "https://duckduckgo.com/?q=shared%20browser",
+  );
+  const cwd = "/Users/me/project";
+  assert.deepEqual(resolveWorkspaceFileOpenTarget(`${cwd}/src/app.ts`, cwd), {
+    root: cwd,
+    rel: "src/app.ts",
+    kind: "file",
+  });
+  assert.equal(resolveWorkspaceFileOpenTarget("/Users/me/secret.txt", cwd), null);
+  assert.equal(resolveWorkspaceFileOpenTarget("/Users/me/project2/secret.txt", cwd), null);
+  assert.equal(resolveWorkspaceFileOpenTarget("src/../../secret.txt", cwd), null);
+  assert.equal(
+    resolveWorkspaceFileOpenTarget("file:///Users/me/project/src/%2E%2E/%2E%2E/secret.txt", cwd),
+    null,
+  );
+  assert.equal(resolveWorkspaceFileOpenTarget("/tmp/secret.txt", null), null);
+});
+
+test("frontend source contains no desktop guest browser path", () => {
+  const root = fileURLToPath(new URL("../../../..", import.meta.url));
+  const source =
+    "src/features/agent/ui/agent-browser.tsx src/features/agent/ui/agent-browser-effects.ts src/features/agent/ui/agent-browser-panel.tsx src/features/agent/ui/computer-tab-panel.tsx desktop/logic/security.ts desktop/logic/window-manager.ts"
+      .split(" ")
+      .map((path) => readFileSync(join(root, path), "utf8"))
+      .join("\n");
+  const guest = "web" + "view";
+  const forbidden = [`<${guest}`, `${guest}Tag: true`, `will-attach-${guest}`, "is" + "Electron"];
+  assert.equal(
+    forbidden.some((value) => source.includes(value)),
+    false,
+  );
+});

--- a/frontend/src/features/agent/ui/agent-browser-effects.ts
+++ b/frontend/src/features/agent/ui/agent-browser-effects.ts
@@ -1,3 +1,4 @@
+import { Effect, Schema, Semaphore } from "effect";
 import { useMountSubscription } from "@/hooks/use-mount-subscription";
 
 export type LocalhostSite = {
@@ -48,6 +49,13 @@ export function useLocalhostSitesEffects({
   }, [enabled, onErrorChange, onLoadingChange, onSitesChange]);
 }
 
+export type BrowserPaneState = {
+  url: string;
+  title: string;
+  canGoBack: boolean;
+  canGoForward: boolean;
+};
+
 type UseAgentBrowserEffectsParams = {
   url: string;
   readingMode: boolean;
@@ -68,6 +76,87 @@ export function useAgentBrowserEffects({
   }, [enabled, fetchReadable, readingMode, url]);
 }
 
+type BrowserHostResponse = { status: number; body: unknown };
+export type BrowserHostTransport = (path: string, body?: unknown) => Promise<BrowserHostResponse>;
+export type BrowserMutationResult = { error: string | null; url?: string; readingMode?: boolean };
+
+const BrowserActionResponseSchema = Schema.Struct({
+  ok: Schema.Boolean,
+  error: Schema.optional(Schema.String),
+  data: Schema.optional(
+    Schema.Struct({
+      url: Schema.optional(Schema.String),
+      readingMode: Schema.optional(Schema.Boolean),
+    }),
+  ),
+});
+
+const requestBrowserHost: BrowserHostTransport = async (path, body) => {
+  const response = await fetch(`/api/agent/browser/${path}`, {
+    method: "POST",
+    ...(body === undefined
+      ? {}
+      : { headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) }),
+  });
+  return { status: response.status, body: await response.json() };
+};
+
+const messageFor = (error: unknown): string =>
+  error instanceof Error ? error.message : "Browser command failed";
+
+export function createBrowserHostCoordinator(transport: BrowserHostTransport) {
+  let pollSequence = 0;
+  let mutationSequence = 0;
+  let settledMutation = 0;
+  let locationBarrier = 0;
+  const lock = Semaphore.makeUnsafe(1);
+
+  const mutate = (path: string, body?: unknown): Promise<BrowserMutationResult> => {
+    const sequence = (mutationSequence += 1);
+    const program = Effect.gen(function* () {
+      const response = yield* Effect.tryPromise({
+        try: () => transport(path, body),
+        catch: (error) => error,
+      });
+      const payload = yield* Schema.decodeUnknownEffect(BrowserActionResponseSchema)(response.body);
+      if (response.status < 200 || response.status >= 300 || !payload.ok) {
+        return yield* Effect.fail(
+          new Error(payload.error ?? `Browser command failed with HTTP ${response.status}`),
+        );
+      }
+      return { error: null, ...payload.data };
+    }).pipe(
+      Effect.match({
+        onFailure: (error) => ({ error: messageFor(error) }),
+        onSuccess: (result) => result,
+      }),
+      Effect.ensuring(
+        Effect.sync(() => {
+          if (sequence !== mutationSequence) return;
+          settledMutation = sequence;
+          locationBarrier = pollSequence;
+        }),
+      ),
+    );
+    return Effect.runPromise(lock.withPermit(program));
+  };
+
+  return {
+    beginFrame: () => (pollSequence += 1),
+    locationIsAuthoritative: (sequence: number) =>
+      settledMutation === mutationSequence && sequence > locationBarrier,
+    mutate,
+  };
+}
+
+const browserHostCoordinator = createBrowserHostCoordinator(requestBrowserHost);
+
+export const beginBrowserFrame = (): number => browserHostCoordinator.beginFrame();
+export const browserFrameLocationIsAuthoritative = (sequence: number): boolean =>
+  browserHostCoordinator.locationIsAuthoritative(sequence);
+export const mutateBrowserHost = (path: string, body?: unknown): Promise<BrowserMutationResult> =>
+  browserHostCoordinator.mutate(path, body);
+
 const LIVE_STATE_POLL_MS = 2_000;
 
 export function useBrowserLiveStateSync({
@@ -81,11 +170,20 @@ export function useBrowserLiveStateSync({
     if (!enabled) return;
     let cancelled = false;
     const poll = async () => {
+      const sequence = beginBrowserFrame();
       try {
         const response = await fetch("/api/agent/browser/state", { cache: "no-store" });
+        if (!response.ok) return;
         const payload = (await response.json()) as { ok?: boolean; data?: { url?: string } };
         const liveUrl = payload.ok ? (payload.data?.url ?? "") : "";
-        if (!cancelled && liveUrl && liveUrl !== "about:blank") onLiveUrl(liveUrl);
+        if (
+          !cancelled &&
+          liveUrl &&
+          liveUrl !== "about:blank" &&
+          browserFrameLocationIsAuthoritative(sequence)
+        ) {
+          onLiveUrl(liveUrl);
+        }
       } catch {
         return;
       }

--- a/frontend/src/features/agent/ui/agent-browser-panel.tsx
+++ b/frontend/src/features/agent/ui/agent-browser-panel.tsx
@@ -25,10 +25,7 @@ import {
 } from "@/features/agent/ui/use-persistent-terminal-owners";
 import { normalizeBrowserInput } from "@/features/agent/tools/browser-url";
 import { MAX_COMPUTER_WIDTH, MIN_COMPUTER_WIDTH } from "@/features/agent/tools/persistence";
-import {
-  sanitizeBrowserPaneUrl,
-  sanitizeLocalFileUrl,
-} from "@/features/agent/sanitize-embedded-browser-url";
+import { sanitizeBrowserPaneUrl } from "@/features/agent/sanitize-embedded-browser-url";
 import { useTools } from "@/features/agent/tools/context";
 import type { ComputerTab } from "@/features/agent/tools/types";
 import type { GitSummary, Project } from "@/features/agent/projects/types";
@@ -42,6 +39,7 @@ import {
 } from "@/features/agent/terminal-owners";
 import { ComputerTabPanel, type SideChatTabsUpdater } from "@/features/agent/ui/computer-tab-panel";
 import { PersistentTerminals } from "@/features/agent/ui/persistent-terminals";
+import { mutateBrowserHost } from "@/features/agent/ui/agent-browser-effects";
 import type { WorkspaceHandles } from "@/features/agent/ui/use-workspace";
 
 type AgentBrowserPanelHandles = Pick<
@@ -97,10 +95,6 @@ function closePersistedTerminalOwners(owners: readonly TerminalOwner[]) {
 function closePersistedTerminalOwner(ownerKey: string) {
   const owner = removePersistentTerminalOwner(ownerKey);
   if (owner) void terminalBridge()?.closeOwner?.(owner.mountKey);
-}
-
-function acceptedBrowserUrl(url: string): string | null {
-  return /^file:\/\//i.test(url) ? sanitizeLocalFileUrl(url) : sanitizeBrowserPaneUrl(url);
 }
 
 export function AgentBrowserPanel({
@@ -166,18 +160,13 @@ export function AgentBrowserPanel({
     },
     [selectTerminalOwner, visibleTerminalState.owners],
   );
-  const navigateBrowser = (value: string) => {
-    const next = normalizeBrowserInput(value, focusedSession?.cwd ?? activeProject?.path ?? "");
-    if (!next) return;
-    const accepted = acceptedBrowserUrl(next);
-    if (!accepted) return;
-    tools.setBrowserUrl(accepted, accepted);
-    if (/^file:\/\//i.test(accepted)) return;
-    void fetch("/api/agent/browser/navigate", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ url: accepted }),
-    }).catch(() => undefined);
+  const navigateBrowser = async (value: string) => {
+    const next = normalizeBrowserInput(value);
+    if (!next) return { error: "Project files open in Files, not Browser." };
+    const accepted = sanitizeBrowserPaneUrl(next);
+    if (!accepted) return { error: "Browser navigation supports HTTP(S) URLs only." };
+    tools.setBrowserInput(accepted);
+    return mutateBrowserHost("navigate", { url: accepted });
   };
   const openSideChat = useCallback(() => {
     handles.updateDetachedSession(sideChatSeed, (current) =>

--- a/frontend/src/features/agent/ui/agent-browser-screencast.tsx
+++ b/frontend/src/features/agent/ui/agent-browser-screencast.tsx
@@ -21,14 +21,12 @@ import {
   type PointerEvent as ReactPointerEvent,
   type WheelEvent as ReactWheelEvent,
 } from "react";
+import {
+  beginBrowserFrame,
+  browserFrameLocationIsAuthoritative,
+  type BrowserPaneState,
+} from "@/features/agent/ui/agent-browser-effects";
 import { useMountSubscription } from "@/hooks/use-mount-subscription";
-
-export type BrowserPaneState = {
-  url: string;
-  title: string;
-  canGoBack: boolean;
-  canGoForward: boolean;
-};
 
 type FramePayload = {
   ok: boolean;
@@ -37,9 +35,7 @@ type FramePayload = {
 };
 
 type Props = {
-  /** Desired URL from the address bar; navigated server-side when it diverges. */
-  url: string;
-  onState: (state: BrowserPaneState) => void;
+  onState: (state: BrowserPaneState, locationIsAuthoritative: boolean) => void;
   /** Called once when the host reports no Chromium — the pane should fall back to reading mode. */
   onUnavailable: (error: string) => void;
   /** Frame polling pauses entirely while the surface is hidden. */
@@ -59,11 +55,9 @@ function postBrowser(path: string, body: unknown): void {
   }).catch(() => undefined);
 }
 
-export function ScreencastSurface({ url, onState, onUnavailable, visible = true }: Props) {
+export function ScreencastSurface({ onState, onUnavailable, visible = true }: Props) {
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const [frameSrc, setFrameSrc] = useState<string | null>(null);
-  const [navError, setNavError] = useState<string | null>(null);
-  const serverUrlRef = useRef<string>("");
   const viewportRef = useRef({ width: 1280, height: 800 });
   const lastMoveAtRef = useRef(0);
   const onStateRef = useRef(onState);
@@ -93,22 +87,37 @@ export function ScreencastSurface({ url, onState, onUnavailable, visible = true 
         return;
       }
       try {
+        const frameSequence = beginBrowserFrame();
         const response = await fetch("/api/agent/browser/frame", { cache: "no-store" });
         if (response.status === 503) {
           const payload = (await response.json().catch(() => null)) as FramePayload | null;
+          if (!disposed && payload?.data) {
+            onStateRef.current(
+              {
+                url: payload.data.url,
+                title: payload.data.title,
+                canGoBack: false,
+                canGoForward: false,
+              },
+              browserFrameLocationIsAuthoritative(frameSequence),
+            );
+          }
           onUnavailableRef.current(payload?.error || "Browser unavailable");
-          return; // stop polling; pane switches to reading mode
+          if (!disposed) timer = effectTimeout(() => void tick(), 1_000);
+          return;
         }
         const payload = (await response.json()) as FramePayload;
         if (!disposed && payload.ok && payload.data) {
           if (payload.data.frame) setFrameSrc(`data:image/jpeg;base64,${payload.data.frame}`);
-          serverUrlRef.current = payload.data.url;
-          onStateRef.current({
-            url: payload.data.url,
-            title: payload.data.title,
-            canGoBack: payload.data.canGoBack,
-            canGoForward: payload.data.canGoForward,
-          });
+          onStateRef.current(
+            {
+              url: payload.data.url,
+              title: payload.data.title,
+              canGoBack: payload.data.canGoBack,
+              canGoForward: payload.data.canGoForward,
+            },
+            browserFrameLocationIsAuthoritative(frameSequence),
+          );
         }
       } catch {
         // transient — keep polling
@@ -122,32 +131,6 @@ export function ScreencastSurface({ url, onState, onUnavailable, visible = true 
       if (timer) timer.cancel();
     };
   }, [visible]);
-
-  // ── Address-bar navigation: navigate server-side when the desired URL
-  // diverges from what the host last reported ────────────────────────────
-  useMountSubscription(() => {
-    const target = url.trim();
-    if (!target || target === serverUrlRef.current) return;
-    let cancelled = false;
-    void fetch("/api/agent/browser/navigate", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ url: target }),
-    })
-      .then(async (response) => {
-        const payload = (await response.json()) as { ok: boolean; error?: string };
-        if (cancelled) return;
-        setNavError(payload.ok ? null : (payload.error ?? "Navigation failed"));
-      })
-      .catch((error) => {
-        if (!cancelled) {
-          setNavError(error instanceof Error ? error.message : "Navigation failed");
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [url]);
 
   // ── Viewport sync: match the headless viewport to the pane size ────────
   useMountSubscription(() => {
@@ -262,11 +245,6 @@ export function ScreencastSurface({ url, onState, onUnavailable, visible = true 
           Connecting to browser…
         </div>
       )}
-      {navError ? (
-        <div className="absolute left-2 top-2 max-w-[80%] truncate rounded-md border border-(--err)/40 bg-(--bg)/95 px-2 py-1 text-xs text-(--err)">
-          {navError}
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/frontend/src/features/agent/ui/agent-browser.tsx
+++ b/frontend/src/features/agent/ui/agent-browser.tsx
@@ -3,14 +3,14 @@
 import { useCallback, useState, type FormEvent } from "react";
 import { ArrowLeftIcon, ArrowRightIcon, CloseIcon, ReloadIcon } from "@/ui/icons";
 import { DEFAULT_BROWSER_URL } from "@/features/agent/tools/persistence";
+import { ScreencastSurface } from "@/features/agent/ui/agent-browser-screencast";
 import {
-  ScreencastSurface,
-  type BrowserPaneState,
-} from "@/features/agent/ui/agent-browser-screencast";
-import {
+  mutateBrowserHost,
   useAgentBrowserEffects,
   useBrowserLiveStateSync,
   useLocalhostSitesEffects,
+  type BrowserMutationResult,
+  type BrowserPaneState,
   type LocalhostSite,
 } from "@/features/agent/ui/agent-browser-effects";
 import { LocalhostStartPage } from "@/features/agent/ui/agent-browser-start-page";
@@ -20,12 +20,15 @@ type Props = {
   url: string;
   inputValue: string;
   onInputChange: (value: string) => void;
-  onNavigate: (value: string) => void;
+  onNavigate: (value: string) => Promise<BrowserMutationResult>;
   onLocationChange: (value: string) => void;
   onClose: () => void;
   /** Screencast polling pauses while the hosting panel is hidden. */
   visible?: boolean;
 };
+
+const browserAddressValue = (showStartPage: boolean, inputValue: string) =>
+  showStartPage && inputValue === DEFAULT_BROWSER_URL ? "" : inputValue;
 
 export function AgentBrowser({
   url,
@@ -37,6 +40,7 @@ export function AgentBrowser({
   visible = true,
 }: Props) {
   const [readingMode, setReadingMode] = useState(false);
+  const [navigationError, setNavigationError] = useState<string | null>(null);
   const [liveUnavailable, setLiveUnavailable] = useState<string | null>(null);
   const [navState, setNavState] = useState<BrowserPaneState | null>(null);
   const [readable, setReadable] = useState<ReadablePage | null>(null);
@@ -49,7 +53,7 @@ export function AgentBrowser({
   const [localSitesLoading, setLocalSitesLoading] = useState(false);
   const [localSitesError, setLocalSitesError] = useState<string | null>(null);
   const showStartPage = !hasOpenedUrl && url === DEFAULT_BROWSER_URL;
-  const addressValue = showStartPage && inputValue === DEFAULT_BROWSER_URL ? "" : inputValue;
+  const addressValue = browserAddressValue(showStartPage, inputValue);
 
   const fetchReadable = useCallback(async (target: string) => {
     setReadingLoading(true);
@@ -94,9 +98,9 @@ export function AgentBrowser({
     enabled: showStartPage && visible,
     onLiveUrl: adoptLiveUrl,
   });
-
   const postLiveVerb = useCallback((verb: "back" | "forward" | "reload") => {
-    void fetch(`/api/agent/browser/${verb}`, { method: "POST" }).catch(() => undefined);
+    setNavigationError(null);
+    void mutateBrowserHost(verb).then((result) => setNavigationError(result.error));
   }, []);
   const handleReload = () => {
     if (showStartPage) {
@@ -124,8 +128,14 @@ export function AgentBrowser({
   const navigateFromBrowser = (value: string) => {
     const clean = value.trim();
     if (!clean) return;
-    setHasOpenedUrl(true);
-    onNavigate(clean);
+    setNavigationError(null);
+    void onNavigate(clean).then((result) => {
+      setNavigationError(result.error);
+      if (result.error) return;
+      setHasOpenedUrl(true);
+      if (result.readingMode) setReadingMode(true);
+      if (result.readingMode && result.url) onLocationChange(result.url);
+    });
   };
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
@@ -215,6 +225,11 @@ export function AgentBrowser({
           enable the live view and screenshots; reading mode is active meanwhile.
         </div>
       ) : null}
+      {navigationError ? (
+        <div className="shrink-0 border-b border-(--err)/40 bg-(--err)/10 px-3 py-2 text-[length:var(--fs-xs)] text-(--err)">
+          {navigationError}
+        </div>
+      ) : null}
 
       <div className="min-h-0 flex-1 bg-(--bg)">
         {showStartPage ? (
@@ -232,15 +247,18 @@ export function AgentBrowser({
             page={readable}
             error={readingError}
             loading={readingLoading}
-            onLinkClick={onNavigate}
+            onLinkClick={navigateFromBrowser}
           />
         ) : (
           <ScreencastSurface
-            url={url}
             visible={visible}
-            onState={(state) => {
+            onState={(state, locationIsAuthoritative) => {
+              setLiveUnavailable(null);
               setNavState(state);
-              if (state.url && state.url !== url) onLocationChange(state.url);
+              if (!locationIsAuthoritative) return;
+              const observedUrl = /^https?:\/\//i.test(state.url) ? state.url : "";
+              if (observedUrl && observedUrl !== DEFAULT_BROWSER_URL) setHasOpenedUrl(true);
+              if (observedUrl && observedUrl !== url) onLocationChange(observedUrl);
             }}
             onUnavailable={(error) => {
               setLiveUnavailable(error);

--- a/frontend/src/features/agent/ui/assistant-markdown.tsx
+++ b/frontend/src/features/agent/ui/assistant-markdown.tsx
@@ -5,6 +5,7 @@ import { useCopiedFlag } from "@/features/agent/ui/use-copied-flag";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { normalizeBrowserInput } from "@/features/agent/tools/browser-url";
+import { mutateBrowserHost } from "@/features/agent/ui/agent-browser-effects";
 import { useToolsActions } from "@/features/agent/tools/context";
 import type { ComputerTab } from "@/features/agent/tools/types";
 import { writeClipboardText } from "@/lib/clipboard";
@@ -163,6 +164,7 @@ function normalizeLooseMarkdownEmphasis(text: string): string {
 type ToolHandlers = {
   setComputerOpen: (open: boolean) => void;
   setComputerTab: (tab: ComputerTab) => void;
+  setBrowserInput: (input: string) => void;
   setBrowserUrl: (url: string, input?: string) => void;
   requestFileOpen: (path: string) => void;
 };
@@ -232,12 +234,17 @@ function buildComponentsWithAppLinks(tools: ToolHandlers): Components {
           rel="noreferrer noopener"
           onClick={(event) => {
             if (!href) return;
-            const next = normalizeBrowserInput(href, "");
+            const next = normalizeBrowserInput(href);
             if (!next) return;
             event.preventDefault();
             tools.setComputerOpen(true);
             tools.setComputerTab("browser");
-            tools.setBrowserUrl(next, next);
+            tools.setBrowserInput(next);
+            void mutateBrowserHost("navigate", { url: next }).then((result) => {
+              if (!result.error && result.readingMode && result.url) {
+                tools.setBrowserUrl(result.url, result.url);
+              }
+            });
           }}
           title={href}
         >
@@ -286,10 +293,17 @@ function AssistantMarkdownInner({ text }: { text: string }) {
       buildComponentsWithAppLinks({
         setComputerOpen: tools.setComputerOpen,
         setComputerTab: tools.setComputerTab,
+        setBrowserInput: tools.setBrowserInput,
         setBrowserUrl: tools.setBrowserUrl,
         requestFileOpen: tools.requestFileOpen,
       }),
-    [tools.setComputerOpen, tools.setComputerTab, tools.setBrowserUrl, tools.requestFileOpen],
+    [
+      tools.requestFileOpen,
+      tools.setBrowserInput,
+      tools.setBrowserUrl,
+      tools.setComputerOpen,
+      tools.setComputerTab,
+    ],
   );
   return (
     <div className="chat-markdown min-w-0 max-w-full overflow-x-hidden [overflow-wrap:anywhere]">

--- a/frontend/src/features/agent/ui/assistant-markdown.tsx
+++ b/frontend/src/features/agent/ui/assistant-markdown.tsx
@@ -169,6 +169,13 @@ type ToolHandlers = {
   requestFileOpen: (path: string) => void;
 };
 
+async function navigateMarkdownBrowser(tools: ToolHandlers, next: string): Promise<void> {
+  const result = await mutateBrowserHost("navigate", { url: next });
+  if (!result.error && result.readingMode && result.url) {
+    tools.setBrowserUrl(result.url, result.url);
+  }
+}
+
 function buildComponentsWithAppLinks(tools: ToolHandlers): Components {
   const stripPath = (raw: string) =>
     raw
@@ -240,11 +247,7 @@ function buildComponentsWithAppLinks(tools: ToolHandlers): Components {
             tools.setComputerOpen(true);
             tools.setComputerTab("browser");
             tools.setBrowserInput(next);
-            void mutateBrowserHost("navigate", { url: next }).then((result) => {
-              if (!result.error && result.readingMode && result.url) {
-                tools.setBrowserUrl(result.url, result.url);
-              }
-            });
+            void navigateMarkdownBrowser(tools, next);
           }}
           title={href}
         >

--- a/frontend/src/features/agent/ui/computer-tab-panel.tsx
+++ b/frontend/src/features/agent/ui/computer-tab-panel.tsx
@@ -15,6 +15,7 @@ import type { Session, UpdateSession } from "@/features/agent/runtime/types";
 import type { AgentModel } from "@/features/agent/workspace/types";
 import { AgentModelPicker } from "@/features/agent/ui/agent-model-picker";
 import { ChatPane } from "@/features/agent/ui/chat-pane";
+import type { BrowserMutationResult } from "@/features/agent/ui/agent-browser-effects";
 
 const LazyAgentBrowser = lazy(() =>
   import("@/features/agent/ui/agent-browser").then(({ AgentBrowser }) => ({
@@ -49,7 +50,7 @@ type ComputerTabPanelProps = {
   modelsLoading: boolean;
   onCloseSideChat: () => void;
   onCompactSession?: () => Promise<void>;
-  onNavigateBrowser: (value: string) => void;
+  onNavigateBrowser: (value: string) => Promise<BrowserMutationResult>;
   onOpenSideChat: () => void;
   onOpenTerminal: () => void;
   onRenameSideChat: (tabId: string, title: string) => void;

--- a/frontend/src/features/agent/ui/filesystem-panel-effects.test.ts
+++ b/frontend/src/features/agent/ui/filesystem-panel-effects.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
-import { resolveFileOpenTarget } from "./filesystem-panel-effects";
+import { resolveFileOpenTarget, resolveWorkspaceFileOpenTarget } from "./filesystem-panel-effects";
 
 const CWD = "/Users/me/projects/app";
 
@@ -80,5 +80,21 @@ describe("resolveFileOpenTarget", () => {
     assert.equal(resolveFileOpenTarget("../outside.ts", CWD), null);
     assert.equal(resolveFileOpenTarget("src/in\0dex.ts", CWD), null);
     assert.equal(resolveFileOpenTarget("src/index.ts", null), null);
+  });
+});
+
+describe("resolveWorkspaceFileOpenTarget", () => {
+  test("normalizes contained paths and rejects lexical escapes", () => {
+    assert.deepEqual(resolveWorkspaceFileOpenTarget("src/lib/../index.ts", CWD), {
+      root: CWD,
+      rel: "src/index.ts",
+      kind: "file",
+    });
+    assert.equal(resolveWorkspaceFileOpenTarget("src/../../secret.ts", CWD), null);
+    assert.equal(resolveWorkspaceFileOpenTarget(`${CWD}2/secret.ts`, CWD), null);
+    assert.equal(
+      resolveWorkspaceFileOpenTarget(`file://${CWD}/src/%2E%2E/%2E%2E/secret.ts`, CWD),
+      null,
+    );
   });
 });

--- a/frontend/src/features/agent/ui/filesystem-panel-effects.ts
+++ b/frontend/src/features/agent/ui/filesystem-panel-effects.ts
@@ -142,8 +142,12 @@ export function useFilesystemPanelEffects({
       return;
     }
     handledFileOpenRequest.current = fileOpenRequest.id;
-    const target = resolveFileOpenTarget(fileOpenRequest.path, cwd);
-    if (!target) return;
+    const target = resolveWorkspaceFileOpenTarget(fileOpenRequest.path, cwd);
+    if (!target) {
+      setSaveError("Only files inside the active project can be opened.");
+      return;
+    }
+    setSaveError(null);
     // Returning to the session project clears the override rather than pinning
     // an identical root, so the "external root" bar stays off.
     const nextOverride = target.root === cwd ? null : target.root;
@@ -171,6 +175,7 @@ export function useFilesystemPanelEffects({
     setOpenFile,
     setRelPath,
     setRootOverride,
+    setSaveError,
   ]);
 
   useMountSubscription(() => {
@@ -282,6 +287,26 @@ export function resolveFileOpenTarget(
   const rel = clean.startsWith("./") ? clean.slice(2) : clean;
   if (!rel || rel.startsWith("../")) return null;
   return { root: projectRoot, rel, kind: isDirectory ? "directory" : "file" };
+}
+
+export function resolveWorkspaceFileOpenTarget(
+  requestPath: string,
+  cwd: string | null,
+): FileOpenTarget | null {
+  const projectRoot = cwd?.replace(/\/+$/, "") ?? null;
+  const target = resolveFileOpenTarget(requestPath, projectRoot);
+  if (!projectRoot || target?.root !== projectRoot) return null;
+  const segments: string[] = [];
+  for (const segment of target.rel.split("/")) {
+    if (!segment || segment === ".") continue;
+    if (segment === "..") {
+      if (!segments.length) return null;
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+  return { ...target, rel: segments.join("/") };
 }
 
 // Strip the decorations references arrive with (backticks, a `file://` scheme,

--- a/frontend/src/features/agent/ui/filesystem-panel.tsx
+++ b/frontend/src/features/agent/ui/filesystem-panel.tsx
@@ -328,7 +328,9 @@ export function FilesystemPanel({ cwd }: Props) {
         <div className="flex min-w-0 flex-1 flex-col">
           {!openFile ? (
             <div className="flex h-full flex-col items-center justify-center gap-3 text-[length:var(--fs-sm)] text-(--dim)">
-              <span>Select a file to view.</span>
+              <span className={saveError ? "text-(--err)" : undefined}>
+                {saveError ?? "Select a file to view."}
+              </span>
               {!fileListOpen ? (
                 <button
                   type="button"

--- a/services/agent-runtime/src/browser-host/browser-host.ts
+++ b/services/agent-runtime/src/browser-host/browser-host.ts
@@ -17,12 +17,14 @@ const capString = (value: string, maximum: number): string =>
 class BrowserHost {
   private pages = new Map<string, HostedPage>();
   private activeId: string | null = null;
+  private generation = 0;
 
   isAvailable(): boolean {
     return playwrightManager.isAvailable();
   }
 
   async page(pageId?: string): Promise<HostedPage> {
+    const generation = this.generation;
     const targetId = pageId ?? this.activeId;
     const cached = targetId ? this.pages.get(targetId) : undefined;
     if (cached && !cached.closed) {
@@ -32,12 +34,17 @@ class BrowserHost {
     if (cached) this.pages.delete(cached.id);
 
     const context = await playwrightManager.ensure();
+    this.assertGeneration(generation);
     const rawPage =
       context
         .pages()
         .find((candidate) =>
           Array.from(this.pages.values()).every((hosted) => !hosted.matches(candidate)),
         ) ?? (await context.newPage());
+    if (generation !== this.generation) {
+      await rawPage.close().catch(() => undefined);
+      this.assertGeneration(generation);
+    }
     const hosted = HostedPage.attach(rawPage);
     this.pages.set(hosted.id, hosted);
     this.activeId = hosted.id;
@@ -132,11 +139,22 @@ class BrowserHost {
     await (await this.page(pageId)).dispatchKey(args);
   }
 
+  async invalidate(): Promise<void> {
+    this.generation += 1;
+    this.pages.clear();
+    this.activeId = null;
+    await playwrightManager.invalidate();
+  }
+
   stop(): void {
     for (const page of this.pages.values()) page.close();
     this.pages.clear();
     this.activeId = null;
     playwrightManager.stop();
+  }
+
+  private assertGeneration(generation: number): void {
+    if (generation !== this.generation) throw new Error("Browser context invalidated");
   }
 }
 

--- a/services/agent-runtime/src/browser-host/browser-operation-coordinator.ts
+++ b/services/agent-runtime/src/browser-host/browser-operation-coordinator.ts
@@ -1,0 +1,184 @@
+import { Effect, Schema, Semaphore } from "effect";
+
+export type BrowserOperationKind = "frame" | "input" | "state" | "verb" | "viewport";
+export type BrowserOperationFailureReason = "aborted" | "failed" | "recovery-failed" | "timed-out";
+
+const TimeoutSchema = Schema.Int.pipe(
+  Schema.check(Schema.isGreaterThan(0), Schema.isLessThanOrEqualTo(60_000)),
+);
+
+export const BrowserOperationPolicySchema = Schema.Struct({
+  recoveryMs: TimeoutSchema,
+  timeouts: Schema.Struct({
+    frame: TimeoutSchema,
+    input: TimeoutSchema,
+    state: TimeoutSchema,
+    verb: TimeoutSchema,
+    viewport: TimeoutSchema,
+  }),
+});
+
+export type BrowserOperationPolicy = typeof BrowserOperationPolicySchema.Type;
+
+export const DefaultBrowserOperationPolicy: BrowserOperationPolicy = {
+  recoveryMs: 5_000,
+  timeouts: { frame: 5_000, input: 5_000, state: 5_000, verb: 15_000, viewport: 5_000 },
+};
+
+export class BrowserOperationError extends Error {
+  readonly name = "BrowserOperationError";
+
+  constructor(
+    readonly kind: BrowserOperationKind,
+    readonly reason: BrowserOperationFailureReason,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+  }
+}
+
+export type BrowserOperationContext = { assertActive: () => void; signal: AbortSignal };
+export type BrowserOperationRunOptions = { kind: BrowserOperationKind; signal?: AbortSignal };
+
+export type BrowserOperationCoordinatorOptions = {
+  policy?: unknown;
+  recover: (failure: BrowserOperationError) => Promise<void>;
+};
+
+const operationError = (
+  kind: BrowserOperationKind,
+  reason: BrowserOperationFailureReason,
+  cause?: unknown,
+): BrowserOperationError => {
+  const label = reason === "timed-out" ? "timed out" : reason.replace("-", " ");
+  return new BrowserOperationError(kind, reason, `Browser ${kind} operation ${label}`, { cause });
+};
+
+const normalizeError = (kind: BrowserOperationKind, error: unknown): Error =>
+  error instanceof Error ? error : operationError(kind, "failed", error);
+
+export class BrowserOperationCoordinator {
+  private readonly lock = Semaphore.makeUnsafe(1);
+  private readonly policy: BrowserOperationPolicy;
+  private generation = 0;
+  private poisoned: BrowserOperationError | null = null;
+
+  constructor(private readonly options: BrowserOperationCoordinatorOptions) {
+    this.policy = Schema.decodeUnknownSync(BrowserOperationPolicySchema)(
+      options.policy ?? DefaultBrowserOperationPolicy,
+    );
+  }
+
+  run<A>(
+    options: BrowserOperationRunOptions,
+    operation: (context: BrowserOperationContext) => Promise<A>,
+  ): Promise<A> {
+    if (options.signal?.aborted) {
+      return Promise.reject(operationError(options.kind, "aborted", options.signal.reason));
+    }
+    const generation = this.generation;
+    const deadline = Date.now() + this.policy.timeouts[options.kind];
+    const active = Effect.suspend(() => {
+      if (this.poisoned) return Effect.fail(this.poisoned);
+      if (generation !== this.generation) {
+        return Effect.fail(operationError(options.kind, "aborted"));
+      }
+      if (Date.now() >= deadline) {
+        return Effect.fail(operationError(options.kind, "timed-out"));
+      }
+      return this.operationEffect(options, operation, generation, deadline);
+    });
+    return Effect.runPromise(this.lock.withPermit(Effect.uninterruptible(active)), {
+      signal: options.signal,
+    }).catch((error: unknown) => {
+      if (this.poisoned) throw this.poisoned;
+      if (options.signal?.aborted) {
+        throw operationError(options.kind, "aborted", options.signal.reason);
+      }
+      throw error;
+    });
+  }
+
+  private operationEffect<A>(
+    options: BrowserOperationRunOptions,
+    operation: (context: BrowserOperationContext) => Promise<A>,
+    generation: number,
+    deadline: number,
+  ): Effect.Effect<A, Error> {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return Effect.fail(operationError(options.kind, "timed-out"));
+    return Effect.callback<A, Error>((resume) => {
+      const controller = new AbortController();
+      let settled = false;
+      const cleanup = (): void => {
+        clearTimeout(timeout);
+        options.signal?.removeEventListener("abort", abort);
+      };
+      const succeed = (value: A): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resume(Effect.succeed(value));
+      };
+      const fail = (error: unknown): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resume(Effect.fail(normalizeError(options.kind, error)));
+      };
+      const invalidate = (failure: BrowserOperationError): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        this.generation += 1;
+        controller.abort(failure);
+        void this.recover(failure).then((recoveryFailure) => {
+          resume(Effect.fail(recoveryFailure ?? failure));
+        });
+      };
+      const abort = (): void =>
+        invalidate(operationError(options.kind, "aborted", options.signal?.reason));
+      const timeout = setTimeout(
+        () => invalidate(operationError(options.kind, "timed-out")),
+        remaining,
+      );
+      const context: BrowserOperationContext = {
+        assertActive: () => {
+          if (settled || generation !== this.generation || controller.signal.aborted) {
+            throw operationError(options.kind, "aborted", controller.signal.reason);
+          }
+        },
+        signal: controller.signal,
+      };
+      options.signal?.addEventListener("abort", abort, { once: true });
+      if (options.signal?.aborted) abort();
+      else
+        void Promise.resolve()
+          .then(() => operation(context))
+          .then(succeed, fail);
+      return Effect.sync(cleanup);
+    });
+  }
+
+  private async recover(failure: BrowserOperationError): Promise<BrowserOperationError | null> {
+    try {
+      await Effect.runPromise(
+        Effect.tryPromise({
+          try: () => this.options.recover(failure),
+          catch: (error) => error,
+        }).pipe(
+          Effect.timeoutOrElse({
+            duration: this.policy.recoveryMs,
+            orElse: () => Effect.fail(new Error("Browser operation recovery timed out")),
+          }),
+        ),
+      );
+      return null;
+    } catch (error) {
+      const poisoned = operationError(failure.kind, "recovery-failed", error);
+      this.poisoned = poisoned;
+      return poisoned;
+    }
+  }
+}

--- a/services/agent-runtime/src/browser-host/playwright.ts
+++ b/services/agent-runtime/src/browser-host/playwright.ts
@@ -7,6 +7,10 @@ import { getGlobalSingleton } from "../instances";
 
 const LAUNCH_TIMEOUT_MS = 15_000;
 
+class BrowserContextRecoveryError extends Error {
+  readonly name = "BrowserContextRecoveryError";
+}
+
 const browserDataDirectory = (): string => path.join(os.tmpdir(), "local-studio-browser-profile");
 
 const resolveOnPath = (binary: string): string | null => {
@@ -71,15 +75,22 @@ export const findBrowserBinary = (): string | null => {
 
 class PlaywrightManager {
   private context: BrowserContext | null = null;
-  private launching: Promise<BrowserContext> | null = null;
+  private contextGeneration = 0;
+  private generation = 0;
+  private launching: { generation: number; promise: Promise<BrowserContext> } | null = null;
 
   isAvailable(): boolean {
     return findBrowserBinary() !== null;
   }
 
   async ensure(): Promise<BrowserContext> {
-    if (this.context) return this.context;
-    if (this.launching) return this.launching;
+    const generation = this.generation;
+    if (this.context && this.contextGeneration === generation) return this.context;
+    if (this.launching?.generation === generation) return this.launching.promise;
+    if (this.launching) {
+      await this.launching.promise.catch(() => undefined);
+      return this.ensure();
+    }
     const executablePath = findBrowserBinary();
     if (!executablePath) {
       throw new Error("Browser unavailable: no Chromium found — set LOCAL_STUDIO_CHROME_PATH");
@@ -93,28 +104,57 @@ class PlaywrightManager {
         args: ["--no-first-run", "--no-default-browser-check", "--disable-dev-shm-usage"],
       });
     const dataDirectory = browserDataDirectory();
-    this.launching = launch(dataDirectory)
+    const promise = launch(dataDirectory)
       .catch((error: unknown) => {
         if (!String(error).includes("ProcessSingleton")) throw error;
         return launch(`${dataDirectory}-${process.pid}`);
       })
-      .then((context) => {
+      .then(async (context) => {
+        if (generation !== this.generation) {
+          try {
+            await context.close();
+          } catch (error) {
+            throw new BrowserContextRecoveryError("Failed to close invalidated browser context", {
+              cause: error,
+            });
+          }
+          throw new Error("Browser context invalidated during launch");
+        }
         this.context = context;
+        this.contextGeneration = generation;
         context.once("close", () => {
           if (this.context === context) this.context = null;
         });
         return context;
-      })
-      .finally(() => {
-        this.launching = null;
       });
-    return this.launching;
+    const launching = { generation, promise };
+    this.launching = launching;
+    try {
+      return await promise;
+    } finally {
+      if (this.launching === launching) this.launching = null;
+    }
+  }
+
+  async invalidate(): Promise<void> {
+    this.generation += 1;
+    const context = this.context;
+    this.context = null;
+    const launching = this.launching?.promise;
+    const closures: Promise<unknown>[] = [];
+    if (context) closures.push(context.close());
+    if (launching) {
+      closures.push(
+        launching.catch((error: unknown) => {
+          if (error instanceof BrowserContextRecoveryError) throw error;
+        }),
+      );
+    }
+    await Promise.all(closures);
   }
 
   stop(): void {
-    const context = this.context;
-    this.context = null;
-    if (context) void context.close().catch(() => undefined);
+    void this.invalidate().catch(() => undefined);
   }
 }
 

--- a/services/agent-runtime/src/browser-host/reader.ts
+++ b/services/agent-runtime/src/browser-host/reader.ts
@@ -10,6 +10,7 @@
 import { lookup } from "node:dns/promises";
 import { request as httpRequest, type RequestOptions } from "node:http";
 import { request as httpsRequest } from "node:https";
+import { Effect } from "effect";
 import { sanitizePublicBrowserUrl } from "../../../../shared/agent/sanitize-embedded-browser-url";
 
 const MAX_BYTES = 512 * 1024;
@@ -48,10 +49,41 @@ declare global {
     | undefined;
 }
 
-async function resolveReaderHost(hostname: string): Promise<ResolvedHostAddress[]> {
+const abortError = (signal: AbortSignal): Error =>
+  new Error("Browser fetch aborted", { cause: signal.reason });
+
+const assertNotAborted = (signal?: AbortSignal): void => {
+  if (signal?.aborted) throw abortError(signal);
+};
+
+const awaitWithSignal = <A>(promise: Promise<A>, signal?: AbortSignal): Promise<A> => {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(abortError(signal));
+  return Effect.runPromise(
+    Effect.tryPromise({
+      try: () => promise,
+      catch: (error) => (signal.aborted ? abortError(signal) : error),
+    }),
+    { signal },
+  ).catch((error: unknown) => {
+    if (signal.aborted) throw abortError(signal);
+    throw error;
+  });
+};
+
+async function resolveReaderHost(
+  hostname: string,
+  signal?: AbortSignal,
+): Promise<ResolvedHostAddress[]> {
+  assertNotAborted(signal);
   const testResolver = globalThis.__LOCAL_STUDIO_BROWSER_READER_HOST_RESOLVER_FOR_TEST;
-  if (testResolver) return (await testResolver(hostname)).map(normalizeResolvedAddress);
-  const results = await lookup(hostname, { all: true, verbatim: true });
+  if (testResolver) {
+    const inputs = await awaitWithSignal(testResolver(hostname), signal);
+    assertNotAborted(signal);
+    return inputs.map(normalizeResolvedAddress);
+  }
+  const results = await awaitWithSignal(lookup(hostname, { all: true, verbatim: true }), signal);
+  assertNotAborted(signal);
   return results.map((result) => ({
     address: result.address,
     family: result.family === 6 ? 6 : 4,
@@ -127,16 +159,21 @@ function cleanMarkdown(markdown: string): string {
     .trim();
 }
 
-async function fetchBoundedUrl(url: string, redirects = 0): Promise<BoundedResponse> {
-  const addresses = await publicResolvedAddresses(url);
-  const response = await requestBoundedUrl(url, addresses[0]);
+async function fetchBoundedUrl(
+  url: string,
+  redirects = 0,
+  signal?: AbortSignal,
+): Promise<BoundedResponse> {
+  const addresses = await publicResolvedAddresses(url, signal);
+  const response = await requestBoundedUrl(url, addresses[0], signal);
+  assertNotAborted(signal);
   if (isRedirectStatus(response.status)) {
     if (redirects >= MAX_REDIRECTS) throw new Error("Too many redirects");
     if (!response.location) throw new Error("Redirect missing Location header");
     const nextUrl = new URL(response.location, url).toString();
     const safeRedirect = sanitizePublicBrowserUrl(nextUrl);
     if (!safeRedirect) throw new Error("Redirect rejected (must stay public http/https)");
-    return fetchBoundedUrl(safeRedirect, redirects + 1);
+    return fetchBoundedUrl(safeRedirect, redirects + 1, signal);
   }
   return response;
 }
@@ -145,9 +182,12 @@ function isRedirectStatus(status: number): boolean {
   return status >= 300 && status < 400;
 }
 
-async function publicResolvedAddresses(raw: string): Promise<ResolvedHostAddress[]> {
+async function publicResolvedAddresses(
+  raw: string,
+  signal?: AbortSignal,
+): Promise<ResolvedHostAddress[]> {
   const url = new URL(raw);
-  const addresses = await resolveReaderHost(url.hostname);
+  const addresses = await resolveReaderHost(url.hostname, signal);
   if (!addresses.length) throw new Error("Host resolved to no addresses");
   for (const address of addresses) {
     if (!sanitizePublicBrowserUrl(`${url.protocol}//${hostForAddress(address.address)}/`)) {
@@ -166,13 +206,18 @@ function normalizeResolvedAddress(input: ResolvedHostInput): ResolvedHostAddress
   return { address: input, family: input.includes(":") ? 6 : 4 };
 }
 
-function requestBoundedUrl(url: string, address: ResolvedHostAddress): Promise<BoundedResponse> {
+function requestBoundedUrl(
+  url: string,
+  address: ResolvedHostAddress,
+  signal?: AbortSignal,
+): Promise<BoundedResponse> {
   const testRequest = globalThis.__LOCAL_STUDIO_BROWSER_READER_REQUEST_FOR_TEST;
-  if (testRequest) return testRequest(url, address);
+  if (testRequest) return awaitWithSignal(testRequest(url, address), signal);
   const parsed = new URL(url);
   const request = parsed.protocol === "https:" ? httpsRequest : httpRequest;
   const options: RequestOptions = {
     headers: { Accept: ACCEPT, "User-Agent": USER_AGENT },
+    signal,
     lookup: ((
       _hostname: string,
       lookupOptions: unknown,
@@ -273,10 +318,12 @@ function renderReadable(response: BoundedResponse, fallbackUrl: string): ReaderR
 
 // Fetch a public URL and return reading-mode text. Throws on rejected/invalid
 // URLs or upstream failures; callers map errors to their own response shape.
-export async function fetchReadable(rawUrl: string): Promise<ReaderResult> {
+export async function fetchReadable(rawUrl: string, signal?: AbortSignal): Promise<ReaderResult> {
+  assertNotAborted(signal);
   const safe = sanitizePublicBrowserUrl(rawUrl);
   if (!safe) throw new Error("url rejected (must be public http/https)");
-  const response = await fetchBoundedUrl(safe);
+  const response = await fetchBoundedUrl(safe, 0, signal);
+  assertNotAborted(signal);
   if (!response.ok) throw new Error(`Upstream returned HTTP ${response.status}`);
   return renderReadable(response, safe);
 }

--- a/services/agent-runtime/src/http/app.ts
+++ b/services/agent-runtime/src/http/app.ts
@@ -116,10 +116,10 @@ export function createAgentRuntimeApp() {
   app.post("/api/agent/terminal/pty/resize", (c) => handlePtyResize(c.req.raw));
   app.post("/api/agent/terminal/pty/close", (c) => handlePtyClose(c.req.raw));
   app.get("/api/agent/browser/fetch", (c) => handleBrowserFetch(c.req.raw));
-  app.get("/api/agent/browser/frame", () => handleBrowserFrame());
+  app.get("/api/agent/browser/frame", (c) => handleBrowserFrame(c.req.raw));
   app.post("/api/agent/browser/input", (c) => handleBrowserInput(c.req.raw));
   app.get("/api/agent/browser/localhosts", (c) => handleBrowserLocalhosts(c.req.raw));
-  app.get("/api/agent/browser/state", () => handleBrowserState());
+  app.get("/api/agent/browser/state", (c) => handleBrowserState(c.req.raw));
   app.post("/api/agent/browser/viewport", (c) => handleBrowserViewport(c.req.raw));
   app.post("/api/agent/browser/:verb", (c) => handleBrowserVerb(c.req.raw, c.req.param("verb")));
 

--- a/services/agent-runtime/src/http/browser-handlers.ts
+++ b/services/agent-runtime/src/http/browser-handlers.ts
@@ -227,7 +227,7 @@ export async function handleBrowserFetch(request: Request): Promise<Response> {
 export async function handleBrowserFrame(request: Request): Promise<Response> {
   try {
     return await runBrowserOperation({ kind: "frame", signal: request.signal }, async (context) => {
-      if (!browserHost.isAvailable()) return fallbackFrame(UNAVAILABLE_ERROR);
+      if (!browserHost.isAvailable()) return fallbackFrame(UNAVAILABLE_ERROR, 503);
       try {
         const { frame, state } = await browserHost.pollFrame();
         context.assertActive();
@@ -251,7 +251,7 @@ export async function handleBrowserFrame(request: Request): Promise<Response> {
   }
 }
 
-function fallbackFrame(error: string): Response {
+function fallbackFrame(error: string, status = 502): Response {
   return Response.json(
     {
       ok: false,
@@ -264,7 +264,7 @@ function fallbackFrame(error: string): Response {
         canGoForward: false,
       },
     },
-    { status: 503 },
+    { status },
   );
 }
 

--- a/services/agent-runtime/src/http/browser-handlers.ts
+++ b/services/agent-runtime/src/http/browser-handlers.ts
@@ -2,6 +2,12 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { sanitizeBrowserPaneUrl } from "../../../../shared/agent/sanitize-embedded-browser-url";
 import { browserHost, type KeyInput, type MouseInput } from "../browser-host/browser-host";
+import {
+  BrowserOperationCoordinator,
+  type BrowserOperationContext,
+  type BrowserOperationCoordinatorOptions,
+  type BrowserOperationRunOptions,
+} from "../browser-host/browser-operation-coordinator";
 import { fetchReadable } from "../browser-host/reader";
 
 const ALLOWED_VERBS = new Set([
@@ -22,6 +28,20 @@ const UNAVAILABLE_ERROR = "Browser unavailable: no Chromium found — set LOCAL_
 
 let lastFallbackUrl = "";
 
+export function createBrowserOperationQueue(
+  options: BrowserOperationCoordinatorOptions = {
+    recover: () => browserHost.invalidate(),
+  },
+) {
+  const coordinator = new BrowserOperationCoordinator(options);
+  return <A>(
+    runOptions: BrowserOperationRunOptions,
+    operation: (context: BrowserOperationContext) => Promise<A>,
+  ): Promise<A> => coordinator.run(runOptions, operation);
+}
+
+const runBrowserOperation = createBrowserOperationQueue();
+
 type VerbResult = { ok: boolean; data?: unknown; error?: string };
 
 export async function handleBrowserVerb(request: Request, verb: string): Promise<Response> {
@@ -30,7 +50,9 @@ export async function handleBrowserVerb(request: Request, verb: string): Promise
   }
   const payload = await readPayload(request);
   try {
-    const result = await dispatchVerb(verb, payload);
+    const result = await runBrowserOperation({ kind: "verb", signal: request.signal }, (context) =>
+      dispatchVerb(verb, payload, context),
+    );
     return Response.json(result);
   } catch (error) {
     return Response.json({
@@ -54,22 +76,32 @@ async function readPayload(request: Request): Promise<Record<string, unknown>> {
   return {};
 }
 
-async function dispatchVerb(verb: string, payload: Record<string, unknown>): Promise<VerbResult> {
-  if (!browserHost.isAvailable()) return fallbackVerb(verb, payload);
+async function dispatchVerb(
+  verb: string,
+  payload: Record<string, unknown>,
+  context: BrowserOperationContext,
+): Promise<VerbResult> {
+  if (!browserHost.isAvailable()) return fallbackVerb(verb, payload, context);
   try {
-    return await runHostVerb(verb, payload);
+    return await runHostVerb(verb, payload, context);
   } catch (error) {
     // A launch/connection failure for the reading verbs still degrades to
     // reading mode rather than failing the tool call outright.
-    if (verb === "navigate" || verb === "get-text") return fallbackVerb(verb, payload);
+    if (["navigate", "get-url", "get-text", "get-html"].includes(verb)) {
+      return fallbackVerb(verb, payload, context);
+    }
     throw error;
   }
 }
 
-async function runHostVerb(verb: string, payload: Record<string, unknown>): Promise<VerbResult> {
+async function runHostVerb(
+  verb: string,
+  payload: Record<string, unknown>,
+  context: BrowserOperationContext,
+): Promise<VerbResult> {
   switch (verb) {
     case "navigate":
-      return navigateVerb(payload);
+      return navigateVerb(payload, context);
     case "get-url":
       return { ok: true, data: await browserHost.getUrl() };
     case "get-text":
@@ -103,12 +135,17 @@ async function runHostVerb(verb: string, payload: Record<string, unknown>): Prom
   }
 }
 
-async function navigateVerb(payload: Record<string, unknown>): Promise<VerbResult> {
+async function navigateVerb(
+  payload: Record<string, unknown>,
+  context: BrowserOperationContext,
+): Promise<VerbResult> {
   // Pane rules: public web plus loopback (previewing local dev servers is the
   // pane's main job); other private ranges stay blocked.
   const url = sanitizeBrowserPaneUrl(String(payload.url ?? ""));
   if (!url) return { ok: false, error: "valid public or localhost http(s) url required" };
   const result = await browserHost.navigate(url);
+  context.assertActive();
+  lastFallbackUrl = result.url;
   return { ok: true, data: result };
 }
 
@@ -137,11 +174,16 @@ function requireSelector(payload: Record<string, unknown>): string {
 // without a url arg); every other verb returns the clear unavailable error. The
 // fallback honors pane rules (public + loopback) so local dev servers stay
 // previewable even when there's no headless Chromium to drive a full surface.
-async function fallbackVerb(verb: string, payload: Record<string, unknown>): Promise<VerbResult> {
+async function fallbackVerb(
+  verb: string,
+  payload: Record<string, unknown>,
+  context: BrowserOperationContext,
+): Promise<VerbResult> {
   if (verb === "navigate") {
     const url = sanitizeBrowserPaneUrl(String(payload.url ?? ""));
     if (!url) return { ok: false, error: "valid public or localhost http(s) url required" };
-    const reader = await fetchReadable(url);
+    const reader = await fetchReadable(url, context.signal);
+    context.assertActive();
     lastFallbackUrl = reader.url;
     return { ok: true, data: { url: reader.url, title: reader.title, readingMode: true } };
   }
@@ -151,7 +193,8 @@ async function fallbackVerb(verb: string, payload: Record<string, unknown>): Pro
   if (verb === "get-text" || verb === "get-html") {
     const url = sanitizeBrowserPaneUrl(String(payload.url ?? "")) || lastFallbackUrl;
     if (!url) return { ok: false, error: UNAVAILABLE_ERROR };
-    const reader = await fetchReadable(url);
+    const reader = await fetchReadable(url, context.signal);
+    context.assertActive();
     lastFallbackUrl = reader.url;
     return verb === "get-text"
       ? { ok: true, data: { text: reader.text, readingMode: true } }
@@ -164,7 +207,7 @@ export async function handleBrowserFetch(request: Request): Promise<Response> {
   const raw = new URL(request.url).searchParams.get("url");
   if (!raw) return Response.json({ error: "url is required" }, { status: 400 });
   try {
-    const result = await fetchReadable(raw);
+    const result = await fetchReadable(raw, request.signal);
     return Response.json(result);
   } catch (error) {
     const message = error instanceof Error ? error.message : "Fetch failed";
@@ -181,28 +224,48 @@ export async function handleBrowserFetch(request: Request): Promise<Response> {
 // Next's standalone server buffers locally-built event streams, and polling
 // survives buffering proxies for remote deploys).
 
-export async function handleBrowserFrame(): Promise<Response> {
-  if (!browserHost.isAvailable()) {
-    return Response.json({ ok: false, error: UNAVAILABLE_ERROR }, { status: 503 });
-  }
+export async function handleBrowserFrame(request: Request): Promise<Response> {
   try {
-    const { frame, state } = await browserHost.pollFrame();
-    return Response.json({
-      ok: true,
-      data: {
-        frame: frame?.data ?? null,
-        url: state.url,
-        title: state.title,
-        canGoBack: state.canGoBack,
-        canGoForward: state.canGoForward,
-      },
+    return await runBrowserOperation({ kind: "frame", signal: request.signal }, async (context) => {
+      if (!browserHost.isAvailable()) return fallbackFrame(UNAVAILABLE_ERROR);
+      try {
+        const { frame, state } = await browserHost.pollFrame();
+        context.assertActive();
+        lastFallbackUrl = state.url;
+        return Response.json({
+          ok: true,
+          data: {
+            frame: frame?.data ?? null,
+            url: state.url,
+            title: state.title,
+            canGoBack: state.canGoBack,
+            canGoForward: state.canGoForward,
+          },
+        });
+      } catch (error) {
+        return fallbackFrame(error instanceof Error ? error.message : "frame poll failed");
+      }
     });
   } catch (error) {
-    return Response.json({
-      ok: false,
-      error: error instanceof Error ? error.message : "frame poll failed",
-    });
+    return fallbackFrame(error instanceof Error ? error.message : "frame poll failed");
   }
+}
+
+function fallbackFrame(error: string): Response {
+  return Response.json(
+    {
+      ok: false,
+      error,
+      data: {
+        frame: null,
+        url: lastFallbackUrl,
+        title: "",
+        canGoBack: false,
+        canGoForward: false,
+      },
+    },
+    { status: 503 },
+  );
 }
 
 type InputBody =
@@ -221,7 +284,7 @@ export async function handleBrowserInput(request: Request): Promise<Response> {
     return Response.json({ ok: false, error: "Invalid JSON" }, { status: 400 });
   }
   try {
-    await dispatchInput(body);
+    await runBrowserOperation({ kind: "input", signal: request.signal }, () => dispatchInput(body));
     return Response.json({ ok: true });
   } catch (error) {
     return Response.json({
@@ -381,12 +444,17 @@ export async function handleBrowserLocalhosts(request: Request): Promise<Respons
 
 // ─── GET /api/agent/browser/state ─────────────────────────────────────────
 
-export async function handleBrowserState(): Promise<Response> {
+export async function handleBrowserState(request: Request): Promise<Response> {
   if (!browserHost.isAvailable()) {
     return Response.json({ ok: false, error: "Browser unavailable" }, { status: 503 });
   }
   try {
-    return Response.json({ ok: true, data: await browserHost.peekState() });
+    return Response.json({
+      ok: true,
+      data: await runBrowserOperation({ kind: "state", signal: request.signal }, () =>
+        browserHost.peekState(),
+      ),
+    });
   } catch (error) {
     return Response.json({
       ok: false,
@@ -416,7 +484,9 @@ export async function handleBrowserViewport(request: Request): Promise<Response>
     return Response.json({ ok: false, error: "width and height are required" }, { status: 400 });
   }
   try {
-    await browserHost.setViewport(width, height);
+    await runBrowserOperation({ kind: "viewport", signal: request.signal }, () =>
+      browserHost.setViewport(width, height),
+    );
     return Response.json({
       ok: true,
       data: { width: Math.round(width), height: Math.round(height) },

--- a/services/agent-runtime/test/browser-operation-coordinator.test.ts
+++ b/services/agent-runtime/test/browser-operation-coordinator.test.ts
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "bun:test";
+import {
+  BrowserOperationCoordinator,
+  BrowserOperationError,
+} from "../src/browser-host/browser-operation-coordinator";
+import { fetchReadable } from "../src/browser-host/reader";
+
+const policy = {
+  recoveryMs: 100,
+  timeouts: { frame: 25, input: 25, state: 25, verb: 25, viewport: 25 },
+};
+
+const errorReason = (error: unknown): string | undefined =>
+  error instanceof BrowserOperationError ? error.reason : undefined;
+
+type Recover = ConstructorParameters<typeof BrowserOperationCoordinator>[0]["recover"];
+
+const makeCoordinator = (recover: Recover = async () => undefined, recoveryMs = 100) =>
+  new BrowserOperationCoordinator({ policy: { ...policy, recoveryMs }, recover });
+
+afterEach(() => {
+  globalThis.__LOCAL_STUDIO_BROWSER_READER_HOST_RESOLVER_FOR_TEST = undefined;
+  globalThis.__LOCAL_STUDIO_BROWSER_READER_REQUEST_FOR_TEST = undefined;
+});
+
+test("a stalled frame is recovered before later browser work starts", async () => {
+  const started = Promise.withResolvers<void>();
+  const late = Promise.withResolvers<void>();
+  const recoveries: string[] = [];
+  let state = "initial";
+  const coordinator = makeCoordinator(async (failure) => {
+    recoveries.push(`${failure.kind}:${failure.reason}`);
+  });
+  const frame = coordinator.run({ kind: "frame" }, async (context) => {
+    started.resolve();
+    await late.promise;
+    context.assertActive();
+    state = "stale";
+  });
+  await started.promise;
+  let laterStarted = false;
+  const stale = coordinator.run({ kind: "verb" }, async () => {
+    laterStarted = true;
+  });
+  const staleRejected = assert.rejects(stale, (error) => errorReason(error) === "aborted");
+  await assert.rejects(frame, (error) => errorReason(error) === "timed-out");
+  await staleRejected;
+  const later = coordinator.run({ kind: "verb" }, async () => {
+    state = "current";
+    return "ready";
+  });
+  assert.equal(await later, "ready");
+  late.resolve();
+  await Bun.sleep(0);
+  assert.equal(laterStarted, false);
+  assert.equal(state, "current");
+  assert.deepEqual(recoveries, ["frame:timed-out"]);
+});
+
+test("an aborted queued request performs no browser side effect", async () => {
+  const activeStarted = Promise.withResolvers<void>();
+  const releaseActive = Promise.withResolvers<void>();
+  const coordinator = makeCoordinator();
+  const active = coordinator.run({ kind: "frame" }, async () => {
+    activeStarted.resolve();
+    await releaseActive.promise;
+  });
+  await activeStarted.promise;
+  const cancellation = new AbortController();
+  let sideEffects = 0;
+  const queued = coordinator.run({ kind: "input", signal: cancellation.signal }, async () => {
+    sideEffects += 1;
+  });
+  cancellation.abort();
+  await assert.rejects(queued, (error) => errorReason(error) === "aborted");
+  assert.equal(sideEffects, 0);
+  releaseActive.resolve();
+  await active;
+});
+
+test("an active abort recovers before the next operation starts", async () => {
+  const activeStarted = Promise.withResolvers<void>();
+  const cancellation = new AbortController();
+  let recovered = false;
+  const coordinator = makeCoordinator(async () => {
+    recovered = true;
+  });
+  const active = coordinator.run({ kind: "input", signal: cancellation.signal }, async () => {
+    activeStarted.resolve();
+    return new Promise<never>(() => undefined);
+  });
+  await activeStarted.promise;
+  cancellation.abort();
+  const later = coordinator.run({ kind: "state" }, async () => recovered);
+  await assert.rejects(active, (error) => errorReason(error) === "aborted");
+  assert.equal(await later, true);
+});
+
+test("queued input and verb cannot mutate the replacement browser generation", async () => {
+  const activeStarted = Promise.withResolvers<void>();
+  const cancellation = new AbortController();
+  const sideEffects: string[] = [];
+  let page = "initial";
+  const coordinator = makeCoordinator(async () => {
+    page = "replacement";
+  });
+  const active = coordinator.run({ kind: "frame", signal: cancellation.signal }, async () => {
+    activeStarted.resolve();
+    return new Promise<never>(() => undefined);
+  });
+  await activeStarted.promise;
+  const input = coordinator.run({ kind: "input" }, async () => {
+    sideEffects.push(`${page}:input`);
+  });
+  const verb = coordinator.run({ kind: "verb" }, async () => {
+    sideEffects.push(`${page}:verb`);
+  });
+  cancellation.abort();
+  await assert.rejects(active, (error) => errorReason(error) === "aborted");
+  await assert.rejects(input, (error) => errorReason(error) === "aborted");
+  await assert.rejects(verb, (error) => errorReason(error) === "aborted");
+  assert.equal(page, "replacement");
+  assert.deepEqual(sideEffects, []);
+});
+
+test("queued work expires from its enqueue deadline without side effects", async () => {
+  const activeStarted = Promise.withResolvers<void>();
+  const releaseActive = Promise.withResolvers<void>();
+  let recoveries = 0;
+  let sideEffects = 0;
+  const coordinator = new BrowserOperationCoordinator({
+    policy: {
+      ...policy,
+      timeouts: { ...policy.timeouts, input: 1, state: 1_000 },
+    },
+    recover: async () => {
+      recoveries += 1;
+    },
+  });
+  const active = coordinator.run({ kind: "state" }, async () => {
+    activeStarted.resolve();
+    await releaseActive.promise;
+  });
+  await activeStarted.promise;
+  const queued = coordinator.run({ kind: "input" }, async () => {
+    sideEffects += 1;
+  });
+  const queuedRejected = assert.rejects(queued, (error) => errorReason(error) === "timed-out");
+  const waitUntil = Date.now() + 10;
+  while (Date.now() < waitUntil) await Promise.resolve();
+  releaseActive.resolve();
+  await active;
+  await queuedRejected;
+  assert.equal(sideEffects, 0);
+  assert.equal(recoveries, 0);
+});
+
+test("reader fallback is bounded and a later fallback can proceed", async () => {
+  let recoveries = 0;
+  const coordinator = makeCoordinator(async () => {
+    recoveries += 1;
+  });
+  globalThis.__LOCAL_STUDIO_BROWSER_READER_HOST_RESOLVER_FOR_TEST = async () => ["93.184.216.34"];
+  globalThis.__LOCAL_STUDIO_BROWSER_READER_REQUEST_FOR_TEST = async () =>
+    new Promise<never>(() => undefined);
+  const stalled = coordinator.run({ kind: "verb" }, async (context) => {
+    const result = await fetchReadable("https://fallback.test/stalled", context.signal);
+    context.assertActive();
+    return result;
+  });
+  await assert.rejects(stalled, (error) => errorReason(error) === "timed-out");
+  globalThis.__LOCAL_STUDIO_BROWSER_READER_REQUEST_FOR_TEST = async (url) => ({
+    status: 200,
+    ok: true,
+    url,
+    contentType: "text/html",
+    body: "<title>Recovered</title><body>ready</body>",
+  });
+  const recovered = await coordinator.run({ kind: "verb" }, async (context) => {
+    const result = await fetchReadable("https://fallback.test/recovered", context.signal);
+    context.assertActive();
+    return result;
+  });
+  assert.equal(recovered.title, "Recovered");
+  assert.equal(recoveries, 1);
+});
+
+test("unconfirmed recovery poisons later browser work closed", async () => {
+  let laterSideEffects = 0;
+  const coordinator = makeCoordinator(async () => new Promise<never>(() => undefined), 10);
+  const stalled = coordinator.run(
+    { kind: "frame" },
+    async () => new Promise<never>(() => undefined),
+  );
+  await assert.rejects(stalled, (error) => errorReason(error) === "recovery-failed");
+  await assert.rejects(
+    coordinator.run({ kind: "verb" }, async () => {
+      laterSideEffects += 1;
+    }),
+    (error) => errorReason(error) === "recovery-failed",
+  );
+  assert.equal(laterSideEffects, 0);
+});

--- a/services/agent-runtime/test/http-app.test.ts
+++ b/services/agent-runtime/test/http-app.test.ts
@@ -3,6 +3,7 @@ import { readdirSync, readFileSync } from "node:fs";
 import { dirname, join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createAgentRuntimeApp } from "../src/http/app";
+import { browserHost } from "../src/browser-host/browser-host";
 import {
   createBrowserOperationQueue,
   handleBrowserFrame,
@@ -146,6 +147,52 @@ describe("agent runtime HTTP application", () => {
       else process.env["LOCAL_STUDIO_CHROME_PATH"] = previousChrome;
       globalThis.__LOCAL_STUDIO_BROWSER_READER_HOST_RESOLVER_FOR_TEST = undefined;
       globalThis.__LOCAL_STUDIO_BROWSER_READER_REQUEST_FOR_TEST = undefined;
+    }
+  });
+
+  test("keeps transient frame failures retryable", async () => {
+    const previousChrome = process.env["LOCAL_STUDIO_CHROME_PATH"];
+    const pollFrame = browserHost.pollFrame;
+    process.env["LOCAL_STUDIO_CHROME_PATH"] = process.execPath;
+    let attempts = 0;
+    browserHost.pollFrame = async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("capture interrupted");
+      return {
+        frame: null,
+        state: {
+          url: "https://recovered.test/",
+          title: "Recovered",
+          canGoBack: false,
+          canGoForward: false,
+        },
+      };
+    };
+    try {
+      const failed = await handleBrowserFrame(
+        new Request("http://runtime/api/agent/browser/frame"),
+      );
+      expect(failed.status).toBe(502);
+      expect((await failed.json()).error).toBe("capture interrupted");
+
+      const recovered = await handleBrowserFrame(
+        new Request("http://runtime/api/agent/browser/frame"),
+      );
+      expect(recovered.status).toBe(200);
+      expect(await recovered.json()).toEqual({
+        ok: true,
+        data: {
+          frame: null,
+          url: "https://recovered.test/",
+          title: "Recovered",
+          canGoBack: false,
+          canGoForward: false,
+        },
+      });
+    } finally {
+      browserHost.pollFrame = pollFrame;
+      if (previousChrome === undefined) delete process.env["LOCAL_STUDIO_CHROME_PATH"];
+      else process.env["LOCAL_STUDIO_CHROME_PATH"] = previousChrome;
     }
   });
   test("exposes health without starting a network listener", async () => {

--- a/services/agent-runtime/test/http-app.test.ts
+++ b/services/agent-runtime/test/http-app.test.ts
@@ -3,6 +3,11 @@ import { readdirSync, readFileSync } from "node:fs";
 import { dirname, join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createAgentRuntimeApp } from "../src/http/app";
+import {
+  createBrowserOperationQueue,
+  handleBrowserFrame,
+  handleBrowserVerb,
+} from "../src/http/browser-handlers";
 
 const expectedOperations = [
   "GET /health",
@@ -61,10 +66,7 @@ const routePath = (root: string, directory: string): string =>
     .join("/")}`;
 
 const collectFrontendOperations = (): Set<string> => {
-  const root = join(
-    dirname(fileURLToPath(import.meta.url)),
-    "../../../frontend/src/app/api/agent",
-  );
+  const root = join(dirname(fileURLToPath(import.meta.url)), "../../../frontend/src/app/api/agent");
   const operations = new Set<string>();
   const visit = (directory: string): void => {
     for (const entry of readdirSync(directory, { withFileTypes: true })) {
@@ -96,6 +98,56 @@ describe("agent runtime HTTP application", () => {
     }
   });
 
+  test("serializes browser callers and exposes fallback location to frames", async () => {
+    const run = createBrowserOperationQueue();
+    const gate = Promise.withResolvers<void>();
+    const calls: string[] = [];
+    const first = run({ kind: "frame" }, async () => {
+      calls.push("frame");
+      await gate.promise;
+    });
+    const second = run({ kind: "verb" }, async () => {
+      calls.push("navigate");
+    });
+    await Bun.sleep(0);
+    expect(calls).toEqual(["frame"]);
+    gate.resolve();
+    await Promise.all([first, second]);
+    expect(calls).toEqual(["frame", "navigate"]);
+
+    const previousChrome = process.env["LOCAL_STUDIO_CHROME_PATH"];
+    process.env["LOCAL_STUDIO_CHROME_PATH"] = "/missing/local-studio-chromium";
+    globalThis.__LOCAL_STUDIO_BROWSER_READER_HOST_RESOLVER_FOR_TEST = async () => ["93.184.216.34"];
+    globalThis.__LOCAL_STUDIO_BROWSER_READER_REQUEST_FOR_TEST = async (url) => ({
+      status: 200,
+      ok: true,
+      url,
+      contentType: "text/html",
+      body: "<title>Fallback</title><body>ready</body>",
+    });
+    try {
+      const url = "https://fallback.test/page";
+      const navigate = await handleBrowserVerb(
+        new Request("http://runtime/api/agent/browser/navigate", {
+          method: "POST",
+          body: JSON.stringify({ url }),
+        }),
+        "navigate",
+      );
+      expect(await navigate.json()).toEqual({
+        ok: true,
+        data: { url, title: "Fallback", readingMode: true },
+      });
+      const frame = await handleBrowserFrame(new Request("http://runtime/api/agent/browser/frame"));
+      expect(frame.status).toBe(503);
+      expect((await frame.json()).data.url).toBe(url);
+    } finally {
+      if (previousChrome === undefined) delete process.env["LOCAL_STUDIO_CHROME_PATH"];
+      else process.env["LOCAL_STUDIO_CHROME_PATH"] = previousChrome;
+      globalThis.__LOCAL_STUDIO_BROWSER_READER_HOST_RESOLVER_FOR_TEST = undefined;
+      globalThis.__LOCAL_STUDIO_BROWSER_READER_REQUEST_FOR_TEST = undefined;
+    }
+  });
   test("exposes health without starting a network listener", async () => {
     const { app, litterBridgeGateway } = createAgentRuntimeApp();
     try {


### PR DESCRIPTION
## Summary

- Rebase the unified browser surface onto current `dev` while preserving its lightweight start-page state synchronization.
- Route visible browser state, frames, navigation, input, viewport changes, and agent verbs through one managed Chromium host with a single authority barrier.
- Keep Browser navigation HTTP(S)-only and hand workspace-contained file targets to Files.
- Bound, cancel, recover, and invalidate shared browser operations without allowing stale work to overwrite newer state.

## Maintainer rework addressed

This is a focused replacement based on current `dev`, not the historical `main` snapshot.

- Electron keeps `webviewTag: false`; no guest/webview browser surface is restored.
- The Browser start page uses `peekState()` polling and does not mount a hidden high-frequency screencast or launch Chromium merely by opening the pane.
- User mutations and frame/state observations share a generation barrier, preventing duplicate navigation and stale-frame rollback.
- Markdown links commit browser location only after an authoritative result; rejected or timed-out navigation leaves the committed URL unchanged.
- Workspace file resolution rejects nested traversal, encoded traversal, and sibling-prefix escapes.
- Transient frame capture/recovery failures remain retryable; only genuine browser-host unavailability selects the Reader fallback.

## Design

An Effect-backed coordinator serializes operations against the shared host. It captures generation and absolute deadline before queue acquisition, propagates request cancellation, rejects expired or stale queued work before invocation, and performs bounded recovery. Browser and Playwright invalidation prevent late launches, pages, frames, fallbacks, or state writes from attaching to a replacement generation. A shared frontend authority sequence ensures model-state polling, user mutations, and frame observations cannot overwrite one another out of order.

## Validation

- Exact head: `511ee85f94e4eac843e5c33f62e192f474a7d939` on current `dev` `a765eb27bca4baffabc6dc84c553fc6d8be5590d`.
- `npm run check` passed: release self-tests 12/12, frontend 134/134, controller 90/90, and agent runtime 106/106, plus typecheck, lint, build, dead-code, duplicate, dependency, and cycle gates.
- `npm --prefix frontend run test` passed 134/134; the exact-head agent-runtime suite passed 106/106.
- Regression coverage includes stale observation rejection, failed navigation authority, workspace-boundary traversal, and transient frame failure followed by successful recovery.
- `git diff --check` passed and the worktree is clean.
- `npm --prefix frontend run desktop:dist` completed at the exact head and produced arm64 ZIP, DMG, and blockmap artifacts.
- The host has zero valid signing identities. The repository installer rejected the unsigned bundle at its initial strict signature check, before staging or replacing `/Applications/Local Studio.app`; signing and Gatekeeper were not bypassed, and installed-app health is not claimed for this head.
- Two independent exact-head P0/P1 reviews report no findings.

## Acceptance criteria

- [x] One managed page backs the visible browser pane and agent browser tools.
- [x] No webview capability or guest handler remains.
- [x] Browser navigation accepts only policy-approved HTTP(S) targets.
- [x] Workspace file links cannot escape the active project boundary.
- [x] Queue waits and active operations honor cancellation and bounded deadlines.
- [x] Stale generations cannot replay work or overwrite newer browser/fallback state.
- [x] Transient frame failures remain recoverable while genuine host unavailability fails closed.
- [x] Exact-head local checks, focused regressions, packaging, and independent review pass.
- [ ] After #367 merges, rebase onto it and repeat the exact-head gates and independent review while preserving its DNS-pinned/network policy.
- [ ] Complete repository-installer and `GET /api/desktop-health` acceptance in an environment with a valid signing identity.

## Dependency and scope

Depends on #367 for browser network policy. Merge #367 first, then rebase and fully revalidate this PR. Cross-session browser isolation remains scoped to #375.

Closes #236

Maintainer review is requested in the PR discussion.
