### PR TITLE
[Security] Isolate browser pages, storage, fallback, and input by agent session

### DIFF
--- a/frontend/desktop/logic/browser-session-smoke.test.ts
+++ b/frontend/desktop/logic/browser-session-smoke.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+const repository = path.resolve(import.meta.dirname, "../../..");
+const projectScript = readFileSync(path.join(repository, "frontend/desktop/project.mjs"), "utf8");
+
+test("packaged browser smoke carries an isolated session key", () => {
+  assert.match(
+    projectScript,
+    /browser\/navigate[^\n]+"x-local-studio-browser-session": "desktop-package-smoke"/u,
+  );
+});

--- a/frontend/desktop/project.mjs
+++ b/frontend/desktop/project.mjs
@@ -788,10 +788,10 @@ async function waitForJson(url, timeoutMs) {
   }
   throw Error(`Timed out waiting for ${url}: ${String(lastError)}`);
 }
-async function postJson(url, body2) {
+async function postJson(url, body2, headers2 = {}) {
   let response = await fetch(url, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", ...headers2 },
     body: JSON.stringify(body2),
     signal: AbortSignal.timeout(30000)
   }), payload = await response.json();
@@ -904,7 +904,7 @@ async function runDesktopPackageSmoke(args2 = process2.argv.slice(2)) {
     let frontendPort = Number(await waitForFile(frontendPortFile, 60000));
     if (!Number.isInteger(frontendPort) || frontendPort <= 0)
       throw Error(`Invalid embedded frontend port: ${frontendPort}`);
-    let origin = `http://127.0.0.1:${frontendPort}`, desktopHealth = await waitForJson(`${origin}/api/desktop-health`, 30000), agentRuntime = await waitForAgentRuntime(logFile, 30000), embeddedBrowser = await postJson(`${agentRuntime.url}/api/agent/browser/navigate`, { url: `${origin}/agent` });
+    let origin = `http://127.0.0.1:${frontendPort}`, desktopHealth = await waitForJson(`${origin}/api/desktop-health`, 30000), agentRuntime = await waitForAgentRuntime(logFile, 30000), embeddedBrowser = await postJson(`${agentRuntime.url}/api/agent/browser/navigate`, { url: `${origin}/agent` }, { "x-local-studio-browser-session": "desktop-package-smoke" });
     if (!String(embeddedBrowser.data?.url ?? "").startsWith(origin))
       throw Error(`Packaged browser navigated to an unexpected URL: ${JSON.stringify(embeddedBrowser)}`);
     browser = await chromium.connectOverCDP(`http://127.0.0.1:${debugPort}`);

--- a/frontend/desktop/resources/pi-extensions/automations.test.ts
+++ b/frontend/desktop/resources/pi-extensions/automations.test.ts
@@ -1,5 +1,18 @@
+import assert from "node:assert/strict";
 import { describe, expect, test } from "bun:test";
-import { describeSchedule, normalizeScheduleArg } from "./automations";
+import automationsExtension, { describeSchedule, normalizeScheduleArg } from "./automations";
+
+type ScheduleTool = {
+  execute: (
+    id: string,
+    params: {
+      prompt: string;
+      schedule: { kind: "interval"; minutes: number };
+    },
+    signal?: AbortSignal,
+  ) => Promise<{ details: Record<string, unknown> }>;
+  name: string;
+};
 
 describe("normalizeScheduleArg", () => {
   test("accepts an interval schedule and rounds minutes", () => {
@@ -57,4 +70,40 @@ describe("describeSchedule", () => {
       "weekly on Monday at 07:00",
     );
   });
+});
+
+test("schedule tool retains the session model after environment restoration", async () => {
+  let scheduleTool: ScheduleTool | null = null;
+  const previousModel = process.env.LOCAL_STUDIO_MODEL_ID;
+  try {
+    process.env.LOCAL_STUDIO_MODEL_ID = "session-model";
+    automationsExtension({
+      registerTool(tool: unknown) {
+        const registered = tool as ScheduleTool;
+        if (registered.name === "schedule_automation") scheduleTool = registered;
+      },
+    } as unknown as Parameters<typeof automationsExtension>[0]);
+  } finally {
+    if (previousModel === undefined) delete process.env.LOCAL_STUDIO_MODEL_ID;
+    else process.env.LOCAL_STUDIO_MODEL_ID = previousModel;
+  }
+
+  const requests: Request[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input, init) => {
+    requests.push(new Request(input, init));
+    return Promise.resolve(Response.json({ automation: { id: "automation-1", name: "Audit" } }));
+  };
+  try {
+    if (!scheduleTool) throw new Error("schedule_automation was not registered");
+    const result = await scheduleTool.execute("call-1", {
+      prompt: "Run an audit",
+      schedule: { kind: "interval", minutes: 30 },
+    });
+    assert.equal(result.details.modelId, "session-model");
+    assert.equal(requests.length, 1);
+    assert.equal((await requests[0]?.json()).modelId, "session-model");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });

--- a/frontend/desktop/resources/pi-extensions/automations.ts
+++ b/frontend/desktop/resources/pi-extensions/automations.ts
@@ -39,7 +39,15 @@ type ScheduleArg = {
   weekdaysOnly?: unknown;
 };
 
-const WEEKDAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+const WEEKDAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
 
 function isValidTime(value: unknown): value is string {
   return typeof value === "string" && /^([01]?\d|2[0-3]):[0-5]\d$/.test(value.trim());
@@ -138,12 +146,12 @@ function errorText(body: unknown, status: number): string {
  *  current session's model (injected by pi-runtime), else the first available. */
 async function resolveModelId(
   explicit: string | undefined,
+  sessionModelId: string | null,
   signal: AbortSignal | undefined,
 ): Promise<string | null> {
   const trimmed = explicit?.trim();
   if (trimmed) return trimmed;
-  const envModel = process.env.LOCAL_STUDIO_MODEL_ID?.trim();
-  if (envModel) return envModel;
+  if (sessionModelId) return sessionModelId;
   const { ok, body } = await httpJson("/api/agent/models", { method: "GET" }, signal);
   if (!ok || !body || typeof body !== "object") return null;
   const models = (body as { models?: unknown }).models;
@@ -184,6 +192,7 @@ function describeScheduleLoose(schedule: ScheduleArg): string {
 }
 
 export default function automationsExtension(pi: ExtensionAPI): void {
+  const sessionModelId = process.env.LOCAL_STUDIO_MODEL_ID?.trim() || null;
   pi.registerTool({
     name: "schedule_automation",
     label: "Schedule automation",
@@ -202,9 +211,7 @@ export default function automationsExtension(pi: ExtensionAPI): void {
           ),
           minutes: Type.Optional(Type.Number({ description: "interval only: minutes, >= 1" })),
           time: Type.Optional(Type.String({ description: "daily/weekly only: 'HH:MM' 24h" })),
-          day: Type.Optional(
-            Type.Number({ description: "weekly only: 0-6, 0 = Sunday" }),
-          ),
+          day: Type.Optional(Type.Number({ description: "weekly only: 0-6, 0 = Sunday" })),
           weekdaysOnly: Type.Optional(
             Type.Boolean({ description: "daily only: skip Saturday/Sunday" }),
           ),
@@ -228,16 +235,16 @@ export default function automationsExtension(pi: ExtensionAPI): void {
         cwd?: string;
       };
       const prompt = typeof args.prompt === "string" ? args.prompt.trim() : "";
-      if (!prompt) return textResult("schedule_automation needs a non-empty prompt.", { failed: true });
+      if (!prompt)
+        return textResult("schedule_automation needs a non-empty prompt.", { failed: true });
       const scheduleResult = normalizeScheduleArg(args.schedule);
       if (!scheduleResult.ok) return textResult(scheduleResult.error, { failed: true });
       try {
-        const modelId = await resolveModelId(args.model, signal);
+        const modelId = await resolveModelId(args.model, sessionModelId, signal);
         if (!modelId) {
-          return textResult(
-            "No model available to run the automation. Pass a 'model' id.",
-            { failed: true },
-          );
+          return textResult("No model available to run the automation. Pass a 'model' id.", {
+            failed: true,
+          });
         }
         const { ok, status, body } = await httpJson(
           "/api/agent/automations",
@@ -254,11 +261,14 @@ export default function automationsExtension(pi: ExtensionAPI): void {
           },
           signal,
         );
-        if (!ok) return textResult(`Failed to create automation: ${errorText(body, status)}`, { failed: true });
+        if (!ok)
+          return textResult(`Failed to create automation: ${errorText(body, status)}`, {
+            failed: true,
+          });
         const automation = (body as { automation?: AutomationRecord }).automation ?? {};
         const id = typeof automation.id === "string" ? automation.id : "(unknown)";
         return textResult(
-          `Created automation "${typeof automation.name === "string" ? automation.name : args.name ?? "Untitled"}" [${id}] — ` +
+          `Created automation "${typeof automation.name === "string" ? automation.name : (args.name ?? "Untitled")}" [${id}] — ` +
             `${describeSchedule(scheduleResult.schedule)}. Next run ${typeof automation.nextRunAt === "string" ? automation.nextRunAt : "pending"}.`,
           { id, schedule: scheduleResult.schedule, modelId },
         );
@@ -281,11 +291,15 @@ export default function automationsExtension(pi: ExtensionAPI): void {
           { method: "GET" },
           signal,
         );
-        if (!ok) return textResult(`Failed to list automations: ${errorText(body, status)}`, { failed: true });
+        if (!ok)
+          return textResult(`Failed to list automations: ${errorText(body, status)}`, {
+            failed: true,
+          });
         const automations = Array.isArray((body as { automations?: unknown }).automations)
-          ? ((body as { automations: AutomationRecord[] }).automations)
+          ? (body as { automations: AutomationRecord[] }).automations
           : [];
-        if (automations.length === 0) return textResult("No automations are scheduled.", { count: 0 });
+        if (automations.length === 0)
+          return textResult("No automations are scheduled.", { count: 0 });
         const lines = automations.map(formatAutomationLine);
         return textResult(`${automations.length} automation(s):\n${lines.join("\n")}`, {
           count: automations.length,
@@ -305,7 +319,10 @@ export default function automationsExtension(pi: ExtensionAPI): void {
       id: Type.String({ description: "The automation id, e.g. 'auto-1a2b3c4d'." }),
     }),
     async execute(_id, params, signal) {
-      const id = typeof (params as { id?: unknown })?.id === "string" ? (params as { id: string }).id.trim() : "";
+      const id =
+        typeof (params as { id?: unknown })?.id === "string"
+          ? (params as { id: string }).id.trim()
+          : "";
       if (!id) return textResult("delete_automation needs an automation id.", { failed: true });
       try {
         const { ok, status, body } = await httpJson(
@@ -313,7 +330,10 @@ export default function automationsExtension(pi: ExtensionAPI): void {
           { method: "DELETE" },
           signal,
         );
-        if (!ok) return textResult(`Failed to delete automation: ${errorText(body, status)}`, { failed: true });
+        if (!ok)
+          return textResult(`Failed to delete automation: ${errorText(body, status)}`, {
+            failed: true,
+          });
         return textResult(`Deleted automation ${id}.`, { id });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/frontend/desktop/resources/pi-extensions/browser-session.test.ts
+++ b/frontend/desktop/resources/pi-extensions/browser-session.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { BROWSER_SESSION_HEADER } from "../../../../shared/agent/browser-session";
+import { browserExtensionConfig, callBrowserAction, type BrowserExtensionConfig } from "./browser";
+
+describe("Pi browser session transport", () => {
+  test("requires a configured session and canonical header", () => {
+    assert.throws(() => browserExtensionConfig({}));
+    assert.deepEqual(
+      browserExtensionConfig({
+        LOCAL_STUDIO_BROWSER_SESSION_HEADER: BROWSER_SESSION_HEADER,
+        LOCAL_STUDIO_BROWSER_SESSION_ID: "session-a",
+      }),
+      {
+        frontendBase: "http://127.0.0.1:3000",
+        sessionHeader: BROWSER_SESSION_HEADER,
+        sessionId: "session-a",
+        timeoutMs: 60_000,
+      },
+    );
+  });
+
+  test("sends the current session only in the canonical header", async () => {
+    const requests: Request[] = [];
+    const request: typeof fetch = (input, init) => {
+      requests.push(new Request(input, init));
+      return Promise.resolve(Response.json({ data: { url: "https://example.com" }, ok: true }));
+    };
+    const config = (sessionId: string): BrowserExtensionConfig => ({
+      frontendBase: "http://127.0.0.1:3000",
+      sessionHeader: BROWSER_SESSION_HEADER,
+      sessionId,
+      timeoutMs: 1_000,
+    });
+    await callBrowserAction(
+      config("session-a"),
+      "navigate",
+      { url: "https://example.com" },
+      undefined,
+      request,
+    );
+    await callBrowserAction(config("session-b"), "get-url", {}, undefined, request);
+    assert.equal(requests.length, 2);
+    assert.equal(requests[0]?.headers.get(BROWSER_SESSION_HEADER), "session-a");
+    assert.equal(requests[1]?.headers.get(BROWSER_SESSION_HEADER), "session-b");
+    assert.deepEqual(await requests[0]?.json(), { url: "https://example.com" });
+    assert.deepEqual(await requests[1]?.json(), {});
+  });
+});

--- a/frontend/desktop/resources/pi-extensions/browser.ts
+++ b/frontend/desktop/resources/pi-extensions/browser.ts
@@ -72,26 +72,29 @@ export async function callBrowserAction(
   const abort = () => controller.abort();
   signal?.addEventListener("abort", abort, { once: true });
   if (signal?.aborted) controller.abort();
-  const response = await request(`${config.frontendBase}/api/agent/browser/${verb}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json", [config.sessionHeader]: config.sessionId },
-    body: JSON.stringify(payload),
-    signal: controller.signal,
-  }).finally(() => {
+  try {
+    const response = await request(`${config.frontendBase}/api/agent/browser/${verb}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", [config.sessionHeader]: config.sessionId },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      const errBody = await response.text().catch(() => "");
+      throw new Error(`HTTP ${response.status} ${errBody}`);
+    }
+    const result = Schema.decodeUnknownSync(BrowserActionResponseSchema)(await response.json());
+    if (!result.ok) throw new Error(result.error || "browser bridge returned ok=false");
+    const text =
+      typeof result.data === "string" ? result.data : JSON.stringify(result.data, null, 2);
+    return {
+      content: [{ type: "text", text }],
+      details: { verb, payload, data: result.data },
+    };
+  } finally {
     clearTimeout(timeout);
     signal?.removeEventListener("abort", abort);
-  });
-  if (!response.ok) {
-    const errBody = await response.text().catch(() => "");
-    throw new Error(`HTTP ${response.status} ${errBody}`);
   }
-  const result = Schema.decodeUnknownSync(BrowserActionResponseSchema)(await response.json());
-  if (!result.ok) throw new Error(result.error || "browser bridge returned ok=false");
-  const text = typeof result.data === "string" ? result.data : JSON.stringify(result.data, null, 2);
-  return {
-    content: [{ type: "text", text }],
-    details: { verb, payload, data: result.data },
-  };
 }
 
 async function safeBrowserAction(

--- a/frontend/desktop/resources/pi-extensions/browser.ts
+++ b/frontend/desktop/resources/pi-extensions/browser.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Schema } from "effect";
 import { Type } from "typebox";
 
 type ToolResult = {
@@ -6,19 +7,46 @@ type ToolResult = {
   details: Record<string, unknown>;
 };
 
-const FRONTEND_BASE = process.env.LOCAL_STUDIO_FRONTEND_BASE ?? "http://127.0.0.1:3000";
-const BROWSER_SESSION_ID = process.env.LOCAL_STUDIO_BROWSER_SESSION_ID ?? "";
 const DEFAULT_BROWSER_TOOL_TIMEOUT_MS = 60_000;
+const BrowserActionResponseSchema = Schema.Struct({
+  ok: Schema.Boolean,
+  data: Schema.optional(Schema.Unknown),
+  error: Schema.optional(Schema.String),
+});
 
-function readTimeoutMs(name: string, fallback: number): number {
-  const value = Number(process.env[name]);
+function readTimeoutMs(
+  name: string,
+  fallback: number,
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const value = Number(env[name]);
   return Number.isFinite(value) && value > 0 ? Math.trunc(value) : fallback;
 }
 
-const BROWSER_TOOL_TIMEOUT_MS = readTimeoutMs(
-  "LOCAL_STUDIO_BROWSER_TOOL_TIMEOUT_MS",
-  DEFAULT_BROWSER_TOOL_TIMEOUT_MS,
-);
+export type BrowserExtensionConfig = {
+  frontendBase: string;
+  sessionHeader: string;
+  sessionId: string;
+  timeoutMs: number;
+};
+
+export function browserExtensionConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): BrowserExtensionConfig {
+  const sessionHeader = env.LOCAL_STUDIO_BROWSER_SESSION_HEADER ?? "";
+  const sessionId = env.LOCAL_STUDIO_BROWSER_SESSION_ID ?? "";
+  if (!sessionHeader || !sessionId) throw new Error("Browser session configuration is missing");
+  return {
+    frontendBase: env.LOCAL_STUDIO_FRONTEND_BASE ?? "http://127.0.0.1:3000",
+    sessionHeader,
+    sessionId,
+    timeoutMs: readTimeoutMs(
+      "LOCAL_STUDIO_BROWSER_TOOL_TIMEOUT_MS",
+      DEFAULT_BROWSER_TOOL_TIMEOUT_MS,
+      env,
+    ),
+  };
+}
 
 function failedToolResult(
   verb: string,
@@ -32,22 +60,22 @@ function failedToolResult(
   };
 }
 
-async function callBrowserAction(
+export async function callBrowserAction(
+  config: BrowserExtensionConfig,
   verb: string,
   payload: Record<string, unknown>,
   signal: AbortSignal | undefined,
+  request: typeof fetch = fetch,
 ): Promise<ToolResult> {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), BROWSER_TOOL_TIMEOUT_MS);
+  const timeout = setTimeout(() => controller.abort(), config.timeoutMs);
   const abort = () => controller.abort();
   signal?.addEventListener("abort", abort, { once: true });
   if (signal?.aborted) controller.abort();
-  const response = await fetch(`${FRONTEND_BASE}/api/agent/browser/${verb}`, {
+  const response = await request(`${config.frontendBase}/api/agent/browser/${verb}`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(
-      BROWSER_SESSION_ID ? { ...payload, sessionId: BROWSER_SESSION_ID } : payload,
-    ),
+    headers: { "Content-Type": "application/json", [config.sessionHeader]: config.sessionId },
+    body: JSON.stringify(payload),
     signal: controller.signal,
   }).finally(() => {
     clearTimeout(timeout);
@@ -57,7 +85,7 @@ async function callBrowserAction(
     const errBody = await response.text().catch(() => "");
     throw new Error(`HTTP ${response.status} ${errBody}`);
   }
-  const result = (await response.json()) as { ok: boolean; data?: unknown; error?: string };
+  const result = Schema.decodeUnknownSync(BrowserActionResponseSchema)(await response.json());
   if (!result.ok) throw new Error(result.error || "browser bridge returned ok=false");
   const text = typeof result.data === "string" ? result.data : JSON.stringify(result.data, null, 2);
   return {
@@ -67,18 +95,22 @@ async function callBrowserAction(
 }
 
 async function safeBrowserAction(
+  config: BrowserExtensionConfig,
   verb: string,
   payload: Record<string, unknown>,
   signal: AbortSignal | undefined,
 ): Promise<ToolResult> {
   try {
-    return await callBrowserAction(verb, payload, signal);
+    return await callBrowserAction(config, verb, payload, signal);
   } catch (error) {
     return failedToolResult(verb, payload, error);
   }
 }
 
 export default function registerBrowserExtension(pi: ExtensionAPI) {
+  const config = browserExtensionConfig();
+  const run = (verb: string, payload: Record<string, unknown>, signal: AbortSignal | undefined) =>
+    safeBrowserAction(config, verb, payload, signal);
   pi.registerTool({
     name: "browser_navigate",
     label: "Browser: Navigate",
@@ -88,7 +120,7 @@ export default function registerBrowserExtension(pi: ExtensionAPI) {
       url: Type.String({ description: "Absolute http(s) URL to load" }),
     }),
     async execute(_id, params, signal) {
-      return safeBrowserAction("navigate", { url: params.url }, signal);
+      return run("navigate", { url: params.url }, signal);
     },
   });
 
@@ -98,7 +130,7 @@ export default function registerBrowserExtension(pi: ExtensionAPI) {
     description: "Return the current URL of the embedded browser.",
     parameters: Type.Object({}),
     async execute(_id, _params, signal) {
-      return safeBrowserAction("get-url", {}, signal);
+      return run("get-url", {}, signal);
     },
   });
 
@@ -109,7 +141,7 @@ export default function registerBrowserExtension(pi: ExtensionAPI) {
       "Return the visible text of the current page (innerText of <body>). Use after navigating to read page contents.",
     parameters: Type.Object({}),
     async execute(_id, _params, signal) {
-      return safeBrowserAction("get-text", {}, signal);
+      return run("get-text", {}, signal);
     },
   });
 
@@ -120,7 +152,7 @@ export default function registerBrowserExtension(pi: ExtensionAPI) {
       "Return the rendered HTML of the current page. Useful when text alone isn't enough.",
     parameters: Type.Object({}),
     async execute(_id, _params, signal) {
-      return safeBrowserAction("get-html", {}, signal);
+      return run("get-html", {}, signal);
     },
   });
 
@@ -130,7 +162,7 @@ export default function registerBrowserExtension(pi: ExtensionAPI) {
     description: "Capture a PNG screenshot of the current page; returns a base64 data URI.",
     parameters: Type.Object({}),
     async execute(_id, _params, signal) {
-      return safeBrowserAction("screenshot", {}, signal);
+      return run("screenshot", {}, signal);
     },
   });
 
@@ -142,7 +174,7 @@ export default function registerBrowserExtension(pi: ExtensionAPI) {
       selector: Type.String({ description: "CSS selector for the element to click" }),
     }),
     async execute(_id, params, signal) {
-      return safeBrowserAction("click", { selector: params.selector }, signal);
+      return run("click", { selector: params.selector }, signal);
     },
   });
 
@@ -154,7 +186,7 @@ export default function registerBrowserExtension(pi: ExtensionAPI) {
       deltaY: Type.Number({ description: "Pixels to scroll vertically" }),
     }),
     async execute(_id, params, signal) {
-      return safeBrowserAction("scroll", { deltaY: params.deltaY }, signal);
+      return run("scroll", { deltaY: params.deltaY }, signal);
     },
   });
 
@@ -168,7 +200,7 @@ export default function registerBrowserExtension(pi: ExtensionAPI) {
       value: Type.String({ description: "Value to set" }),
     }),
     async execute(_id, params, signal) {
-      return safeBrowserAction("fill", { selector: params.selector, value: params.value }, signal);
+      return run("fill", { selector: params.selector, value: params.value }, signal);
     },
   });
 }

--- a/frontend/desktop/resources/pi-extensions/sitegeist-browser.test.ts
+++ b/frontend/desktop/resources/pi-extensions/sitegeist-browser.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { test } from "bun:test";
+import { relayCapabilities, type RelayConfig } from "./sitegeist-browser";
+
+test("sitegeist capability discovery releases a stalled runtime startup", async () => {
+  const config: RelayConfig = {
+    relayUrl: "http://127.0.0.1:7717",
+    sessionId: "session-a",
+    timeoutMs: 120_000,
+    token: "",
+  };
+  const request = ((_input: RequestInfo | URL, init?: RequestInit) =>
+    new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+    })) as typeof fetch;
+  const started = Date.now();
+  assert.equal(await relayCapabilities(config, request, 20), null);
+  assert.ok(Date.now() - started < 500);
+});
+
+test("sitegeist capability discovery times out a stalled response body", async () => {
+  const config: RelayConfig = {
+    relayUrl: "http://127.0.0.1:7717",
+    sessionId: "session-a",
+    timeoutMs: 120_000,
+    token: "",
+  };
+  const request = ((_input: RequestInfo | URL, init?: RequestInit) =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () =>
+        new Promise<unknown>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(new Error("aborted")), {
+            once: true,
+          });
+        }),
+    } as Response)) as typeof fetch;
+  assert.equal(await relayCapabilities(config, request, 20), null);
+});

--- a/frontend/desktop/resources/pi-extensions/sitegeist-browser.ts
+++ b/frontend/desktop/resources/pi-extensions/sitegeist-browser.ts
@@ -16,6 +16,7 @@ type ToolResult = {
 
 const DEFAULT_RELAY_URL = "http://127.0.0.1:7717";
 const DEFAULT_TIMEOUT_MS = 120_000;
+const CAPABILITIES_TIMEOUT_MS = 2_000;
 const RelayResponseSchema = Schema.Struct({
   result: Schema.optional(Schema.Unknown),
   error: Schema.optional(
@@ -29,7 +30,7 @@ const RelayCapabilitiesSchema = Schema.Struct({
   methods: Schema.optional(Schema.Array(Schema.String)),
 });
 
-type RelayConfig = {
+export type RelayConfig = {
   relayUrl: string;
   sessionId: string;
   timeoutMs: number;
@@ -54,9 +55,11 @@ async function callRelay(
   method: string,
   params: Record<string, unknown>,
   signal?: AbortSignal,
+  request: typeof fetch = fetch,
+  timeoutMs = config.timeoutMs,
 ): Promise<unknown> {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), config.timeoutMs);
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
   const abort = () => controller.abort();
   signal?.addEventListener("abort", abort, { once: true });
   if (signal?.aborted) controller.abort();
@@ -67,23 +70,25 @@ async function callRelay(
   };
   if (config.token) headers.Authorization = `Bearer ${config.token}`;
 
-  const response = await fetch(`${config.relayUrl}/rpc`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method, params }),
-    signal: controller.signal,
-  }).finally(() => {
+  try {
+    const response = await request(`${config.relayUrl}/rpc`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method, params }),
+      signal: controller.signal,
+    });
+
+    const body = Schema.decodeUnknownSync(RelayResponseSchema)(
+      await response.json().catch(() => ({})),
+    );
+    if (!response.ok || body.error) {
+      throw new Error(body.error?.message || `sitegeist relay HTTP ${response.status}`);
+    }
+    return body.result;
+  } finally {
     clearTimeout(timeout);
     signal?.removeEventListener("abort", abort);
-  });
-
-  const body = Schema.decodeUnknownSync(RelayResponseSchema)(
-    await response.json().catch(() => ({})),
-  );
-  if (!response.ok || body.error) {
-    throw new Error(body.error?.message || `sitegeist relay HTTP ${response.status}`);
   }
-  return body.result;
 }
 
 // Tool definitions: each maps a `sitegeist_*` tool to one relay method. `pick`
@@ -263,11 +268,22 @@ async function runTool(
   }
 }
 
-async function relayCapabilities(config: RelayConfig): Promise<Set<string> | null> {
+export async function relayCapabilities(
+  config: RelayConfig,
+  request: typeof fetch = fetch,
+  timeoutMs = CAPABILITIES_TIMEOUT_MS,
+): Promise<Set<string> | null> {
   try {
     const controller = new AbortController();
     const result = Schema.decodeUnknownSync(RelayCapabilitiesSchema)(
-      await callRelay(config, "relay.capabilities", {}, controller.signal),
+      await callRelay(
+        config,
+        "relay.capabilities",
+        {},
+        controller.signal,
+        request,
+        Math.min(config.timeoutMs, timeoutMs),
+      ),
     );
     return result.methods ? new Set(result.methods) : null;
   } catch {

--- a/frontend/desktop/resources/pi-extensions/sitegeist-browser.ts
+++ b/frontend/desktop/resources/pi-extensions/sitegeist-browser.ts
@@ -6,6 +6,7 @@
 // LOCAL_STUDIO_BROWSER_BACKEND=sitegeist while the browser tool toggle is on.
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Schema } from "effect";
 import { Type, type Static, type TSchema } from "typebox";
 
 type ToolResult = {
@@ -13,40 +14,60 @@ type ToolResult = {
   details: Record<string, unknown>;
 };
 
-type RelayResponse = { result?: unknown; error?: { code?: number; message?: string } };
-
 const DEFAULT_RELAY_URL = "http://127.0.0.1:7717";
 const DEFAULT_TIMEOUT_MS = 120_000;
+const RelayResponseSchema = Schema.Struct({
+  result: Schema.optional(Schema.Unknown),
+  error: Schema.optional(
+    Schema.Struct({
+      code: Schema.optional(Schema.Number),
+      message: Schema.optional(Schema.String),
+    }),
+  ),
+});
+const RelayCapabilitiesSchema = Schema.Struct({
+  methods: Schema.optional(Schema.Array(Schema.String)),
+});
 
-const RELAY_URL = (process.env.SITEGEIST_RELAY_URL || DEFAULT_RELAY_URL).replace(/\/+$/, "");
-const RELAY_TOKEN = process.env.SITEGEIST_RELAY_TOKEN ?? "";
-const RELAY_SESSION_ID =
-  process.env.SITEGEIST_RELAY_SESSION_ID ||
-  process.env.LOCAL_STUDIO_BROWSER_SESSION_ID ||
-  "default";
-const TIMEOUT_MS = (() => {
+type RelayConfig = {
+  relayUrl: string;
+  sessionId: string;
+  timeoutMs: number;
+  token: string;
+};
+
+function relayConfig(): RelayConfig {
+  const sessionId =
+    process.env.SITEGEIST_RELAY_SESSION_ID || process.env.LOCAL_STUDIO_BROWSER_SESSION_ID || "";
+  if (!sessionId) throw new Error("Sitegeist browser session configuration is missing");
   const value = Number(process.env.SITEGEIST_RELAY_TOOL_TIMEOUT_MS);
-  return Number.isFinite(value) && value > 0 ? Math.trunc(value) : DEFAULT_TIMEOUT_MS;
-})();
+  return {
+    relayUrl: (process.env.SITEGEIST_RELAY_URL || DEFAULT_RELAY_URL).replace(/\/+$/, ""),
+    sessionId,
+    timeoutMs: Number.isFinite(value) && value > 0 ? Math.trunc(value) : DEFAULT_TIMEOUT_MS,
+    token: process.env.SITEGEIST_RELAY_TOKEN ?? "",
+  };
+}
 
 async function callRelay(
+  config: RelayConfig,
   method: string,
   params: Record<string, unknown>,
   signal?: AbortSignal,
 ): Promise<unknown> {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  const timeout = setTimeout(() => controller.abort(), config.timeoutMs);
   const abort = () => controller.abort();
   signal?.addEventListener("abort", abort, { once: true });
   if (signal?.aborted) controller.abort();
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
-    "X-Sitegeist-Session": RELAY_SESSION_ID,
+    "X-Sitegeist-Session": config.sessionId,
   };
-  if (RELAY_TOKEN) headers.Authorization = `Bearer ${RELAY_TOKEN}`;
+  if (config.token) headers.Authorization = `Bearer ${config.token}`;
 
-  const response = await fetch(`${RELAY_URL}/rpc`, {
+  const response = await fetch(`${config.relayUrl}/rpc`, {
     method: "POST",
     headers,
     body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method, params }),
@@ -56,7 +77,9 @@ async function callRelay(
     signal?.removeEventListener("abort", abort);
   });
 
-  const body = (await response.json().catch(() => ({}))) as RelayResponse;
+  const body = Schema.decodeUnknownSync(RelayResponseSchema)(
+    await response.json().catch(() => ({})),
+  );
   if (!response.ok || body.error) {
     throw new Error(body.error?.message || `sitegeist relay HTTP ${response.status}`);
   }
@@ -211,19 +234,25 @@ const TOOLS = [
   }),
 ] as const;
 
+type RunToolInput = {
+  name: string;
+  method: string;
+  params: Record<string, unknown>;
+  rpcParams: Record<string, unknown>;
+};
+
 async function runTool(
-  name: string,
-  method: string,
-  params: Record<string, unknown>,
-  rpcParams: Record<string, unknown>,
+  config: RelayConfig,
+  input: RunToolInput,
   signal?: AbortSignal,
 ): Promise<ToolResult> {
+  const { method, name, params, rpcParams } = input;
   try {
-    const result = await callRelay(method, rpcParams, signal);
+    const result = await callRelay(config, method, rpcParams, signal);
     const text = typeof result === "string" ? result : JSON.stringify(result, null, 2);
     return {
       content: [{ type: "text", text }],
-      details: { method, params, data: result, relaySessionId: RELAY_SESSION_ID },
+      details: { method, params, data: result, relaySessionId: config.sessionId },
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -234,14 +263,13 @@ async function runTool(
   }
 }
 
-async function relayCapabilities(): Promise<Set<string> | null> {
+async function relayCapabilities(config: RelayConfig): Promise<Set<string> | null> {
   try {
     const controller = new AbortController();
-    const result = await callRelay("relay.capabilities", {}, controller.signal);
-    const methods = (result as { methods?: unknown })?.methods;
-    return Array.isArray(methods)
-      ? new Set(methods.filter((m): m is string => typeof m === "string"))
-      : null;
+    const result = Schema.decodeUnknownSync(RelayCapabilitiesSchema)(
+      await callRelay(config, "relay.capabilities", {}, controller.signal),
+    );
+    return result.methods ? new Set(result.methods) : null;
   } catch {
     return null;
   }
@@ -251,7 +279,8 @@ export default async function registerSitegeistBrowserExtension(pi: ExtensionAPI
   // Capability discovery: register only the tools the connected extension
   // implements. If discovery fails (relay down), register everything and let
   // each call surface the relay error.
-  const supported = await relayCapabilities();
+  const config = relayConfig();
+  const supported = await relayCapabilities(config);
 
   for (const tool of TOOLS) {
     if (supported && !supported.has(tool.method)) continue;
@@ -262,7 +291,16 @@ export default async function registerSitegeistBrowserExtension(pi: ExtensionAPI
       parameters: tool.parameters,
       execute(_id, params, signal) {
         const args = params as Record<string, unknown>;
-        return runTool(tool.name, tool.method, args, tool.pick(params as never), signal);
+        return runTool(
+          config,
+          {
+            name: tool.name,
+            method: tool.method,
+            params: args,
+            rpcParams: tool.pick(params as never),
+          },
+          signal,
+        );
       },
     });
   }

--- a/frontend/src/features/agent/browser/session-request.test.ts
+++ b/frontend/src/features/agent/browser/session-request.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { BROWSER_SESSION_HEADER } from "@shared/agent/browser-session";
+import { browserSessionRequest } from "@/features/agent/browser/session-request";
+
+describe("browser session requests", () => {
+  test("does not create a stateful request without a focused session", () => {
+    assert.equal(browserSessionRequest(null, "frame"), null);
+  });
+
+  test("replaces the canonical header when the focused session changes", () => {
+    const first = browserSessionRequest("session-a", "navigate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+    const second = browserSessionRequest("session-b", "navigate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+    assert.ok(first);
+    assert.ok(second);
+    assert.equal(first.input, "/api/agent/browser/navigate");
+    assert.equal(new Headers(first.init.headers).get(BROWSER_SESSION_HEADER), "session-a");
+    assert.equal(new Headers(second.init.headers).get(BROWSER_SESSION_HEADER), "session-b");
+    assert.equal(new Headers(second.init.headers).get("Content-Type"), "application/json");
+  });
+});

--- a/frontend/src/features/agent/browser/session-request.ts
+++ b/frontend/src/features/agent/browser/session-request.ts
@@ -1,0 +1,20 @@
+import { BROWSER_SESSION_HEADER, type BrowserSessionKey } from "@shared/agent/browser-session";
+
+export type BrowserSessionRequest = {
+  input: string;
+  init: RequestInit;
+};
+
+export function browserSessionRequest(
+  sessionId: BrowserSessionKey | null,
+  path: string,
+  init: RequestInit = {},
+): BrowserSessionRequest | null {
+  if (!sessionId) return null;
+  const headers = new Headers(init.headers);
+  headers.set(BROWSER_SESSION_HEADER, sessionId);
+  return {
+    input: `/api/agent/browser/${path}`,
+    init: { ...init, headers },
+  };
+}

--- a/frontend/src/features/agent/browser/session-surface.test.ts
+++ b/frontend/src/features/agent/browser/session-surface.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { BrowserSessionSurface } from "@/features/agent/browser/session-surface";
+
+test("switching sessions aborts old traffic without replaying the inherited URL", () => {
+  const surface = new BrowserSessionSurface();
+  surface.enterSession("session-a", "https://a.example");
+  const frameA = surface.requestController("session-a");
+  const navigationA = surface.requestController("session-a");
+  assert.ok(frameA);
+  assert.ok(navigationA);
+  surface.observeServerUrl("session-a", "https://a.example");
+  assert.equal(surface.syncViewport("session-a", { height: 600, width: 800 }), true);
+  assert.equal(surface.syncViewport("session-a", { height: 600, width: 800 }), false);
+
+  surface.enterSession("session-b", "https://a.example");
+
+  assert.equal(frameA.signal.aborted, true);
+  assert.equal(navigationA.signal.aborted, true);
+  assert.equal(surface.requestController("session-a"), null);
+  assert.equal(surface.navigationTarget("session-b", "https://a.example"), null);
+  assert.equal(surface.syncViewport("session-b", { height: 600, width: 800 }), true);
+  assert.deepEqual(surface.viewport(), { height: 600, width: 800 });
+
+  surface.observeServerUrl("session-b", "https://b.example");
+  assert.equal(surface.navigationTarget("session-b", "https://b.example"), null);
+  assert.equal(
+    surface.navigationTarget("session-b", "https://next.example"),
+    "https://next.example",
+  );
+});

--- a/frontend/src/features/agent/browser/session-surface.test.ts
+++ b/frontend/src/features/agent/browser/session-surface.test.ts
@@ -1,10 +1,17 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  browserFrameResponseAction,
   browserFrameSource,
   browserSurfaceRequest,
   BrowserSessionSurface,
 } from "@/features/agent/browser/session-surface";
+
+test("transient frame responses retry while true unavailability stops polling", () => {
+  assert.equal(browserFrameResponseAction(200), "read");
+  assert.equal(browserFrameResponseAction(502), "retry");
+  assert.equal(browserFrameResponseAction(503), "unavailable");
+});
 
 test("a previous session frame is hidden before the new poll settles", () => {
   const frame = { sessionId: "session-a", src: "data:image/jpeg;base64,a" };

--- a/frontend/src/features/agent/browser/session-surface.test.ts
+++ b/frontend/src/features/agent/browser/session-surface.test.ts
@@ -43,10 +43,7 @@ test("switching sessions aborts old traffic without replaying the inherited URL"
 
   surface.observeServerUrl("session-b", "https://b.example");
   assert.equal(surface.navigationTarget("session-b", "https://b.example"), null);
-  assert.equal(
-    surface.navigationTarget("session-b", "https://a.example"),
-    "https://a.example",
-  );
+  assert.equal(surface.navigationTarget("session-b", "https://a.example"), "https://a.example");
   assert.equal(
     surface.navigationTarget("session-b", "https://next.example"),
     "https://next.example",
@@ -62,4 +59,16 @@ test("disposing a keyed surface aborts pending session traffic", () => {
   assert.equal(input.controller.signal.aborted, true);
   assert.equal(surface.ownsSession("session-a"), false);
   surface.dispose();
+});
+
+test("reattaching a keyed surface restores traffic after a Strict Mode ref cleanup", () => {
+  const surface = new BrowserSessionSurface("session-a", "https://a.example");
+  const first = surface.requestController("session-a");
+  assert.ok(first);
+  surface.dispose();
+  assert.equal(first.signal.aborted, true);
+  assert.equal(surface.requestController("session-a"), null);
+  surface.attach();
+  assert.ok(surface.requestController("session-a"));
+  assert.equal(surface.navigationTarget("session-a", "https://a.example"), null);
 });

--- a/frontend/src/features/agent/browser/session-surface.test.ts
+++ b/frontend/src/features/agent/browser/session-surface.test.ts
@@ -1,14 +1,29 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { BrowserSessionSurface } from "@/features/agent/browser/session-surface";
+import {
+  browserFrameSource,
+  browserSurfaceRequest,
+  BrowserSessionSurface,
+} from "@/features/agent/browser/session-surface";
+
+test("a previous session frame is hidden before the new poll settles", () => {
+  const frame = { sessionId: "session-a", src: "data:image/jpeg;base64,a" };
+  assert.equal(browserFrameSource(frame, "session-a"), frame.src);
+  assert.equal(browserFrameSource(frame, "session-b"), null);
+  assert.equal(browserFrameSource(frame, null), null);
+});
 
 test("switching sessions aborts old traffic without replaying the inherited URL", () => {
   const surface = new BrowserSessionSurface();
   surface.enterSession("session-a", "https://a.example");
   const frameA = surface.requestController("session-a");
   const navigationA = surface.requestController("session-a");
+  const inputA = browserSurfaceRequest(surface, "session-a", "input", { method: "POST" });
+  const viewportA = browserSurfaceRequest(surface, "session-a", "viewport", { method: "POST" });
   assert.ok(frameA);
   assert.ok(navigationA);
+  assert.ok(inputA);
+  assert.ok(viewportA);
   surface.observeServerUrl("session-a", "https://a.example");
   assert.equal(surface.syncViewport("session-a", { height: 600, width: 800 }), true);
   assert.equal(surface.syncViewport("session-a", { height: 600, width: 800 }), false);
@@ -17,6 +32,10 @@ test("switching sessions aborts old traffic without replaying the inherited URL"
 
   assert.equal(frameA.signal.aborted, true);
   assert.equal(navigationA.signal.aborted, true);
+  assert.equal(inputA.controller.signal.aborted, true);
+  assert.equal(viewportA.controller.signal.aborted, true);
+  assert.equal(surface.ownsSession("session-a"), false);
+  assert.equal(surface.ownsSession("session-b"), true);
   assert.equal(surface.requestController("session-a"), null);
   assert.equal(surface.navigationTarget("session-b", "https://a.example"), null);
   assert.equal(surface.syncViewport("session-b", { height: 600, width: 800 }), true);
@@ -25,7 +44,22 @@ test("switching sessions aborts old traffic without replaying the inherited URL"
   surface.observeServerUrl("session-b", "https://b.example");
   assert.equal(surface.navigationTarget("session-b", "https://b.example"), null);
   assert.equal(
+    surface.navigationTarget("session-b", "https://a.example"),
+    "https://a.example",
+  );
+  assert.equal(
     surface.navigationTarget("session-b", "https://next.example"),
     "https://next.example",
   );
+});
+
+test("disposing a keyed surface aborts pending session traffic", () => {
+  const surface = new BrowserSessionSurface();
+  surface.enterSession("session-a", "https://a.example");
+  const input = browserSurfaceRequest(surface, "session-a", "input", { method: "POST" });
+  assert.ok(input);
+  surface.dispose();
+  assert.equal(input.controller.signal.aborted, true);
+  assert.equal(surface.ownsSession("session-a"), false);
+  surface.dispose();
 });

--- a/frontend/src/features/agent/browser/session-surface.ts
+++ b/frontend/src/features/agent/browser/session-surface.ts
@@ -25,6 +25,11 @@ export class BrowserSessionSurface {
   private viewportState = DEFAULT_VIEWPORT;
   private viewportSessionId: string | null = null;
 
+  constructor(sessionId: string | null = null, desiredUrl = "") {
+    this.sessionId = sessionId;
+    this.inheritedUrl = desiredUrl.trim();
+  }
+
   enterSession(sessionId: string | null, desiredUrl: string): void {
     if (this.sessionId === sessionId) return;
     this.abortRequests();

--- a/frontend/src/features/agent/browser/session-surface.ts
+++ b/frontend/src/features/agent/browser/session-surface.ts
@@ -8,6 +8,11 @@ export type BrowserSurfaceRequest = {
   input: string;
 };
 
+export function browserFrameResponseAction(status: number): "read" | "retry" | "unavailable" {
+  if (status === 503) return "unavailable";
+  return status >= 200 && status < 300 ? "read" : "retry";
+}
+
 export function browserFrameSource(
   frame: BrowserSessionFrame | null,
   sessionId: string | null,

--- a/frontend/src/features/agent/browser/session-surface.ts
+++ b/frontend/src/features/agent/browser/session-surface.ts
@@ -1,0 +1,65 @@
+export type BrowserViewport = { height: number; width: number };
+
+const DEFAULT_VIEWPORT: BrowserViewport = { height: 800, width: 1280 };
+
+export class BrowserSessionSurface {
+  private readonly controllers = new Set<AbortController>();
+  private inheritedUrl = "";
+  private serverUrl = "";
+  private sessionId: string | null = null;
+  private viewportState = DEFAULT_VIEWPORT;
+  private viewportSessionId: string | null = null;
+
+  enterSession(sessionId: string | null, desiredUrl: string): void {
+    if (this.sessionId === sessionId) return;
+    this.abortRequests();
+    this.sessionId = sessionId;
+    this.inheritedUrl = desiredUrl.trim();
+    this.serverUrl = "";
+    this.viewportState = DEFAULT_VIEWPORT;
+    this.viewportSessionId = null;
+  }
+
+  requestController(sessionId: string | null): AbortController | null {
+    if (!sessionId || sessionId !== this.sessionId) return null;
+    const controller = new AbortController();
+    this.controllers.add(controller);
+    return controller;
+  }
+
+  releaseRequest(controller: AbortController): void {
+    this.controllers.delete(controller);
+  }
+
+  observeServerUrl(sessionId: string, url: string): void {
+    if (sessionId === this.sessionId) this.serverUrl = url;
+  }
+
+  navigationTarget(sessionId: string | null, desiredUrl: string): string | null {
+    const target = desiredUrl.trim();
+    if (!sessionId || sessionId !== this.sessionId || !target || target === this.serverUrl) {
+      return null;
+    }
+    return target === this.inheritedUrl ? null : target;
+  }
+
+  syncViewport(sessionId: string, viewport: BrowserViewport): boolean {
+    if (sessionId !== this.sessionId) return false;
+    const changed =
+      this.viewportSessionId !== sessionId ||
+      viewport.width !== this.viewportState.width ||
+      viewport.height !== this.viewportState.height;
+    this.viewportState = viewport;
+    this.viewportSessionId = sessionId;
+    return changed;
+  }
+
+  viewport(): BrowserViewport {
+    return this.viewportState;
+  }
+
+  private abortRequests(): void {
+    for (const controller of this.controllers) controller.abort();
+    this.controllers.clear();
+  }
+}

--- a/frontend/src/features/agent/browser/session-surface.ts
+++ b/frontend/src/features/agent/browser/session-surface.ts
@@ -1,4 +1,19 @@
+import { browserSessionRequest } from "@/features/agent/browser/session-request";
+
 export type BrowserViewport = { height: number; width: number };
+export type BrowserSessionFrame = { sessionId: string; src: string };
+export type BrowserSurfaceRequest = {
+  controller: AbortController;
+  init: RequestInit;
+  input: string;
+};
+
+export function browserFrameSource(
+  frame: BrowserSessionFrame | null,
+  sessionId: string | null,
+): string | null {
+  return frame?.sessionId === sessionId ? frame.src : null;
+}
 
 const DEFAULT_VIEWPORT: BrowserViewport = { height: 800, width: 1280 };
 
@@ -27,6 +42,10 @@ export class BrowserSessionSurface {
     return controller;
   }
 
+  ownsSession(sessionId: string | null): boolean {
+    return Boolean(sessionId && sessionId === this.sessionId);
+  }
+
   releaseRequest(controller: AbortController): void {
     this.controllers.delete(controller);
   }
@@ -40,7 +59,11 @@ export class BrowserSessionSurface {
     if (!sessionId || sessionId !== this.sessionId || !target || target === this.serverUrl) {
       return null;
     }
-    return target === this.inheritedUrl ? null : target;
+    if (target === this.inheritedUrl) {
+      this.inheritedUrl = "";
+      return null;
+    }
+    return target;
   }
 
   syncViewport(sessionId: string, viewport: BrowserViewport): boolean {
@@ -58,8 +81,32 @@ export class BrowserSessionSurface {
     return this.viewportState;
   }
 
+  dispose(): void {
+    this.abortRequests();
+    this.sessionId = null;
+  }
+
   private abortRequests(): void {
     for (const controller of this.controllers) controller.abort();
     this.controllers.clear();
   }
+}
+
+export function browserSurfaceRequest(
+  surface: BrowserSessionSurface,
+  sessionId: string | null,
+  path: string,
+  init: RequestInit = {},
+): BrowserSurfaceRequest | null {
+  const controller = surface.requestController(sessionId);
+  if (!controller) return null;
+  const request = browserSessionRequest(sessionId, path, {
+    ...init,
+    signal: controller.signal,
+  });
+  if (!request) {
+    surface.releaseRequest(controller);
+    return null;
+  }
+  return { ...request, controller };
 }

--- a/frontend/src/features/agent/browser/session-surface.ts
+++ b/frontend/src/features/agent/browser/session-surface.ts
@@ -18,6 +18,8 @@ export function browserFrameSource(
 const DEFAULT_VIEWPORT: BrowserViewport = { height: 800, width: 1280 };
 
 export class BrowserSessionSurface {
+  private readonly configuredSessionId: string | null;
+  private readonly configuredUrl: string;
   private readonly controllers = new Set<AbortController>();
   private inheritedUrl = "";
   private serverUrl = "";
@@ -26,8 +28,14 @@ export class BrowserSessionSurface {
   private viewportSessionId: string | null = null;
 
   constructor(sessionId: string | null = null, desiredUrl = "") {
+    this.configuredSessionId = sessionId;
+    this.configuredUrl = desiredUrl;
     this.sessionId = sessionId;
     this.inheritedUrl = desiredUrl.trim();
+  }
+
+  attach(): void {
+    this.enterSession(this.configuredSessionId, this.configuredUrl);
   }
 
   enterSession(sessionId: string | null, desiredUrl: string): void {

--- a/frontend/src/features/agent/tools/context.tsx
+++ b/frontend/src/features/agent/tools/context.tsx
@@ -33,6 +33,7 @@ import {
 import {
   clampComputerWidth,
   computerPanelVisibility,
+  DEFAULT_BROWSER_URL,
   loadBrowserState,
   loadComputerState,
   migrateToolStorage,
@@ -45,6 +46,7 @@ import {
 } from "@/features/agent/tools/persistence";
 import { useMountSubscription } from "@/hooks/use-mount-subscription";
 import {
+  browserSessionView,
   computerSessionView,
   patchSessionView,
   readSessionView,
@@ -61,14 +63,15 @@ type ToolsActions = {
   setBrowserBackend: (backend: BrowserBackend) => void;
   toggleBrowserBackend: () => void;
   toggleBrowser: () => void;
-  setBrowserUrl: (url: string, input?: string) => void;
-  setBrowserInput: (input: string) => void;
+  setBrowserUrl: (url: string, input?: string, sessionId?: SessionId | null) => void;
+  setBrowserInput: (input: string, sessionId?: SessionId | null) => void;
   setComputerOpen: (open: boolean) => void;
   toggleComputerOpen: () => void;
   setComputerTab: (tab: ComputerTab) => void;
   selectComputerTabWithoutOpening: (tab: ComputerTab) => void;
   closeComputerTab: (tab: ComputerTab) => void;
   setComputerWidth: (width: number) => void;
+  setActiveBrowserSession: (sessionId: SessionId | null) => void;
   setActiveComputerSession: (identity: SessionViewIdentity | null) => void;
   requestFileOpen: (path: string) => void;
   requestContextAttach: (request: { label: string; path?: string; content: string }) => void;
@@ -143,7 +146,7 @@ function LazyToolsEffectsBridge(props: ToolsEffectsBridgeProps) {
 
 function buildInitialBrowser(): BrowserState {
   if (typeof window === "undefined") {
-    return { enabled: false, backend: "embedded", url: "", input: "" };
+    return { enabled: false, backend: "embedded", sessionId: null, url: "", input: "" };
   }
   migrateToolStorage();
   return loadBrowserState();
@@ -166,6 +169,7 @@ export function ToolsProvider({ children }: { children: ReactNode }) {
   const catalogueEnabled = pathname === "/agent" || pathname === "/quick";
   const [browser, setBrowser] = useState<BrowserState>(() => buildInitialBrowser());
   const [computer, setComputer] = useState<ComputerState>(() => buildInitialComputer());
+  const activeBrowserSessionRef = useRef<SessionId | null>(null);
   const activeComputerSessionRef = useRef<SessionViewIdentity | null>(null);
   const [fileOpenRequest, setFileOpenRequest] = useState<FileOpenRequest | null>(null);
   const [contextAttachRequest, setContextAttachRequest] = useState<ContextAttachRequest | null>(
@@ -228,18 +232,55 @@ export function ToolsProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
-  const setBrowserUrl = useCallback((url: string, input?: string) => {
-    if (typeof url !== "string" || !url.trim()) return;
-    setBrowser((current) => ({
-      ...current,
-      url,
-      input: input ?? current.input,
-    }));
+  const setBrowserUrl = useCallback(
+    (url: string, input?: string, sessionId?: SessionId | null) => {
+      if (typeof url !== "string" || !url.trim()) return;
+      const owner = sessionId === undefined ? activeBrowserSessionRef.current : sessionId;
+      if (!owner) return;
+      setBrowser((current) => {
+        if (current.sessionId !== owner) return current;
+        const next = { url, input: input ?? current.input };
+        patchSessionView(window.localStorage, { key: owner, aliases: [] }, { browser: next });
+        return { ...current, ...next };
+      });
+    },
+    [],
+  );
+
+  const setBrowserInput = useCallback((input: string, sessionId?: SessionId | null) => {
+    if (typeof input !== "string") return;
+    const owner = sessionId === undefined ? activeBrowserSessionRef.current : sessionId;
+    if (!owner) return;
+    setBrowser((current) => {
+      if (current.sessionId !== owner) return current;
+      const previous = current;
+      const next = { input, url: previous.url };
+      patchSessionView(window.localStorage, { key: owner, aliases: [] }, { browser: next });
+      return { ...current, ...next };
+    });
   }, []);
 
-  const setBrowserInput = useCallback((input: string) => {
-    if (typeof input !== "string") return;
-    setBrowser((current) => ({ ...current, input }));
+  const setActiveBrowserSession = useCallback((sessionId: SessionId | null) => {
+    if (activeBrowserSessionRef.current === sessionId) return;
+    activeBrowserSessionRef.current = sessionId;
+    setBrowser((current) => {
+      if (current.sessionId) {
+        patchSessionView(
+          window.localStorage,
+          { key: current.sessionId, aliases: [] },
+          { browser: browserSessionView(current) },
+        );
+      }
+      const view = sessionId
+        ? readSessionView(window.localStorage, { key: sessionId, aliases: [] })?.browser
+        : null;
+      return {
+        ...current,
+        sessionId,
+        input: view?.input ?? DEFAULT_BROWSER_URL,
+        url: view?.url ?? DEFAULT_BROWSER_URL,
+      };
+    });
   }, []);
 
   const setComputerOpen = useCallback(
@@ -435,6 +476,7 @@ export function ToolsProvider({ children }: { children: ReactNode }) {
       selectComputerTabWithoutOpening,
       closeComputerTab,
       setComputerWidth,
+      setActiveBrowserSession,
       setActiveComputerSession,
       requestFileOpen,
       requestContextAttach,
@@ -454,6 +496,7 @@ export function ToolsProvider({ children }: { children: ReactNode }) {
       selectComputerTabWithoutOpening,
       closeComputerTab,
       setComputerWidth,
+      setActiveBrowserSession,
       setActiveComputerSession,
       requestFileOpen,
       requestContextAttach,

--- a/frontend/src/features/agent/tools/context.tsx
+++ b/frontend/src/features/agent/tools/context.tsx
@@ -46,7 +46,6 @@ import {
 } from "@/features/agent/tools/persistence";
 import { useMountSubscription } from "@/hooks/use-mount-subscription";
 import {
-  browserSessionView,
   computerSessionView,
   patchSessionView,
   readSessionView,
@@ -232,30 +231,28 @@ export function ToolsProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
-  const setBrowserUrl = useCallback(
-    (url: string, input?: string, sessionId?: SessionId | null) => {
-      if (typeof url !== "string" || !url.trim()) return;
-      const owner = sessionId === undefined ? activeBrowserSessionRef.current : sessionId;
-      if (!owner) return;
-      setBrowser((current) => {
-        if (current.sessionId !== owner) return current;
-        const next = { url, input: input ?? current.input };
-        patchSessionView(window.localStorage, { key: owner, aliases: [] }, { browser: next });
-        return { ...current, ...next };
-      });
-    },
-    [],
-  );
+  const setBrowserUrl = useCallback((url: string, input?: string, sessionId?: SessionId | null) => {
+    if (typeof url !== "string" || !url.trim()) return;
+    const owner = sessionId === undefined ? activeBrowserSessionRef.current : sessionId;
+    if (!owner) return;
+    const previous = readSessionView(window.localStorage, { key: owner, aliases: [] })?.browser;
+    const next = { url, input: input ?? previous?.input ?? DEFAULT_BROWSER_URL };
+    patchSessionView(window.localStorage, { key: owner, aliases: [] }, { browser: next });
+    setBrowser((current) => {
+      if (current.sessionId !== owner) return current;
+      return { ...current, ...next };
+    });
+  }, []);
 
   const setBrowserInput = useCallback((input: string, sessionId?: SessionId | null) => {
     if (typeof input !== "string") return;
     const owner = sessionId === undefined ? activeBrowserSessionRef.current : sessionId;
     if (!owner) return;
+    const previous = readSessionView(window.localStorage, { key: owner, aliases: [] })?.browser;
+    const next = { input, url: previous?.url ?? DEFAULT_BROWSER_URL };
+    patchSessionView(window.localStorage, { key: owner, aliases: [] }, { browser: next });
     setBrowser((current) => {
       if (current.sessionId !== owner) return current;
-      const previous = current;
-      const next = { input, url: previous.url };
-      patchSessionView(window.localStorage, { key: owner, aliases: [] }, { browser: next });
       return { ...current, ...next };
     });
   }, []);
@@ -263,17 +260,10 @@ export function ToolsProvider({ children }: { children: ReactNode }) {
   const setActiveBrowserSession = useCallback((sessionId: SessionId | null) => {
     if (activeBrowserSessionRef.current === sessionId) return;
     activeBrowserSessionRef.current = sessionId;
+    const view = sessionId
+      ? readSessionView(window.localStorage, { key: sessionId, aliases: [] })?.browser
+      : null;
     setBrowser((current) => {
-      if (current.sessionId) {
-        patchSessionView(
-          window.localStorage,
-          { key: current.sessionId, aliases: [] },
-          { browser: browserSessionView(current) },
-        );
-      }
-      const view = sessionId
-        ? readSessionView(window.localStorage, { key: sessionId, aliases: [] })?.browser
-        : null;
       return {
         ...current,
         sessionId,

--- a/frontend/src/features/agent/tools/persistence.ts
+++ b/frontend/src/features/agent/tools/persistence.ts
@@ -115,6 +115,7 @@ export function loadBrowserState(): BrowserState {
   return {
     enabled: read(BROWSER_TOOL_KEY) === "1",
     backend: parseBrowserBackend(read(BROWSER_BACKEND_KEY)),
+    sessionId: null,
     url: DEFAULT_BROWSER_URL,
     input: DEFAULT_BROWSER_URL,
   };

--- a/frontend/src/features/agent/tools/types.ts
+++ b/frontend/src/features/agent/tools/types.ts
@@ -32,6 +32,7 @@ export type BrowserBackend = "embedded" | "sitegeist";
 export type BrowserState = {
   enabled: boolean;
   backend: BrowserBackend;
+  sessionId: SessionId | null;
   url: string;
   input: string;
 };

--- a/frontend/src/features/agent/ui/agent-browser-effects.ts
+++ b/frontend/src/features/agent/ui/agent-browser-effects.ts
@@ -1,4 +1,5 @@
 import { useMountSubscription } from "@/hooks/use-mount-subscription";
+import { browserSessionRequest } from "@/features/agent/browser/session-request";
 
 export type LocalhostSite = {
   port: number;
@@ -72,17 +73,26 @@ const LIVE_STATE_POLL_MS = 2_000;
 
 export function useBrowserLiveStateSync({
   enabled,
+  sessionId,
   onLiveUrl,
 }: {
   enabled: boolean;
+  sessionId: string | null;
   onLiveUrl: (url: string) => void;
 }): void {
   useMountSubscription(() => {
-    if (!enabled) return;
+    if (!enabled || !sessionId) return;
     let cancelled = false;
+    const controller = new AbortController();
     const poll = async () => {
       try {
-        const response = await fetch("/api/agent/browser/state", { cache: "no-store" });
+        const request = browserSessionRequest(sessionId, "state", {
+          cache: "no-store",
+          signal: controller.signal,
+        });
+        if (!request) return;
+        const response = await fetch(request.input, request.init);
+        if (!response.ok) return;
         const payload = (await response.json()) as { ok?: boolean; data?: { url?: string } };
         const liveUrl = payload.ok ? (payload.data?.url ?? "") : "";
         if (!cancelled && liveUrl && liveUrl !== "about:blank") onLiveUrl(liveUrl);
@@ -94,7 +104,8 @@ export function useBrowserLiveStateSync({
     const timer = setInterval(() => void poll(), LIVE_STATE_POLL_MS);
     return () => {
       cancelled = true;
+      controller.abort();
       clearInterval(timer);
     };
-  }, [enabled, onLiveUrl]);
+  }, [enabled, onLiveUrl, sessionId]);
 }

--- a/frontend/src/features/agent/ui/agent-browser-panel.tsx
+++ b/frontend/src/features/agent/ui/agent-browser-panel.tsx
@@ -29,6 +29,7 @@ import {
   sanitizeBrowserPaneUrl,
   sanitizeLocalFileUrl,
 } from "@/features/agent/sanitize-embedded-browser-url";
+import { browserSessionRequest } from "@/features/agent/browser/session-request";
 import { useTools } from "@/features/agent/tools/context";
 import type { ComputerTab } from "@/features/agent/tools/types";
 import type { GitSummary, Project } from "@/features/agent/projects/types";
@@ -173,11 +174,13 @@ export function AgentBrowserPanel({
     if (!accepted) return;
     tools.setBrowserUrl(accepted, accepted);
     if (/^file:\/\//i.test(accepted)) return;
-    void fetch("/api/agent/browser/navigate", {
+    const request = browserSessionRequest(focusedSession?.id ?? null, "navigate", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ url: accepted }),
-    }).catch(() => undefined);
+    });
+    if (!request) return;
+    void fetch(request.input, request.init).catch(() => undefined);
   };
   const openSideChat = useCallback(() => {
     handles.updateDetachedSession(sideChatSeed, (current) =>

--- a/frontend/src/features/agent/ui/agent-browser-panel.tsx
+++ b/frontend/src/features/agent/ui/agent-browser-panel.tsx
@@ -172,9 +172,10 @@ export function AgentBrowserPanel({
     if (!next) return;
     const accepted = acceptedBrowserUrl(next);
     if (!accepted) return;
-    tools.setBrowserUrl(accepted, accepted);
+    const browserSessionId = tools.browser.sessionId;
+    tools.setBrowserUrl(accepted, accepted, browserSessionId);
     if (/^file:\/\//i.test(accepted)) return;
-    const request = browserSessionRequest(focusedSession?.id ?? null, "navigate", {
+    const request = browserSessionRequest(browserSessionId, "navigate", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ url: accepted }),
@@ -219,6 +220,7 @@ export function AgentBrowserPanel({
   const closeSideChat = useCallback(() => {
     handles.removeDetachedSession(sideChatSeed.id);
     setSideChatSeed(createSideChatSession(activeProject ?? null, focusedSession, activeModelId));
+    tools.setActiveBrowserSession(focusedSession?.id ?? null);
     tools.closeComputerTab("side-chat");
   }, [activeModelId, activeProject, focusedSession, handles, sideChatSeed.id, tools]);
   const closeComputerTab = useCallback(
@@ -281,6 +283,7 @@ export function AgentBrowserPanel({
         onOpenSideChat={openSideChat}
         onOpenTerminal={openTerminalForFocusedSession}
         onRenameSideChat={renameSideChat}
+        onSelectBrowserSession={tools.setActiveBrowserSession}
         onUpdateSideChatTabs={updateSideChatTabs}
         sessions={sessions}
         sideChatSession={sideChatSession}

--- a/frontend/src/features/agent/ui/agent-browser-screencast.tsx
+++ b/frontend/src/features/agent/ui/agent-browser-screencast.tsx
@@ -196,12 +196,13 @@ export function ScreencastSurface({
     if (!request) return;
     void fetch(request.input, request.init)
       .then(async (response) => {
+        if (!response.ok) throw new Error(`Navigation failed (${response.status})`);
         const payload = (await response.json().catch(() => null)) as {
           ok: boolean;
           error?: string;
         } | null;
         if (cancelled) return;
-        setNavError(response.ok && payload?.ok ? null : (payload?.error ?? "Navigation failed"));
+        setNavError(payload?.ok ? null : (payload?.error ?? "Navigation failed"));
       })
       .catch((error) => {
         if (!cancelled) {

--- a/frontend/src/features/agent/ui/agent-browser-screencast.tsx
+++ b/frontend/src/features/agent/ui/agent-browser-screencast.tsx
@@ -3,6 +3,7 @@
 import { effectTimeout, type EffectTimer } from "@/lib/effect-timers";
 import { browserSessionRequest } from "@/features/agent/browser/session-request";
 import {
+  browserFrameResponseAction,
   browserFrameSource,
   browserSurfaceRequest,
   BrowserSessionSurface,
@@ -139,16 +140,17 @@ export function ScreencastSurface({
         });
         if (!request) return;
         const response = await fetch(request.input, request.init);
-        if (!disposed && surface.ownsSession(sessionId) && response.status === 503) {
+        const responseAction = browserFrameResponseAction(response.status);
+        if (!disposed && surface.ownsSession(sessionId) && responseAction === "unavailable") {
           const payload = (await response.json().catch(() => null)) as FramePayload | null;
           if (!disposed && surface.ownsSession(sessionId)) {
             onUnavailableRef.current(payload?.error || "Browser unavailable");
           }
           return; // stop polling; pane switches to reading mode
         }
-        if (!response.ok) return;
-        const payload = (await response.json()) as FramePayload;
-        if (!disposed && surface.ownsSession(sessionId) && payload.ok && payload.data) {
+        const payload =
+          responseAction === "read" ? ((await response.json()) as FramePayload) : null;
+        if (!disposed && surface.ownsSession(sessionId) && payload?.ok && payload.data) {
           if (payload.data.frame) {
             setFrame({
               sessionId,

--- a/frontend/src/features/agent/ui/agent-browser-screencast.tsx
+++ b/frontend/src/features/agent/ui/agent-browser-screencast.tsx
@@ -2,7 +2,12 @@
 
 import { effectTimeout, type EffectTimer } from "@/lib/effect-timers";
 import { browserSessionRequest } from "@/features/agent/browser/session-request";
-import { BrowserSessionSurface } from "@/features/agent/browser/session-surface";
+import {
+  browserFrameSource,
+  browserSurfaceRequest,
+  BrowserSessionSurface,
+  type BrowserSessionFrame,
+} from "@/features/agent/browser/session-surface";
 
 /**
  * Live surface for the agent browser pane: renders the server-side headless
@@ -19,6 +24,7 @@ import { BrowserSessionSurface } from "@/features/agent/browser/session-surface"
 import {
   useRef,
   useState,
+  useLayoutEffect,
   type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
   type WheelEvent as ReactWheelEvent,
@@ -54,14 +60,21 @@ const VIEWPORT_MAX = { width: 1920, height: 1200 };
 const POLL_INTERVAL_MS = 110; // ~9fps
 const MOVE_THROTTLE_MS = 33;
 
-function postBrowser(sessionId: string | null, path: string, body: unknown): void {
-  const request = browserSessionRequest(sessionId, path, {
+function postBrowser(
+  surface: BrowserSessionSurface,
+  sessionId: string | null,
+  path: string,
+  body: unknown,
+): void {
+  const request = browserSurfaceRequest(surface, sessionId, path, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
   if (!request) return;
-  void fetch(request.input, request.init).catch(() => undefined);
+  void fetch(request.input, request.init)
+    .catch(() => undefined)
+    .finally(() => surface.releaseRequest(request.controller));
 }
 
 export function ScreencastSurface({
@@ -72,12 +85,18 @@ export function ScreencastSurface({
   visible = true,
 }: Props) {
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
-  const [frameSrc, setFrameSrc] = useState<string | null>(null);
+  const [frame, setFrame] = useState<BrowserSessionFrame | null>(null);
   const [navError, setNavError] = useState<string | null>(null);
   const [surface] = useState(() => new BrowserSessionSurface());
   const lastMoveAtRef = useRef(0);
   const onStateRef = useRef(onState);
   const onUnavailableRef = useRef(onUnavailable);
+  const frameSrc = browserFrameSource(frame, sessionId);
+
+  useLayoutEffect(() => {
+    surface.enterSession(sessionId, url);
+  }, [sessionId, surface, url]);
+  useLayoutEffect(() => () => surface.dispose(), [surface]);
 
   // Mirror the latest callbacks into refs in the commit phase (never during
   // render), so the long-lived poll loop always calls the current handlers
@@ -92,8 +111,7 @@ export function ScreencastSurface({
   // collapsed) and idles at 1s while the document itself is hidden, so a
   // background browser tab doesn't burn ~9 fetches+JPEG decodes per second. ──
   useMountSubscription(() => {
-    surface.enterSession(sessionId, url);
-    setFrameSrc(null);
+    setFrame(null);
     setNavError(null);
     if (!visible || !sessionId) return;
     let disposed = false;
@@ -115,14 +133,27 @@ export function ScreencastSurface({
         });
         if (!request) return;
         const response = await fetch(request.input, request.init);
-        if (response.status === 503) {
+        if (!disposed && surface.ownsSession(sessionId) && response.status === 503) {
           const payload = (await response.json().catch(() => null)) as FramePayload | null;
-          onUnavailableRef.current(payload?.error || "Browser unavailable");
+          if (!disposed && surface.ownsSession(sessionId)) {
+            onUnavailableRef.current(payload?.error || "Browser unavailable");
+          }
           return; // stop polling; pane switches to reading mode
         }
+        if (!response.ok) return;
         const payload = (await response.json()) as FramePayload;
-        if (!disposed && payload.ok && payload.data) {
-          if (payload.data.frame) setFrameSrc(`data:image/jpeg;base64,${payload.data.frame}`);
+        if (
+          !disposed &&
+          surface.ownsSession(sessionId) &&
+          payload.ok &&
+          payload.data
+        ) {
+          if (payload.data.frame) {
+            setFrame({
+              sessionId,
+              src: `data:image/jpeg;base64,${payload.data.frame}`,
+            });
+          }
           surface.observeServerUrl(sessionId, payload.data.url);
           onStateRef.current({
             url: payload.data.url,
@@ -152,7 +183,6 @@ export function ScreencastSurface({
   // ── Address-bar navigation: navigate server-side when the desired URL
   // diverges from what the host last reported ────────────────────────────
   useMountSubscription(() => {
-    surface.enterSession(sessionId, url);
     const target = surface.navigationTarget(sessionId, url);
     if (!target) return;
     let cancelled = false;
@@ -197,7 +227,7 @@ export function ScreencastSurface({
         Math.min(VIEWPORT_MAX.height, Math.max(VIEWPORT_MIN.height, rect.height)),
       );
       if (!surface.syncViewport(sessionId, { width, height })) return;
-      postBrowser(sessionId, "viewport", { width, height });
+      postBrowser(surface, sessionId, "viewport", { width, height });
     };
     const observer = new ResizeObserver(() => {
       if (timer) timer.cancel();
@@ -229,7 +259,7 @@ export function ScreencastSurface({
     container?.focus();
     event.currentTarget.setPointerCapture(event.pointerId);
     const { x, y } = toViewport(event);
-    postBrowser(sessionId, "input", {
+    postBrowser(surface, sessionId, "input", {
       kind: "mouse",
       type: "down",
       x,
@@ -241,7 +271,7 @@ export function ScreencastSurface({
 
   const handlePointerUp = (event: ReactPointerEvent<HTMLDivElement>) => {
     const { x, y } = toViewport(event);
-    postBrowser(sessionId, "input", {
+    postBrowser(surface, sessionId, "input", {
       kind: "mouse",
       type: "up",
       x,
@@ -256,12 +286,12 @@ export function ScreencastSurface({
     if (now - lastMoveAtRef.current < MOVE_THROTTLE_MS) return;
     lastMoveAtRef.current = now;
     const { x, y } = toViewport(event);
-    postBrowser(sessionId, "input", { kind: "mouse", type: "move", x, y });
+    postBrowser(surface, sessionId, "input", { kind: "mouse", type: "move", x, y });
   };
 
   const handleWheel = (event: ReactWheelEvent<HTMLDivElement>) => {
     const { x, y } = toViewport(event);
-    postBrowser(sessionId, "input", {
+    postBrowser(surface, sessionId, "input", {
       kind: "wheel",
       x,
       y,
@@ -273,7 +303,7 @@ export function ScreencastSurface({
   const handleKey = (type: "down" | "up") => (event: ReactKeyboardEvent<HTMLDivElement>) => {
     if (event.metaKey) return;
     event.preventDefault();
-    postBrowser(sessionId, "input", {
+    postBrowser(surface, sessionId, "input", {
       kind: "key",
       type,
       key: event.key,

--- a/frontend/src/features/agent/ui/agent-browser-screencast.tsx
+++ b/frontend/src/features/agent/ui/agent-browser-screencast.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { effectTimeout, type EffectTimer } from "@/lib/effect-timers";
+import { browserSessionRequest } from "@/features/agent/browser/session-request";
 
 /**
  * Live surface for the agent browser pane: renders the server-side headless
@@ -37,6 +38,7 @@ type FramePayload = {
 };
 
 type Props = {
+  sessionId: string | null;
   /** Desired URL from the address bar; navigated server-side when it diverges. */
   url: string;
   onState: (state: BrowserPaneState) => void;
@@ -51,15 +53,23 @@ const VIEWPORT_MAX = { width: 1920, height: 1200 };
 const POLL_INTERVAL_MS = 110; // ~9fps
 const MOVE_THROTTLE_MS = 33;
 
-function postBrowser(path: string, body: unknown): void {
-  void fetch(`/api/agent/browser/${path}`, {
+function postBrowser(sessionId: string | null, path: string, body: unknown): void {
+  const request = browserSessionRequest(sessionId, path, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
-  }).catch(() => undefined);
+  });
+  if (!request) return;
+  void fetch(request.input, request.init).catch(() => undefined);
 }
 
-export function ScreencastSurface({ url, onState, onUnavailable, visible = true }: Props) {
+export function ScreencastSurface({
+  sessionId,
+  url,
+  onState,
+  onUnavailable,
+  visible = true,
+}: Props) {
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const [frameSrc, setFrameSrc] = useState<string | null>(null);
   const [navError, setNavError] = useState<string | null>(null);
@@ -82,9 +92,13 @@ export function ScreencastSurface({ url, onState, onUnavailable, visible = true 
   // collapsed) and idles at 1s while the document itself is hidden, so a
   // background browser tab doesn't burn ~9 fetches+JPEG decodes per second. ──
   useMountSubscription(() => {
-    if (!visible) return;
+    serverUrlRef.current = "";
+    setFrameSrc(null);
+    setNavError(null);
+    if (!visible || !sessionId) return;
     let disposed = false;
     let timer: EffectTimer | null = null;
+    let requestController: AbortController | null = null;
 
     const tick = async () => {
       if (disposed) return;
@@ -93,7 +107,13 @@ export function ScreencastSurface({ url, onState, onUnavailable, visible = true 
         return;
       }
       try {
-        const response = await fetch("/api/agent/browser/frame", { cache: "no-store" });
+        requestController = new AbortController();
+        const request = browserSessionRequest(sessionId, "frame", {
+          cache: "no-store",
+          signal: requestController.signal,
+        });
+        if (!request) return;
+        const response = await fetch(request.input, request.init);
         if (response.status === 503) {
           const payload = (await response.json().catch(() => null)) as FramePayload | null;
           onUnavailableRef.current(payload?.error || "Browser unavailable");
@@ -112,6 +132,8 @@ export function ScreencastSurface({ url, onState, onUnavailable, visible = true 
         }
       } catch {
         // transient — keep polling
+      } finally {
+        requestController = null;
       }
       if (!disposed) timer = effectTimeout(() => void tick(), POLL_INTERVAL_MS);
     };
@@ -120,20 +142,25 @@ export function ScreencastSurface({ url, onState, onUnavailable, visible = true 
     return () => {
       disposed = true;
       if (timer) timer.cancel();
+      requestController?.abort();
     };
-  }, [visible]);
+  }, [sessionId, visible]);
 
   // ── Address-bar navigation: navigate server-side when the desired URL
   // diverges from what the host last reported ────────────────────────────
   useMountSubscription(() => {
     const target = url.trim();
-    if (!target || target === serverUrlRef.current) return;
+    if (!sessionId || !target || target === serverUrlRef.current) return;
     let cancelled = false;
-    void fetch("/api/agent/browser/navigate", {
+    const controller = new AbortController();
+    const request = browserSessionRequest(sessionId, "navigate", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ url: target }),
-    })
+      signal: controller.signal,
+    });
+    if (!request) return;
+    void fetch(request.input, request.init)
       .then(async (response) => {
         const payload = (await response.json()) as { ok: boolean; error?: string };
         if (cancelled) return;
@@ -146,12 +173,13 @@ export function ScreencastSurface({ url, onState, onUnavailable, visible = true 
       });
     return () => {
       cancelled = true;
+      controller.abort();
     };
-  }, [url]);
+  }, [sessionId, url]);
 
   // ── Viewport sync: match the headless viewport to the pane size ────────
   useMountSubscription(() => {
-    if (!container) return;
+    if (!container || !sessionId) return;
     let timer: EffectTimer | null = null;
     const sync = () => {
       const rect = container.getBoundingClientRect();
@@ -163,7 +191,7 @@ export function ScreencastSurface({ url, onState, onUnavailable, visible = true 
       );
       if (width === viewportRef.current.width && height === viewportRef.current.height) return;
       viewportRef.current = { width, height };
-      postBrowser("viewport", { width, height });
+      postBrowser(sessionId, "viewport", { width, height });
     };
     const observer = new ResizeObserver(() => {
       if (timer) timer.cancel();
@@ -175,7 +203,7 @@ export function ScreencastSurface({ url, onState, onUnavailable, visible = true 
       if (timer) timer.cancel();
       observer.disconnect();
     };
-  }, [container]);
+  }, [container, sessionId]);
 
   // ── Input forwarding ────────────────────────────────────────────────────
   const toViewport = (event: { clientX: number; clientY: number }) => {
@@ -194,7 +222,7 @@ export function ScreencastSurface({ url, onState, onUnavailable, visible = true 
     container?.focus();
     event.currentTarget.setPointerCapture(event.pointerId);
     const { x, y } = toViewport(event);
-    postBrowser("input", {
+    postBrowser(sessionId, "input", {
       kind: "mouse",
       type: "down",
       x,
@@ -206,7 +234,7 @@ export function ScreencastSurface({ url, onState, onUnavailable, visible = true 
 
   const handlePointerUp = (event: ReactPointerEvent<HTMLDivElement>) => {
     const { x, y } = toViewport(event);
-    postBrowser("input", {
+    postBrowser(sessionId, "input", {
       kind: "mouse",
       type: "up",
       x,
@@ -221,19 +249,38 @@ export function ScreencastSurface({ url, onState, onUnavailable, visible = true 
     if (now - lastMoveAtRef.current < MOVE_THROTTLE_MS) return;
     lastMoveAtRef.current = now;
     const { x, y } = toViewport(event);
-    postBrowser("input", { kind: "mouse", type: "move", x, y });
+    postBrowser(sessionId, "input", { kind: "mouse", type: "move", x, y });
   };
 
   const handleWheel = (event: ReactWheelEvent<HTMLDivElement>) => {
     const { x, y } = toViewport(event);
-    postBrowser("input", { kind: "wheel", x, y, deltaX: event.deltaX, deltaY: event.deltaY });
+    postBrowser(sessionId, "input", {
+      kind: "wheel",
+      x,
+      y,
+      deltaX: event.deltaX,
+      deltaY: event.deltaY,
+    });
   };
 
   const handleKey = (type: "down" | "up") => (event: ReactKeyboardEvent<HTMLDivElement>) => {
     if (event.metaKey) return;
     event.preventDefault();
-    postBrowser("input", { kind: "key", type, key: event.key, code: event.code });
+    postBrowser(sessionId, "input", {
+      kind: "key",
+      type,
+      key: event.key,
+      code: event.code,
+    });
   };
+
+  if (!sessionId) {
+    return (
+      <div className="flex size-full items-center justify-center bg-(--bg) px-6 text-center text-xs text-(--dim)">
+        Select an agent session to use the live browser.
+      </div>
+    );
+  }
 
   return (
     <div

--- a/frontend/src/features/agent/ui/agent-browser-screencast.tsx
+++ b/frontend/src/features/agent/ui/agent-browser-screencast.tsx
@@ -96,8 +96,10 @@ export function ScreencastSurface({
   const frameSrc = browserFrameSource(frame, sessionId);
   const bindContainer = useCallback(
     (node: HTMLDivElement | null) => {
-      if (node) setContainer(node);
-      else surface.dispose();
+      if (node) {
+        surface.attach();
+        setContainer(node);
+      } else surface.dispose();
     },
     [surface],
   );

--- a/frontend/src/features/agent/ui/agent-browser-screencast.tsx
+++ b/frontend/src/features/agent/ui/agent-browser-screencast.tsx
@@ -22,9 +22,9 @@ import {
  */
 
 import {
+  useCallback,
   useRef,
   useState,
-  useLayoutEffect,
   type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
   type WheelEvent as ReactWheelEvent,
@@ -59,6 +59,8 @@ const VIEWPORT_MIN = { width: 320, height: 240 };
 const VIEWPORT_MAX = { width: 1920, height: 1200 };
 const POLL_INTERVAL_MS = 110; // ~9fps
 const MOVE_THROTTLE_MS = 33;
+const browserButtonName = (button: number) =>
+  button === 1 ? "middle" : button === 2 ? "right" : "left";
 
 function postBrowser(
   surface: BrowserSessionSurface,
@@ -87,16 +89,18 @@ export function ScreencastSurface({
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const [frame, setFrame] = useState<BrowserSessionFrame | null>(null);
   const [navError, setNavError] = useState<string | null>(null);
-  const [surface] = useState(() => new BrowserSessionSurface());
+  const [surface] = useState(() => new BrowserSessionSurface(sessionId, url));
   const lastMoveAtRef = useRef(0);
   const onStateRef = useRef(onState);
   const onUnavailableRef = useRef(onUnavailable);
   const frameSrc = browserFrameSource(frame, sessionId);
-
-  useLayoutEffect(() => {
-    surface.enterSession(sessionId, url);
-  }, [sessionId, surface, url]);
-  useLayoutEffect(() => () => surface.dispose(), [surface]);
+  const bindContainer = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (node) setContainer(node);
+      else surface.dispose();
+    },
+    [surface],
+  );
 
   // Mirror the latest callbacks into refs in the commit phase (never during
   // render), so the long-lived poll loop always calls the current handlers
@@ -142,12 +146,7 @@ export function ScreencastSurface({
         }
         if (!response.ok) return;
         const payload = (await response.json()) as FramePayload;
-        if (
-          !disposed &&
-          surface.ownsSession(sessionId) &&
-          payload.ok &&
-          payload.data
-        ) {
+        if (!disposed && surface.ownsSession(sessionId) && payload.ok && payload.data) {
           if (payload.data.frame) {
             setFrame({
               sessionId,
@@ -197,9 +196,12 @@ export function ScreencastSurface({
     if (!request) return;
     void fetch(request.input, request.init)
       .then(async (response) => {
-        const payload = (await response.json()) as { ok: boolean; error?: string };
+        const payload = (await response.json().catch(() => null)) as {
+          ok: boolean;
+          error?: string;
+        } | null;
         if (cancelled) return;
-        setNavError(payload.ok ? null : (payload.error ?? "Navigation failed"));
+        setNavError(response.ok && payload?.ok ? null : (payload?.error ?? "Navigation failed"));
       })
       .catch((error) => {
         if (!cancelled) {
@@ -252,9 +254,6 @@ export function ScreencastSurface({
     };
   };
 
-  const buttonName = (button: number) =>
-    button === 1 ? "middle" : button === 2 ? "right" : "left";
-
   const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
     container?.focus();
     event.currentTarget.setPointerCapture(event.pointerId);
@@ -264,7 +263,7 @@ export function ScreencastSurface({
       type: "down",
       x,
       y,
-      button: buttonName(event.button),
+      button: browserButtonName(event.button),
       clickCount: Math.max(1, event.detail),
     });
   };
@@ -276,9 +275,16 @@ export function ScreencastSurface({
       type: "up",
       x,
       y,
-      button: buttonName(event.button),
+      button: browserButtonName(event.button),
       clickCount: Math.max(1, event.detail),
     });
+  };
+
+  const handlePointerCancel = (event: ReactPointerEvent<HTMLDivElement>) => {
+    handlePointerUp(event);
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
   };
 
   const handlePointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -321,13 +327,14 @@ export function ScreencastSurface({
 
   return (
     <div
-      ref={setContainer}
+      ref={bindContainer}
       tabIndex={0}
       role="application"
       aria-label="Live browser"
       className="relative size-full min-h-0 overflow-hidden bg-white outline-none"
       onPointerDown={handlePointerDown}
       onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerCancel}
       onPointerMove={handlePointerMove}
       onWheel={handleWheel}
       onKeyDown={handleKey("down")}

--- a/frontend/src/features/agent/ui/agent-browser-screencast.tsx
+++ b/frontend/src/features/agent/ui/agent-browser-screencast.tsx
@@ -2,6 +2,7 @@
 
 import { effectTimeout, type EffectTimer } from "@/lib/effect-timers";
 import { browserSessionRequest } from "@/features/agent/browser/session-request";
+import { BrowserSessionSurface } from "@/features/agent/browser/session-surface";
 
 /**
  * Live surface for the agent browser pane: renders the server-side headless
@@ -73,8 +74,7 @@ export function ScreencastSurface({
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const [frameSrc, setFrameSrc] = useState<string | null>(null);
   const [navError, setNavError] = useState<string | null>(null);
-  const serverUrlRef = useRef<string>("");
-  const viewportRef = useRef({ width: 1280, height: 800 });
+  const [surface] = useState(() => new BrowserSessionSurface());
   const lastMoveAtRef = useRef(0);
   const onStateRef = useRef(onState);
   const onUnavailableRef = useRef(onUnavailable);
@@ -92,7 +92,7 @@ export function ScreencastSurface({
   // collapsed) and idles at 1s while the document itself is hidden, so a
   // background browser tab doesn't burn ~9 fetches+JPEG decodes per second. ──
   useMountSubscription(() => {
-    serverUrlRef.current = "";
+    surface.enterSession(sessionId, url);
     setFrameSrc(null);
     setNavError(null);
     if (!visible || !sessionId) return;
@@ -107,7 +107,8 @@ export function ScreencastSurface({
         return;
       }
       try {
-        requestController = new AbortController();
+        requestController = surface.requestController(sessionId);
+        if (!requestController) return;
         const request = browserSessionRequest(sessionId, "frame", {
           cache: "no-store",
           signal: requestController.signal,
@@ -122,7 +123,7 @@ export function ScreencastSurface({
         const payload = (await response.json()) as FramePayload;
         if (!disposed && payload.ok && payload.data) {
           if (payload.data.frame) setFrameSrc(`data:image/jpeg;base64,${payload.data.frame}`);
-          serverUrlRef.current = payload.data.url;
+          surface.observeServerUrl(sessionId, payload.data.url);
           onStateRef.current({
             url: payload.data.url,
             title: payload.data.title,
@@ -133,6 +134,7 @@ export function ScreencastSurface({
       } catch {
         // transient — keep polling
       } finally {
+        if (requestController) surface.releaseRequest(requestController);
         requestController = null;
       }
       if (!disposed) timer = effectTimeout(() => void tick(), POLL_INTERVAL_MS);
@@ -143,16 +145,19 @@ export function ScreencastSurface({
       disposed = true;
       if (timer) timer.cancel();
       requestController?.abort();
+      if (requestController) surface.releaseRequest(requestController);
     };
-  }, [sessionId, visible]);
+  }, [sessionId, surface, visible]);
 
   // ── Address-bar navigation: navigate server-side when the desired URL
   // diverges from what the host last reported ────────────────────────────
   useMountSubscription(() => {
-    const target = url.trim();
-    if (!sessionId || !target || target === serverUrlRef.current) return;
+    surface.enterSession(sessionId, url);
+    const target = surface.navigationTarget(sessionId, url);
+    if (!target) return;
     let cancelled = false;
-    const controller = new AbortController();
+    const controller = surface.requestController(sessionId);
+    if (!controller) return;
     const request = browserSessionRequest(sessionId, "navigate", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -170,12 +175,14 @@ export function ScreencastSurface({
         if (!cancelled) {
           setNavError(error instanceof Error ? error.message : "Navigation failed");
         }
-      });
+      })
+      .finally(() => surface.releaseRequest(controller));
     return () => {
       cancelled = true;
       controller.abort();
+      surface.releaseRequest(controller);
     };
-  }, [sessionId, url]);
+  }, [sessionId, surface, url]);
 
   // ── Viewport sync: match the headless viewport to the pane size ────────
   useMountSubscription(() => {
@@ -189,8 +196,7 @@ export function ScreencastSurface({
       const height = Math.round(
         Math.min(VIEWPORT_MAX.height, Math.max(VIEWPORT_MIN.height, rect.height)),
       );
-      if (width === viewportRef.current.width && height === viewportRef.current.height) return;
-      viewportRef.current = { width, height };
+      if (!surface.syncViewport(sessionId, { width, height })) return;
       postBrowser(sessionId, "viewport", { width, height });
     };
     const observer = new ResizeObserver(() => {
@@ -203,15 +209,16 @@ export function ScreencastSurface({
       if (timer) timer.cancel();
       observer.disconnect();
     };
-  }, [container, sessionId]);
+  }, [container, sessionId, surface]);
 
   // ── Input forwarding ────────────────────────────────────────────────────
   const toViewport = (event: { clientX: number; clientY: number }) => {
     const rect = container?.getBoundingClientRect();
     if (!rect || rect.width === 0 || rect.height === 0) return { x: 0, y: 0 };
+    const viewport = surface.viewport();
     return {
-      x: Math.round(((event.clientX - rect.left) / rect.width) * viewportRef.current.width),
-      y: Math.round(((event.clientY - rect.top) / rect.height) * viewportRef.current.height),
+      x: Math.round(((event.clientX - rect.left) / rect.width) * viewport.width),
+      y: Math.round(((event.clientY - rect.top) / rect.height) * viewport.height),
     };
   };
 

--- a/frontend/src/features/agent/ui/agent-browser.tsx
+++ b/frontend/src/features/agent/ui/agent-browser.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useState, type FormEvent } from "react";
 import { ArrowLeftIcon, ArrowRightIcon, CloseIcon, ReloadIcon } from "@/ui/icons";
+import { browserSessionRequest } from "@/features/agent/browser/session-request";
 import { DEFAULT_BROWSER_URL } from "@/features/agent/tools/persistence";
 import {
   ScreencastSurface,
@@ -17,6 +18,7 @@ import { LocalhostStartPage } from "@/features/agent/ui/agent-browser-start-page
 import { ReadingView, type ReadablePage } from "@/features/agent/ui/agent-browser-reading-view";
 
 type Props = {
+  sessionId: string | null;
   url: string;
   inputValue: string;
   onInputChange: (value: string) => void;
@@ -28,6 +30,7 @@ type Props = {
 };
 
 export function AgentBrowser({
+  sessionId,
   url,
   inputValue,
   onInputChange,
@@ -92,12 +95,20 @@ export function AgentBrowser({
   );
   useBrowserLiveStateSync({
     enabled: showStartPage && visible,
+    sessionId,
     onLiveUrl: adoptLiveUrl,
   });
 
-  const postLiveVerb = useCallback((verb: "back" | "forward" | "reload") => {
-    void fetch(`/api/agent/browser/${verb}`, { method: "POST" }).catch(() => undefined);
-  }, []);
+  const postLiveVerb = useCallback(
+    (verb: "back" | "forward" | "reload") => {
+      const request = browserSessionRequest(sessionId, verb, {
+        method: "POST",
+      });
+      if (!request) return;
+      void fetch(request.input, request.init).catch(() => undefined);
+    },
+    [sessionId],
+  );
   const handleReload = () => {
     if (showStartPage) {
       setLocalSites([]);
@@ -236,6 +247,7 @@ export function AgentBrowser({
           />
         ) : (
           <ScreencastSurface
+            sessionId={sessionId}
             url={url}
             visible={visible}
             onState={(state) => {

--- a/frontend/src/features/agent/ui/agent-workspace-shell.tsx
+++ b/frontend/src/features/agent/ui/agent-workspace-shell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, lazy, useLayoutEffect, type ReactNode } from "react";
+import { Suspense, lazy, useCallback, type ReactNode, type RefCallback } from "react";
 import { useSearchParams } from "next/navigation";
 import { triggerAddProjectFlow } from "@/features/agent/ui/projects-nav/helpers";
 import {
@@ -96,7 +96,7 @@ export function AgentWorkspaceShell({
   const focusedTab = focusedSession(state);
   const activeSessionIdentity = workspaceSessionIdentity(focusedTab);
   const activeProject = projects.resolveProject(focusedTab) ?? projects.selectedProject;
-  useActiveSessionEffects({
+  const bindActiveSession = useActiveSessionBinder({
     ...activeSessionIdentity,
     browserSessionId: focusedTab?.id ?? null,
     setActiveBrowserSession: tools.setActiveBrowserSession,
@@ -111,7 +111,11 @@ export function AgentWorkspaceShell({
   const composerOnly = panelMode === "composer";
   useQuickPanelExpandEffect(compact, panelMode === "thread");
   return (
-    <div data-quick-panel-state={panelMode} className={workspaceClassName(panelMode)}>
+    <div
+      ref={bindActiveSession}
+      data-quick-panel-state={panelMode}
+      className={workspaceClassName(panelMode)}
+    >
       <div
         className="agent-workspace-panel-row relative flex min-h-0 flex-1"
         data-multi-pane={collectLeaves(state.layout).length > 1 ? "true" : undefined}
@@ -357,7 +361,7 @@ function ProjectEmptyState() {
   );
 }
 
-function useActiveSessionEffects({
+function useActiveSessionBinder({
   browserSessionId,
   viewKey,
   viewAlias,
@@ -369,13 +373,17 @@ function useActiveSessionEffects({
   viewAlias: string | null;
   setActiveBrowserSession: ReturnType<typeof useTools>["setActiveBrowserSession"];
   setActiveComputerSession: ReturnType<typeof useTools>["setActiveComputerSession"];
-}): void {
-  useLayoutEffect(() => {
-    setActiveBrowserSession(browserSessionId);
-    setActiveComputerSession(
-      viewKey ? { key: viewKey, aliases: viewAlias ? [viewAlias] : [] } : null,
-    );
-  }, [browserSessionId, viewKey, viewAlias, setActiveBrowserSession, setActiveComputerSession]);
+}): RefCallback<HTMLDivElement> {
+  return useCallback(
+    (node: HTMLDivElement | null) => {
+      if (!node) return;
+      setActiveBrowserSession(browserSessionId);
+      setActiveComputerSession(
+        viewKey ? { key: viewKey, aliases: viewAlias ? [viewAlias] : [] } : null,
+      );
+    },
+    [browserSessionId, viewKey, viewAlias, setActiveBrowserSession, setActiveComputerSession],
+  );
 }
 
 export function AgentWorkspace({ compact }: { compact?: boolean } = {}) {

--- a/frontend/src/features/agent/ui/agent-workspace-shell.tsx
+++ b/frontend/src/features/agent/ui/agent-workspace-shell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, lazy, type ReactNode } from "react";
+import { Suspense, lazy, useLayoutEffect, type ReactNode } from "react";
 import { useSearchParams } from "next/navigation";
 import { triggerAddProjectFlow } from "@/features/agent/ui/projects-nav/helpers";
 import {
@@ -98,6 +98,8 @@ export function AgentWorkspaceShell({
   const activeProject = projects.resolveProject(focusedTab) ?? projects.selectedProject;
   useActiveSessionEffects({
     ...activeSessionIdentity,
+    browserSessionId: focusedTab?.id ?? null,
+    setActiveBrowserSession: tools.setActiveBrowserSession,
     setActiveComputerSession: tools.setActiveComputerSession,
   });
   const focusedModel =
@@ -356,19 +358,24 @@ function ProjectEmptyState() {
 }
 
 function useActiveSessionEffects({
+  browserSessionId,
   viewKey,
   viewAlias,
+  setActiveBrowserSession,
   setActiveComputerSession,
 }: {
+  browserSessionId: string | null;
   viewKey: string | null;
   viewAlias: string | null;
+  setActiveBrowserSession: ReturnType<typeof useTools>["setActiveBrowserSession"];
   setActiveComputerSession: ReturnType<typeof useTools>["setActiveComputerSession"];
 }): void {
-  useMountSubscription(() => {
+  useLayoutEffect(() => {
+    setActiveBrowserSession(browserSessionId);
     setActiveComputerSession(
       viewKey ? { key: viewKey, aliases: viewAlias ? [viewAlias] : [] } : null,
     );
-  }, [viewKey, viewAlias, setActiveComputerSession]);
+  }, [browserSessionId, viewKey, viewAlias, setActiveBrowserSession, setActiveComputerSession]);
 }
 
 export function AgentWorkspace({ compact }: { compact?: boolean } = {}) {

--- a/frontend/src/features/agent/ui/browser-session-ownership.test.ts
+++ b/frontend/src/features/agent/ui/browser-session-ownership.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const source = (path: string) => readFileSync(new URL(path, import.meta.url), "utf8");
+
+test("closing side chat restores browser ownership to the focused workspace session", () => {
+  const panel = source("./agent-browser-panel.tsx");
+  assert.match(
+    panel,
+    /removeDetachedSession[\s\S]*setActiveBrowserSession\(focusedSession\?\.id \?\? null\)[\s\S]*closeComputerTab\("side-chat"\)/,
+  );
+});
+
+test("clicking an already-focused workspace pane reasserts its browser owner", () => {
+  const pane = source("./render-workspace-pane.tsx");
+  assert.match(
+    pane,
+    /onFocus=\{\(\) => \{[\s\S]*setActiveBrowserSession\(view\.pane\.sessionId\)[\s\S]*dispatch\(\{ type: "focusPane"/,
+  );
+});

--- a/frontend/src/features/agent/ui/browser-session-ownership.test.ts
+++ b/frontend/src/features/agent/ui/browser-session-ownership.test.ts
@@ -19,3 +19,12 @@ test("clicking an already-focused workspace pane reasserts its browser owner", (
     /onFocus=\{\(\) => \{[\s\S]*setActiveBrowserSession\(view\.pane\.sessionId\)[\s\S]*dispatch\(\{ type: "focusPane"/,
   );
 });
+
+test("workspace session changes bind browser ownership during commit", () => {
+  const shell = source("./agent-workspace-shell.tsx");
+  assert.match(shell, /ref=\{bindActiveSession\}/);
+  assert.match(
+    shell,
+    /useActiveSessionBinder[\s\S]*if \(!node\) return;[\s\S]*setActiveBrowserSession\(browserSessionId\)/,
+  );
+});

--- a/frontend/src/features/agent/ui/chat-pane-send-flow-model.test.ts
+++ b/frontend/src/features/agent/ui/chat-pane-send-flow-model.test.ts
@@ -1,9 +1,45 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  browserContextUrlForSession,
   messagesToResumeAfterAbort,
   removePendingSteersClearedByAbort,
 } from "./chat-pane-send-flow-model";
+
+function storage(): Pick<Storage, "getItem" | "setItem"> {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+  };
+}
+
+test("browser context reads the target session instead of the focused session", () => {
+  const target = storage();
+  target.setItem(
+    "local-studio.agent.sessionViewState.v1",
+    JSON.stringify({
+      version: 1,
+      views: {
+        "session-b": {
+          scrollTop: 0,
+          stickToBottom: true,
+          browser: { input: "https://b.example", url: "https://b.example" },
+        },
+      },
+    }),
+  );
+  const browser = {
+    enabled: true,
+    backend: "embedded" as const,
+    sessionId: "session-a",
+    input: "https://a.example",
+    url: "https://a.example",
+  };
+  assert.equal(browserContextUrlForSession(browser, "session-a", target), "https://a.example");
+  assert.equal(browserContextUrlForSession(browser, "session-b", target), "https://b.example");
+  assert.equal(browserContextUrlForSession(browser, "session-c", target), "about:blank");
+});
 
 test("stop resumes the visible queue without duplicating the runtime copy", () => {
   assert.deepEqual(

--- a/frontend/src/features/agent/ui/chat-pane-send-flow-model.ts
+++ b/frontend/src/features/agent/ui/chat-pane-send-flow-model.ts
@@ -4,6 +4,22 @@ import {
   type ChatMessage,
   type QueuedMessage,
 } from "@/features/agent/messages";
+import type { BrowserState } from "@/features/agent/tools/types";
+import { DEFAULT_BROWSER_URL } from "@/features/agent/tools/persistence";
+import { readSessionView } from "@/features/agent/workspace/session-view-state";
+
+type BrowserViewStorage = Pick<Storage, "getItem" | "setItem">;
+
+export function browserContextUrlForSession(
+  browser: BrowserState,
+  sessionId: string,
+  storage: BrowserViewStorage,
+): string {
+  if (browser.sessionId === sessionId) return browser.url;
+  return (
+    readSessionView(storage, { key: sessionId, aliases: [] })?.browser?.url ?? DEFAULT_BROWSER_URL
+  );
+}
 
 function visibleText(text: string): string {
   return visibleUserTextFromPi(text).trim() || text.trim();

--- a/frontend/src/features/agent/ui/chat-pane-send-flow.ts
+++ b/frontend/src/features/agent/ui/chat-pane-send-flow.ts
@@ -22,6 +22,7 @@ import {
   type ChatAttachment,
 } from "@/features/agent/ui/chat-attachments";
 import {
+  browserContextUrlForSession,
   messagesToResumeAfterAbort,
   removePendingSteersClearedByAbort,
 } from "@/features/agent/ui/chat-pane-send-flow-model";
@@ -80,7 +81,7 @@ export function useChatPaneSendFlow({
       const browserContextText = browserContextPrompt({
         enabled: effectiveBrowserEnabled,
         backend: tools.browser.backend,
-        url: tools.browser.url,
+        url: browserContextUrlForSession(tools.browser, sessionId, window.localStorage),
         vision: modelSupportsVision,
       });
       const prompt = [browserContextText, contextText, attachedText].filter(Boolean).join("\n\n");

--- a/frontend/src/features/agent/ui/chat-pane.tsx
+++ b/frontend/src/features/agent/ui/chat-pane.tsx
@@ -336,6 +336,9 @@ export function ChatPane({
     window.addEventListener(OPEN_TERMINAL_EVENT, onOpenTerminalEvent);
     return () => window.removeEventListener(OPEN_TERMINAL_EVENT, onOpenTerminalEvent);
   }, [isFocused]);
+  useMountSubscription(() => {
+    if (isFocused && activeTab?.id) tools.setActiveBrowserSession(activeTab.id);
+  }, [activeTab?.id, isFocused, tools.setActiveBrowserSession]);
   const updateTab = onUpdateSession;
   const {
     attachments,

--- a/frontend/src/features/agent/ui/computer-tab-panel.tsx
+++ b/frontend/src/features/agent/ui/computer-tab-panel.tsx
@@ -53,6 +53,7 @@ type ComputerTabPanelProps = {
   onOpenSideChat: () => void;
   onOpenTerminal: () => void;
   onRenameSideChat: (tabId: string, title: string) => void;
+  onSelectBrowserSession: (sessionId: string | null) => void;
   onUpdateSideChatTabs: (nextTabsOrUpdater: SideChatTabsUpdater) => void;
   sessions: Session[];
   sideChatSession: Session;
@@ -102,6 +103,7 @@ function SideChatTab({
   modelsLoading,
   onCloseSideChat,
   onRenameSideChat,
+  onSelectBrowserSession,
   onUpdateSideChatTabs,
   sideChatSession,
   tools,
@@ -142,7 +144,7 @@ function SideChatTab({
         onToggleBrowserBackend={tools.toggleBrowserBackend}
         onToggleBrowserTool={tools.toggleBrowser}
         isFocused
-        onFocus={() => undefined}
+        onFocus={() => onSelectBrowserSession(sideChatSession.id)}
         tabs={[sideChatSession]}
         activeTabId={sideChatSession.id}
         onUpdateSession={updateSession}
@@ -157,18 +159,19 @@ function SideChatTab({
 }
 
 function BrowserTab({
-  focusedSession,
   onNavigateBrowser,
   tools,
 }: ComputerTabPanelProps) {
+  const sessionId = tools.browser.sessionId;
   return (
     <LazyAgentBrowser
-      sessionId={focusedSession?.id ?? null}
+      key={sessionId ?? "no-browser-session"}
+      sessionId={sessionId}
       url={tools.browser.url}
       inputValue={tools.browser.input}
-      onInputChange={tools.setBrowserInput}
+      onInputChange={(input) => tools.setBrowserInput(input, sessionId)}
       onNavigate={onNavigateBrowser}
-      onLocationChange={(next) => tools.setBrowserUrl(next, next)}
+      onLocationChange={(next) => tools.setBrowserUrl(next, next, sessionId)}
       onClose={() => tools.setComputerOpen(false)}
       visible={tools.computer.open}
     />

--- a/frontend/src/features/agent/ui/computer-tab-panel.tsx
+++ b/frontend/src/features/agent/ui/computer-tab-panel.tsx
@@ -156,9 +156,14 @@ function SideChatTab({
   );
 }
 
-function BrowserTab({ onNavigateBrowser, tools }: ComputerTabPanelProps) {
+function BrowserTab({
+  focusedSession,
+  onNavigateBrowser,
+  tools,
+}: ComputerTabPanelProps) {
   return (
     <LazyAgentBrowser
+      sessionId={focusedSession?.id ?? null}
       url={tools.browser.url}
       inputValue={tools.browser.input}
       onInputChange={tools.setBrowserInput}

--- a/frontend/src/features/agent/ui/render-workspace-pane.tsx
+++ b/frontend/src/features/agent/ui/render-workspace-pane.tsx
@@ -208,7 +208,10 @@ const WorkspacePane = memo(function WorkspacePane({
       }}
       onPiSessionIdChange={handles.notifySessionsChanged}
       isFocused={view.isFocused}
-      onFocus={() => dispatch({ type: "focusPane", paneId: view.paneId })}
+      onFocus={() => {
+        tools.setActiveBrowserSession(view.pane.sessionId);
+        dispatch({ type: "focusPane", paneId: view.paneId });
+      }}
       tabs={sessions}
       activeTabId={view.pane.sessionId}
       onUpdateSession={handles.updateSession}

--- a/frontend/src/features/agent/workspace/session-view-state.test.ts
+++ b/frontend/src/features/agent/workspace/session-view-state.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  patchSessionView,
+  readSessionView,
+} from "@/features/agent/workspace/session-view-state";
+
+function storage(): Pick<Storage, "getItem" | "setItem"> {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+  };
+}
+
+test("browser location and input remain isolated by session", () => {
+  const target = storage();
+  patchSessionView(target, { key: "session-a", aliases: [] }, {
+    browser: { input: "https://a.example", url: "https://a.example" },
+  });
+  patchSessionView(target, { key: "session-b", aliases: [] }, {
+    browser: { input: "https://b.example", url: "https://b.example" },
+  });
+  assert.deepEqual(readSessionView(target, { key: "session-a", aliases: [] })?.browser, {
+    input: "https://a.example",
+    url: "https://a.example",
+  });
+  assert.deepEqual(readSessionView(target, { key: "session-b", aliases: [] })?.browser, {
+    input: "https://b.example",
+    url: "https://b.example",
+  });
+});

--- a/frontend/src/features/agent/workspace/session-view-state.ts
+++ b/frontend/src/features/agent/workspace/session-view-state.ts
@@ -150,7 +150,3 @@ export function computerSessionView(computer: ComputerState): SessionComputerSta
     width: computer.width,
   };
 }
-
-export function browserSessionView(browser: BrowserState): SessionBrowserState {
-  return { input: browser.input, url: browser.url };
-}

--- a/frontend/src/features/agent/workspace/session-view-state.ts
+++ b/frontend/src/features/agent/workspace/session-view-state.ts
@@ -1,5 +1,6 @@
 import { Schema } from "effect";
 import {
+  type BrowserState,
   COMPUTER_TAB_IDS,
   type ComputerState,
   type ComputerTab,
@@ -17,12 +18,19 @@ export type SessionViewIdentity = {
 };
 
 export type SessionComputerState = Pick<ComputerState, "open" | "tab" | "tabs" | "width">;
+export type SessionBrowserState = Pick<BrowserState, "input" | "url">;
 
 export type SessionViewState = {
   scrollTop: number;
   stickToBottom: boolean;
+  browser?: SessionBrowserState;
   computer?: SessionComputerState;
 };
+
+const SessionBrowserStateSchema = Schema.Struct({
+  input: Schema.String,
+  url: Schema.String,
+});
 
 const SessionComputerStateSchema = Schema.Struct({
   open: Schema.Boolean,
@@ -34,6 +42,7 @@ const SessionComputerStateSchema = Schema.Struct({
 const SessionViewStateSchema = Schema.Struct({
   scrollTop: Schema.Number,
   stickToBottom: Schema.Boolean,
+  browser: Schema.optional(SessionBrowserStateSchema),
   computer: Schema.optional(SessionComputerStateSchema),
 });
 
@@ -72,6 +81,7 @@ function normalizeView(value: typeof SessionViewStateSchema.Type): SessionViewSt
   return {
     scrollTop: Math.max(0, value.scrollTop),
     stickToBottom: value.stickToBottom,
+    ...(value.browser ? { browser: value.browser } : {}),
     ...(computer ? { computer } : {}),
   };
 }
@@ -139,4 +149,8 @@ export function computerSessionView(computer: ComputerState): SessionComputerSta
     tabs: computer.tabs,
     width: computer.width,
   };
+}
+
+export function browserSessionView(browser: BrowserState): SessionBrowserState {
+  return { input: browser.input, url: browser.url };
 }

--- a/services/agent-runtime/src/browser-host/browser-host.ts
+++ b/services/agent-runtime/src/browser-host/browser-host.ts
@@ -237,6 +237,7 @@ type SessionRecord<RawPage> = {
   closing: Promise<void> | null;
   fallbackUrl: string | null;
   fallbackLock: Semaphore.Semaphore;
+  generation: symbol;
   host: BrowserSessionHost<RawPage>;
   inFlight: number;
   key: BrowserSessionKey;
@@ -256,9 +257,22 @@ type AcquireDecision<RawPage> =
   | { type: "evict"; record: SessionRecord<RawPage> }
   | { type: "wait"; record: SessionRecord<RawPage> };
 
+type PendingAcquisition = {
+  count: number;
+  generation: symbol;
+  resolve: () => void;
+  settlement: Promise<void>;
+};
+
+type ReleaseSettlement = {
+  generation: symbol | null;
+  settlement: Promise<void>;
+};
+
 export class BrowserHost<RawPage = Page> {
   private readonly sessions = new Map<BrowserSessionKey, SessionRecord<RawPage>>();
-  private readonly releaseSettlements = new Map<BrowserSessionKey, Promise<void>>();
+  private readonly pendingAcquisitions = new Map<BrowserSessionKey, PendingAcquisition>();
+  private readonly releaseSettlements = new Map<BrowserSessionKey, ReleaseSettlement>();
   private readonly registryLock = Semaphore.makeUnsafe(1);
   private readonly config: BrowserSessionConfig;
   private readonly now: () => number;
@@ -306,11 +320,12 @@ export class BrowserHost<RawPage = Page> {
     );
   }
 
-  private record(key: BrowserSessionKey): SessionRecord<RawPage> {
+  private record(key: BrowserSessionKey, generation: symbol): SessionRecord<RawPage> {
     return {
       closing: null,
       fallbackUrl: null,
       fallbackLock: Semaphore.makeUnsafe(1),
+      generation,
       host: new BrowserSessionHost(this.manager, key, this.options),
       inFlight: 0,
       key,
@@ -333,7 +348,7 @@ export class BrowserHost<RawPage = Page> {
     );
   }
 
-  private acquireDecision(key: BrowserSessionKey): AcquireDecision<RawPage> {
+  private acquireDecision(key: BrowserSessionKey, generation: symbol): AcquireDecision<RawPage> {
     this.assertRunning();
     const existing = this.sessions.get(key);
     if (existing) {
@@ -353,7 +368,7 @@ export class BrowserHost<RawPage = Page> {
       if (releasing) return { type: "wait", record: releasing };
       throw new Error("Browser session capacity reached while all sessions are active");
     }
-    const created = this.record(key);
+    const created = this.record(key, generation);
     created.inFlight = 1;
     this.sessions.set(key, created);
     return { type: "acquired", record: created };
@@ -361,12 +376,45 @@ export class BrowserHost<RawPage = Page> {
 
   private async acquire(key: BrowserSessionKey): Promise<SessionRecord<RawPage>> {
     this.startCleanup();
-    for (;;) {
-      const decision = await this.withPermit(async () => this.acquireDecision(key));
-      if (decision.type === "acquired") return decision.record;
-      if (decision.type === "evict") await this.closeRecord(decision.record);
-      else await Effect.runPromise(Deferred.await(decision.record.released));
+    const acquisition = this.startAcquisition(key);
+    try {
+      for (;;) {
+        const decision = await this.withPermit(async () =>
+          this.acquireDecision(key, acquisition.generation),
+        );
+        if (decision.type === "acquired") return decision.record;
+        if (decision.type === "evict") await this.closeRecord(decision.record);
+        else await Effect.runPromise(Deferred.await(decision.record.released));
+      }
+    } finally {
+      this.finishAcquisition(key, acquisition);
     }
+  }
+
+  private startAcquisition(key: BrowserSessionKey): PendingAcquisition {
+    const pending = this.pendingAcquisitions.get(key);
+    if (pending) {
+      pending.count += 1;
+      return pending;
+    }
+    const completion = Promise.withResolvers<void>();
+    const created = {
+      count: 1,
+      generation: Symbol(),
+      resolve: completion.resolve,
+      settlement: completion.promise,
+    };
+    this.pendingAcquisitions.set(key, created);
+    return created;
+  }
+
+  private finishAcquisition(key: BrowserSessionKey, acquisition: PendingAcquisition): void {
+    acquisition.count -= 1;
+    if (acquisition.count > 0) return;
+    if (this.pendingAcquisitions.get(key) === acquisition) {
+      this.pendingAcquisitions.delete(key);
+    }
+    acquisition.resolve();
   }
 
   private closeRecord(record: SessionRecord<RawPage>): Promise<void> {
@@ -559,30 +607,61 @@ export class BrowserHost<RawPage = Page> {
     } catch (error) {
       return Promise.reject(error);
     }
+    const generation =
+      this.sessions.get(key)?.generation ?? this.pendingAcquisitions.get(key)?.generation ?? null;
     const cached = this.releaseSettlements.get(key);
-    if (cached) return cached;
-    const settlement = this.releaseSessionOnce(key);
-    this.releaseSettlements.set(key, settlement);
-    void settlement.then(
+    if (cached?.generation === generation) return cached.settlement;
+    const completion = Promise.withResolvers<void>();
+    const release: ReleaseSettlement = {
+      generation,
+      settlement: completion.promise,
+    };
+    this.releaseSettlements.set(key, release);
+    void this.releaseSessionOnce(key, release).then(completion.resolve, completion.reject);
+    void release.settlement.then(
       () => {
-        if (this.releaseSettlements.get(key) === settlement) {
+        if (this.releaseSettlements.get(key) === release) {
           this.releaseSettlements.delete(key);
         }
       },
       () => undefined,
     );
-    return settlement;
+    return release.settlement;
   }
 
-  private async releaseSessionOnce(key: BrowserSessionKey): Promise<void> {
-    const record = await this.withPermit(async () => {
-      const record = this.sessions.get(key);
-      if (!record) return null;
-      record.releaseRequested = true;
-      record.releaseStarted = true;
-      return record;
-    });
-    if (record) await this.closeRecord(record);
+  private async releaseSessionOnce(
+    key: BrowserSessionKey,
+    release: ReleaseSettlement,
+  ): Promise<void> {
+    for (;;) {
+      const decision = await this.withPermit(async () => {
+        const record = this.sessions.get(key) ?? null;
+        if (record?.generation === release.generation) {
+          record.releaseRequested = true;
+          record.releaseStarted = true;
+          return { record, settlement: null };
+        }
+        const pending = this.pendingAcquisitions.get(key);
+        if (!record && pending?.generation === release.generation) {
+          return { record: null, settlement: pending.settlement };
+        }
+        return { record: null, settlement: null };
+      });
+      if (decision.settlement) {
+        await decision.settlement;
+        continue;
+      }
+      if (!decision.record) {
+        release.generation = null;
+        return;
+      }
+      try {
+        await this.closeRecord(decision.record);
+      } finally {
+        release.generation = null;
+      }
+      return;
+    }
   }
 
   async cleanupIdleSessions(): Promise<void> {

--- a/services/agent-runtime/src/browser-host/browser-host.ts
+++ b/services/agent-runtime/src/browser-host/browser-host.ts
@@ -216,11 +216,9 @@ class BrowserSessionHost<RawPage> {
   release(): Promise<void> {
     if (this.stopping) return this.stopping;
     this.stopped = true;
-    this.stopping = this.withPermit(this.transitionLock, async () => {
-      this.pages.clear();
-      this.activeId = null;
-      await this.manager.release(this.scope);
-    });
+    this.pages.clear();
+    this.activeId = null;
+    this.stopping = this.manager.release(this.scope);
     return this.stopping;
   }
 
@@ -338,7 +336,7 @@ export class BrowserHost<RawPage = Page> {
     this.assertRunning();
     const existing = this.sessions.get(key);
     if (existing) {
-      if (existing.releaseRequested) return { type: "wait", record: existing };
+      if (existing.releaseRequested) throw new Error("Browser session is releasing");
       existing.inFlight += 1;
       existing.lastAccess = this.now();
       return { type: "acquired", record: existing };
@@ -559,7 +557,7 @@ export class BrowserHost<RawPage = Page> {
       const record = this.sessions.get(key);
       if (!record) return null;
       record.releaseRequested = true;
-      if (record.inFlight > 0 || record.releaseStarted) return { close: false, record };
+      if (record.releaseStarted) return { close: false, record };
       record.releaseStarted = true;
       return { close: true, record };
     });
@@ -596,14 +594,11 @@ export class BrowserHost<RawPage = Page> {
     const records = await this.withPermit(async () =>
       [...this.sessions.values()].map((record) => {
         record.releaseRequested = true;
-        if (record.inFlight === 0) record.releaseStarted = true;
+        record.releaseStarted = true;
         return record;
       }),
     );
-    await Promise.all(
-      records.filter((record) => record.releaseStarted).map((record) => this.closeRecord(record)),
-    );
-    await Promise.all(records.map((record) => Effect.runPromise(Deferred.await(record.released))));
+    await Promise.all(records.map((record) => this.closeRecord(record)));
     await this.manager.stop();
   }
 }

--- a/services/agent-runtime/src/browser-host/browser-host.ts
+++ b/services/agent-runtime/src/browser-host/browser-host.ts
@@ -258,6 +258,7 @@ type AcquireDecision<RawPage> =
 
 export class BrowserHost<RawPage = Page> {
   private readonly sessions = new Map<BrowserSessionKey, SessionRecord<RawPage>>();
+  private readonly releaseSettlements = new Map<BrowserSessionKey, Promise<void>>();
   private readonly registryLock = Semaphore.makeUnsafe(1);
   private readonly config: BrowserSessionConfig;
   private readonly now: () => number;
@@ -368,9 +369,9 @@ export class BrowserHost<RawPage = Page> {
     }
   }
 
-  private async closeRecord(record: SessionRecord<RawPage>): Promise<void> {
+  private closeRecord(record: SessionRecord<RawPage>): Promise<void> {
     record.closing ??= this.closeRecordOnce(record);
-    await record.closing;
+    return record.closing;
   }
 
   private async closeRecordOnce(record: SessionRecord<RawPage>): Promise<void> {
@@ -551,19 +552,37 @@ export class BrowserHost<RawPage = Page> {
     );
   }
 
-  async releaseSession(sessionKey: BrowserSessionKey): Promise<void> {
-    const key = decodeBrowserSessionKey(sessionKey);
-    const decision = await this.withPermit(async () => {
+  releaseSession(sessionKey: BrowserSessionKey): Promise<void> {
+    let key: BrowserSessionKey;
+    try {
+      key = decodeBrowserSessionKey(sessionKey);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+    const cached = this.releaseSettlements.get(key);
+    if (cached) return cached;
+    const settlement = this.releaseSessionOnce(key);
+    this.releaseSettlements.set(key, settlement);
+    void settlement.then(
+      () => {
+        if (this.releaseSettlements.get(key) === settlement) {
+          this.releaseSettlements.delete(key);
+        }
+      },
+      () => undefined,
+    );
+    return settlement;
+  }
+
+  private async releaseSessionOnce(key: BrowserSessionKey): Promise<void> {
+    const record = await this.withPermit(async () => {
       const record = this.sessions.get(key);
       if (!record) return null;
       record.releaseRequested = true;
-      if (record.releaseStarted) return { close: false, record };
       record.releaseStarted = true;
-      return { close: true, record };
+      return record;
     });
-    if (!decision) return;
-    if (decision.close) await this.closeRecord(decision.record);
-    await Effect.runPromise(Deferred.await(decision.record.released));
+    if (record) await this.closeRecord(record);
   }
 
   async cleanupIdleSessions(): Promise<void> {

--- a/services/agent-runtime/src/browser-host/browser-host.ts
+++ b/services/agent-runtime/src/browser-host/browser-host.ts
@@ -415,6 +415,26 @@ export class BrowserHost<RawPage = Page> {
     }
   }
 
+  private async withExistingSession<A>(
+    sessionKey: BrowserSessionKey,
+    task: (session: BrowserSessionHost<RawPage>) => Promise<A>,
+  ): Promise<A | null> {
+    const key = decodeBrowserSessionKey(sessionKey);
+    const record = await this.withPermit(async () => {
+      const existing = this.sessions.get(key);
+      if (!existing || existing.releaseRequested) return null;
+      existing.inFlight += 1;
+      existing.lastAccess = this.now();
+      return existing;
+    });
+    if (!record) return null;
+    try {
+      return await task(record.host);
+    } finally {
+      await this.finish(record);
+    }
+  }
+
   private withFallbackPermit<A>(
     record: SessionRecord<RawPage>,
     task: () => Promise<A>,
@@ -438,6 +458,10 @@ export class BrowserHost<RawPage = Page> {
 
   getState(sessionKey: BrowserSessionKey, pageId?: string): Promise<PageState> {
     return this.withSession(sessionKey, (session) => session.getState(pageId));
+  }
+
+  peekState(sessionKey: BrowserSessionKey): Promise<PageState | null> {
+    return this.withExistingSession(sessionKey, (session) => session.peekState());
   }
 
   goBack(sessionKey: BrowserSessionKey, pageId?: string): Promise<void> {

--- a/services/agent-runtime/src/browser-host/browser-host.ts
+++ b/services/agent-runtime/src/browser-host/browser-host.ts
@@ -1,6 +1,15 @@
+import { Deferred, Effect, Fiber, Schedule, Semaphore } from "effect";
+import type { Page } from "playwright-core";
+import { type BrowserSessionKey } from "../../../../shared/agent/browser-session";
+import { sanitizeBrowserPaneUrl } from "../../../../shared/agent/sanitize-embedded-browser-url";
 import { getGlobalSingleton } from "../instances";
 import { HostedPage, type PageState, type ScreencastFrame } from "./hosted-page";
-import { playwrightManager } from "./playwright";
+import {
+  browserSessionConfig,
+  decodeBrowserSessionKey,
+  type BrowserSessionConfig,
+} from "./browser-session";
+import { playwrightManager, type ManagedPlaywrightSession } from "./playwright";
 
 export type { PageState, ScreencastFrame };
 
@@ -14,46 +23,116 @@ const normalizeUrl = (value: string): string =>
 const capString = (value: string, maximum: number): string =>
   value.length > maximum ? value.slice(0, maximum) : value;
 
-class BrowserHost {
-  private pages = new Map<string, HostedPage>();
-  private activeId: string | null = null;
+export type BrowserContextSurface<RawPage> = {
+  newPage: () => Promise<RawPage>;
+  pages: () => RawPage[];
+};
 
-  isAvailable(): boolean {
-    return playwrightManager.isAvailable();
+export type BrowserPage<RawPage> = {
+  captureFrame: () => Promise<ScreencastFrame | null>;
+  click: (selector: string) => Promise<boolean>;
+  close: () => void;
+  readonly closed: boolean;
+  dispatchKey: (input: KeyInput) => Promise<void>;
+  dispatchMouse: (input: MouseInput) => Promise<void>;
+  evaluate: (expression: string) => Promise<unknown>;
+  fill: (selector: string, value: string) => Promise<boolean>;
+  goBack: (timeout: number) => Promise<void>;
+  goForward: (timeout: number) => Promise<void>;
+  html: () => Promise<string>;
+  readonly id: string;
+  matches: (page: RawPage) => boolean;
+  navigate: (url: string, timeout: number) => Promise<void>;
+  readState: () => Promise<PageState>;
+  reload: (timeout: number) => Promise<void>;
+  screenshot: (type: "png" | "jpeg", quality?: number) => Promise<string>;
+  scroll: (deltaX: number, deltaY: number) => Promise<number>;
+  setViewport: (width: number, height: number) => Promise<void>;
+  text: () => Promise<string>;
+};
+
+export type BrowserHostManager<RawPage = Page> = {
+  ensure: (scope: string) => Promise<ManagedPlaywrightSession<BrowserContextSurface<RawPage>>>;
+  isAvailable: () => boolean;
+  release: (scope: string) => Promise<void>;
+  stop: () => Promise<void>;
+};
+
+type BrowserSessionHostOptions<RawPage> = {
+  attachPage?: (page: RawPage) => BrowserPage<RawPage>;
+};
+
+export type BrowserHostOptions<RawPage> = BrowserSessionHostOptions<RawPage> & {
+  cleanupIntervalMs?: number;
+  config?: BrowserSessionConfig;
+  now?: () => number;
+};
+
+class BrowserSessionHost<RawPage> {
+  private readonly pages = new Map<string, BrowserPage<RawPage>>();
+  private activeId: string | null = null;
+  private activeGeneration = 0;
+  private stopped = false;
+  private stopping: Promise<void> | null = null;
+  private readonly navigationLock = Semaphore.makeUnsafe(1);
+  private readonly transitionLock = Semaphore.makeUnsafe(1);
+
+  constructor(
+    private readonly manager: BrowserHostManager<RawPage>,
+    private readonly scope: BrowserSessionKey,
+    private readonly options: BrowserSessionHostOptions<RawPage>,
+  ) {}
+
+  page(pageId?: string): Promise<BrowserPage<RawPage>> {
+    return this.withPermit(this.transitionLock, () => this.pageUnlocked(pageId));
   }
 
-  async page(pageId?: string): Promise<HostedPage> {
+  private async pageUnlocked(pageId?: string): Promise<BrowserPage<RawPage>> {
+    this.assertRunning();
+    const attachPage = this.options.attachPage;
+    if (!attachPage) throw new Error("Browser page adapter unavailable");
+    const session = await this.manager.ensure(this.scope);
+    this.assertRunning();
+    if (session.generation !== this.activeGeneration) {
+      this.pages.clear();
+      this.activeId = null;
+      this.activeGeneration = session.generation;
+    }
     const targetId = pageId ?? this.activeId;
     const cached = targetId ? this.pages.get(targetId) : undefined;
+    if (pageId && !cached) throw new Error("Browser page does not belong to session");
     if (cached && !cached.closed) {
       this.activeId = cached.id;
       return cached;
     }
     if (cached) this.pages.delete(cached.id);
-
-    const context = await playwrightManager.ensure();
-    const rawPage =
-      context
-        .pages()
-        .find((candidate) =>
-          Array.from(this.pages.values()).every((hosted) => !hosted.matches(candidate)),
-        ) ?? (await context.newPage());
-    const hosted = HostedPage.attach(rawPage);
+    const existing = session.context
+      .pages()
+      .find((candidate) =>
+        Array.from(this.pages.values()).every((hosted) => !hosted.matches(candidate)),
+      );
+    const rawPage = existing ?? (await session.context.newPage());
+    this.assertRunning();
+    const hosted = attachPage(rawPage);
     this.pages.set(hosted.id, hosted);
     this.activeId = hosted.id;
     return hosted;
   }
 
-  async navigate(url: string, pageId?: string): Promise<{ url: string; title: string }> {
-    const page = await this.page(pageId);
-    await page.navigate(normalizeUrl(url), NAVIGATION_TIMEOUT_MS);
-    const state = await page.readState();
-    return { url: state.url, title: state.title };
+  navigate(url: string, pageId?: string): Promise<{ url: string; title: string }> {
+    const navigation = sanitizeBrowserPaneUrl(normalizeUrl(url));
+    if (!navigation) return Promise.reject(new Error("Browser navigation URL is not allowed"));
+    return this.withPermit(this.navigationLock, async () => {
+      const page = await this.page(pageId);
+      await page.navigate(navigation, NAVIGATION_TIMEOUT_MS);
+      const state = await page.readState();
+      return { title: state.title, url: state.url };
+    });
   }
 
   async getUrl(pageId?: string): Promise<{ url: string; title: string }> {
     const state = await (await this.page(pageId)).readState();
-    return { url: state.url, title: state.title };
+    return { title: state.title, url: state.url };
   }
 
   async getState(pageId?: string): Promise<PageState> {
@@ -86,17 +165,19 @@ class BrowserHost {
     return capString(await (await this.page(pageId)).html(), HTML_CAP_BYTES);
   }
 
+  async evaluate(expression: string, pageId?: string): Promise<unknown> {
+    return (await this.page(pageId)).evaluate(expression);
+  }
+
   async click(args: { selector: string }, pageId?: string): Promise<{ found: boolean }> {
-    const page = await this.page(pageId);
-    return { found: await page.click(args.selector) };
+    return { found: await (await this.page(pageId)).click(args.selector) };
   }
 
   async fill(
     args: { selector: string; value: string },
     pageId?: string,
   ): Promise<{ found: boolean }> {
-    const page = await this.page(pageId);
-    return { found: await page.fill(args.selector, args.value) };
+    return { found: await (await this.page(pageId)).fill(args.selector, args.value) };
   }
 
   async scroll(
@@ -132,11 +213,374 @@ class BrowserHost {
     await (await this.page(pageId)).dispatchKey(args);
   }
 
-  stop(): void {
-    for (const page of this.pages.values()) page.close();
-    this.pages.clear();
-    this.activeId = null;
-    playwrightManager.stop();
+  release(): Promise<void> {
+    if (this.stopping) return this.stopping;
+    this.stopped = true;
+    this.stopping = this.withPermit(this.transitionLock, async () => {
+      this.pages.clear();
+      this.activeId = null;
+      await this.manager.release(this.scope);
+    });
+    return this.stopping;
+  }
+
+  private assertRunning(): void {
+    if (this.stopped) throw new Error("Browser host stopped");
+  }
+
+  private withPermit<A>(semaphore: Semaphore.Semaphore, task: () => Promise<A>): Promise<A> {
+    return Effect.runPromise(
+      semaphore.withPermit(Effect.tryPromise({ try: task, catch: (error) => error })),
+    );
+  }
+}
+
+type SessionRecord<RawPage> = {
+  closing: Promise<void> | null;
+  fallbackUrl: string | null;
+  fallbackLock: Semaphore.Semaphore;
+  host: BrowserSessionHost<RawPage>;
+  inFlight: number;
+  key: BrowserSessionKey;
+  lastAccess: number;
+  releaseRequested: boolean;
+  releaseStarted: boolean;
+  released: Deferred.Deferred<void>;
+};
+
+export type BrowserFallbackResult<A> = {
+  url?: string;
+  result: A;
+};
+
+type AcquireDecision<RawPage> =
+  | { type: "acquired"; record: SessionRecord<RawPage> }
+  | { type: "evict"; record: SessionRecord<RawPage> }
+  | { type: "wait"; record: SessionRecord<RawPage> };
+
+export class BrowserHost<RawPage = Page> {
+  private readonly sessions = new Map<BrowserSessionKey, SessionRecord<RawPage>>();
+  private readonly registryLock = Semaphore.makeUnsafe(1);
+  private readonly config: BrowserSessionConfig;
+  private readonly now: () => number;
+  private readonly cleanupIntervalMs: number;
+  private cleanupFiber: ReturnType<typeof Effect.runFork> | null = null;
+  private stopping: Promise<void> | null = null;
+  private stopped = false;
+
+  constructor(
+    private readonly manager: BrowserHostManager<RawPage>,
+    private readonly options: BrowserHostOptions<RawPage> = {},
+  ) {
+    this.config = options.config ?? browserSessionConfig();
+    this.now = options.now ?? Date.now;
+    this.cleanupIntervalMs =
+      options.cleanupIntervalMs ??
+      Math.min(60_000, Math.max(1_000, Math.floor(this.config.idleMs / 2)));
+  }
+
+  isAvailable(): boolean {
+    return this.manager.isAvailable();
+  }
+
+  private assertRunning(): void {
+    if (this.stopped) throw new Error("Browser host stopped");
+  }
+
+  private withPermit<A>(task: () => Promise<A>): Promise<A> {
+    return Effect.runPromise(
+      this.registryLock.withPermit(Effect.tryPromise({ try: task, catch: (error) => error })),
+    );
+  }
+
+  private startCleanup(): void {
+    if (this.cleanupFiber || this.stopped) return;
+    this.cleanupFiber = Effect.runFork(
+      Effect.tryPromise({
+        try: () => this.cleanupIdleSessions(),
+        catch: (error) => error,
+      }).pipe(
+        Effect.catch(() => Effect.void),
+        Effect.repeat(Schedule.spaced(this.cleanupIntervalMs)),
+        Effect.asVoid,
+      ),
+    );
+  }
+
+  private record(key: BrowserSessionKey): SessionRecord<RawPage> {
+    return {
+      closing: null,
+      fallbackUrl: null,
+      fallbackLock: Semaphore.makeUnsafe(1),
+      host: new BrowserSessionHost(this.manager, key, this.options),
+      inFlight: 0,
+      key,
+      lastAccess: this.now(),
+      releaseRequested: false,
+      releaseStarted: false,
+      released: Deferred.makeUnsafe<void>(),
+    };
+  }
+
+  private lruIdleRecord(): SessionRecord<RawPage> | null {
+    return (
+      [...this.sessions.values()]
+        .filter((record) => record.inFlight === 0 && !record.releaseRequested)
+        .sort((left, right) =>
+          left.lastAccess === right.lastAccess
+            ? left.key.localeCompare(right.key)
+            : left.lastAccess - right.lastAccess,
+        )[0] ?? null
+    );
+  }
+
+  private acquireDecision(key: BrowserSessionKey): AcquireDecision<RawPage> {
+    this.assertRunning();
+    const existing = this.sessions.get(key);
+    if (existing) {
+      if (existing.releaseRequested) return { type: "wait", record: existing };
+      existing.inFlight += 1;
+      existing.lastAccess = this.now();
+      return { type: "acquired", record: existing };
+    }
+    if (this.sessions.size >= this.config.maxSessions) {
+      const idle = this.lruIdleRecord();
+      if (idle) {
+        idle.releaseRequested = true;
+        idle.releaseStarted = true;
+        return { type: "evict", record: idle };
+      }
+      const releasing = [...this.sessions.values()].find((record) => record.releaseRequested);
+      if (releasing) return { type: "wait", record: releasing };
+      throw new Error("Browser session capacity reached while all sessions are active");
+    }
+    const created = this.record(key);
+    created.inFlight = 1;
+    this.sessions.set(key, created);
+    return { type: "acquired", record: created };
+  }
+
+  private async acquire(key: BrowserSessionKey): Promise<SessionRecord<RawPage>> {
+    this.startCleanup();
+    for (;;) {
+      const decision = await this.withPermit(async () => this.acquireDecision(key));
+      if (decision.type === "acquired") return decision.record;
+      if (decision.type === "evict") await this.closeRecord(decision.record);
+      else await Effect.runPromise(Deferred.await(decision.record.released));
+    }
+  }
+
+  private async closeRecord(record: SessionRecord<RawPage>): Promise<void> {
+    record.closing ??= this.closeRecordOnce(record);
+    await record.closing;
+  }
+
+  private async closeRecordOnce(record: SessionRecord<RawPage>): Promise<void> {
+    let failure: unknown;
+    try {
+      await record.host.release();
+    } catch (error) {
+      failure = error;
+      await this.manager.stop().catch(() => undefined);
+    } finally {
+      await this.withPermit(async () => {
+        if (this.sessions.get(record.key) === record) this.sessions.delete(record.key);
+        Deferred.doneUnsafe(record.released, Effect.void);
+      });
+    }
+    if (failure) throw failure;
+  }
+
+  private async finish(record: SessionRecord<RawPage>): Promise<void> {
+    const close = await this.withPermit(async () => {
+      record.inFlight = Math.max(0, record.inFlight - 1);
+      record.lastAccess = this.now();
+      if (!record.releaseRequested || record.inFlight > 0 || record.releaseStarted) return false;
+      record.releaseStarted = true;
+      return true;
+    });
+    if (close) await this.closeRecord(record);
+  }
+
+  private async withSession<A>(
+    sessionKey: BrowserSessionKey,
+    task: (session: BrowserSessionHost<RawPage>, record: SessionRecord<RawPage>) => Promise<A>,
+  ): Promise<A> {
+    const key = decodeBrowserSessionKey(sessionKey);
+    const record = await this.acquire(key);
+    try {
+      return await task(record.host, record);
+    } finally {
+      await this.finish(record);
+    }
+  }
+
+  private withFallbackPermit<A>(
+    record: SessionRecord<RawPage>,
+    task: () => Promise<A>,
+  ): Promise<A> {
+    return Effect.runPromise(
+      record.fallbackLock.withPermit(Effect.tryPromise({ try: task, catch: (error) => error })),
+    );
+  }
+
+  navigate(
+    sessionKey: BrowserSessionKey,
+    url: string,
+    pageId?: string,
+  ): Promise<{ url: string; title: string }> {
+    return this.withSession(sessionKey, (session) => session.navigate(url, pageId));
+  }
+
+  getUrl(sessionKey: BrowserSessionKey, pageId?: string): Promise<{ url: string; title: string }> {
+    return this.withSession(sessionKey, (session) => session.getUrl(pageId));
+  }
+
+  getState(sessionKey: BrowserSessionKey, pageId?: string): Promise<PageState> {
+    return this.withSession(sessionKey, (session) => session.getState(pageId));
+  }
+
+  goBack(sessionKey: BrowserSessionKey, pageId?: string): Promise<void> {
+    return this.withSession(sessionKey, (session) => session.goBack(pageId));
+  }
+
+  goForward(sessionKey: BrowserSessionKey, pageId?: string): Promise<void> {
+    return this.withSession(sessionKey, (session) => session.goForward(pageId));
+  }
+
+  reload(sessionKey: BrowserSessionKey, pageId?: string): Promise<void> {
+    return this.withSession(sessionKey, (session) => session.reload(pageId));
+  }
+
+  getText(sessionKey: BrowserSessionKey, pageId?: string): Promise<string> {
+    return this.withSession(sessionKey, (session) => session.getText(pageId));
+  }
+
+  getHtml(sessionKey: BrowserSessionKey, pageId?: string): Promise<string> {
+    return this.withSession(sessionKey, (session) => session.getHtml(pageId));
+  }
+
+  evaluate(sessionKey: BrowserSessionKey, expression: string, pageId?: string): Promise<unknown> {
+    return this.withSession(sessionKey, (session) => session.evaluate(expression, pageId));
+  }
+
+  click(
+    sessionKey: BrowserSessionKey,
+    args: { selector: string },
+    pageId?: string,
+  ): Promise<{ found: boolean }> {
+    return this.withSession(sessionKey, (session) => session.click(args, pageId));
+  }
+
+  fill(
+    sessionKey: BrowserSessionKey,
+    args: { selector: string; value: string },
+    pageId?: string,
+  ): Promise<{ found: boolean }> {
+    return this.withSession(sessionKey, (session) => session.fill(args, pageId));
+  }
+
+  scroll(
+    sessionKey: BrowserSessionKey,
+    args: { deltaY: number; deltaX?: number },
+    pageId?: string,
+  ): Promise<{ deltaX: number; deltaY: number; scrollY: number }> {
+    return this.withSession(sessionKey, (session) => session.scroll(args, pageId));
+  }
+
+  screenshot(sessionKey: BrowserSessionKey, pageId?: string): Promise<string> {
+    return this.withSession(sessionKey, (session) => session.screenshot(pageId));
+  }
+
+  setViewport(
+    sessionKey: BrowserSessionKey,
+    width: number,
+    height: number,
+    pageId?: string,
+  ): Promise<void> {
+    return this.withSession(sessionKey, (session) => session.setViewport(width, height, pageId));
+  }
+
+  pollFrame(
+    sessionKey: BrowserSessionKey,
+    pageId?: string,
+  ): Promise<{ frame: ScreencastFrame | null; state: PageState }> {
+    return this.withSession(sessionKey, (session) => session.pollFrame(pageId));
+  }
+
+  dispatchMouse(sessionKey: BrowserSessionKey, args: MouseInput, pageId?: string): Promise<void> {
+    return this.withSession(sessionKey, (session) => session.dispatchMouse(args, pageId));
+  }
+
+  dispatchKey(sessionKey: BrowserSessionKey, args: KeyInput, pageId?: string): Promise<void> {
+    return this.withSession(sessionKey, (session) => session.dispatchKey(args, pageId));
+  }
+
+  withFallbackSession<A>(
+    sessionKey: BrowserSessionKey,
+    task: (url: string | null) => Promise<BrowserFallbackResult<A>>,
+  ): Promise<A> {
+    return this.withSession(sessionKey, async (_session, record) =>
+      this.withFallbackPermit(record, async () => {
+        const transition = await task(record.fallbackUrl);
+        if (transition.url) record.fallbackUrl = transition.url;
+        return transition.result;
+      }),
+    );
+  }
+
+  async releaseSession(sessionKey: BrowserSessionKey): Promise<void> {
+    const key = decodeBrowserSessionKey(sessionKey);
+    const decision = await this.withPermit(async () => {
+      const record = this.sessions.get(key);
+      if (!record) return null;
+      record.releaseRequested = true;
+      if (record.inFlight > 0 || record.releaseStarted) return { close: false, record };
+      record.releaseStarted = true;
+      return { close: true, record };
+    });
+    if (!decision) return;
+    if (decision.close) await this.closeRecord(decision.record);
+    await Effect.runPromise(Deferred.await(decision.record.released));
+  }
+
+  async cleanupIdleSessions(): Promise<void> {
+    const expired = await this.withPermit(async () => {
+      const threshold = this.now() - this.config.idleMs;
+      return [...this.sessions.values()].filter((record) => {
+        if (record.inFlight > 0 || record.releaseRequested || record.lastAccess > threshold) {
+          return false;
+        }
+        record.releaseRequested = true;
+        record.releaseStarted = true;
+        return true;
+      });
+    });
+    await Promise.all(expired.map((record) => this.closeRecord(record)));
+  }
+
+  stop(): Promise<void> {
+    this.stopping ??= this.stopOnce();
+    return this.stopping;
+  }
+
+  private async stopOnce(): Promise<void> {
+    this.stopped = true;
+    const cleanup = this.cleanupFiber;
+    this.cleanupFiber = null;
+    if (cleanup) await Effect.runPromise(Fiber.interrupt(cleanup));
+    const records = await this.withPermit(async () =>
+      [...this.sessions.values()].map((record) => {
+        record.releaseRequested = true;
+        if (record.inFlight === 0) record.releaseStarted = true;
+        return record;
+      }),
+    );
+    await Promise.all(
+      records.filter((record) => record.releaseStarted).map((record) => this.closeRecord(record)),
+    );
+    await Promise.all(records.map((record) => Effect.runPromise(Deferred.await(record.released))));
+    await this.manager.stop();
   }
 }
 
@@ -157,4 +601,7 @@ const clampDelta = (value: number): number => {
   return Math.max(-10_000, Math.min(10_000, Math.trunc(value)));
 };
 
-export const browserHost = getGlobalSingleton("browserHost", () => new BrowserHost());
+export const browserHost = getGlobalSingleton(
+  "browserHost",
+  () => new BrowserHost(playwrightManager, { attachPage: HostedPage.attach }),
+);

--- a/services/agent-runtime/src/browser-host/browser-session.ts
+++ b/services/agent-runtime/src/browser-host/browser-session.ts
@@ -1,0 +1,47 @@
+import { Schema } from "effect";
+import {
+  BROWSER_SESSION_KEY_PATTERN,
+  type BrowserSessionKey,
+} from "../../../../shared/agent/browser-session";
+
+export const BrowserSessionKeySchema = Schema.String.pipe(
+  Schema.check(
+    Schema.isMinLength(1),
+    Schema.isMaxLength(128),
+    Schema.isPattern(BROWSER_SESSION_KEY_PATTERN),
+  ),
+);
+
+export function decodeBrowserSessionKey(input: unknown): BrowserSessionKey {
+  return Schema.decodeUnknownSync(BrowserSessionKeySchema)(input);
+}
+
+const SessionLimitSchema = Schema.NumberFromString.pipe(
+  Schema.check(
+    Schema.isFinite(),
+    Schema.isInt(),
+    Schema.isGreaterThanOrEqualTo(1),
+    Schema.isLessThanOrEqualTo(32),
+  ),
+);
+const SessionIdleSchema = Schema.NumberFromString.pipe(
+  Schema.check(
+    Schema.isFinite(),
+    Schema.isInt(),
+    Schema.isGreaterThanOrEqualTo(60_000),
+    Schema.isLessThanOrEqualTo(86_400_000),
+  ),
+);
+const BrowserSessionConfigSchema = Schema.Struct({
+  maxSessions: SessionLimitSchema,
+  idleMs: SessionIdleSchema,
+});
+
+export type BrowserSessionConfig = typeof BrowserSessionConfigSchema.Type;
+
+export function browserSessionConfig(env: NodeJS.ProcessEnv = process.env): BrowserSessionConfig {
+  return Schema.decodeUnknownSync(BrowserSessionConfigSchema)({
+    maxSessions: env.LOCAL_STUDIO_BROWSER_MAX_SESSIONS ?? "8",
+    idleMs: env.LOCAL_STUDIO_BROWSER_SESSION_IDLE_MS ?? "900000",
+  });
+}

--- a/services/agent-runtime/src/browser-host/playwright.ts
+++ b/services/agent-runtime/src/browser-host/playwright.ts
@@ -164,13 +164,8 @@ export class PlaywrightManager<Context = BrowserContext> {
     return !this.stopped && this.poisoned === null && this.resolveBinary() !== null;
   }
 
-  ensure(): Promise<Context>;
-  ensure(scope: string): Promise<ManagedPlaywrightSession<Context>>;
-  ensure(scope?: string): Promise<Context | ManagedPlaywrightSession<Context>> {
-    return this.withPermit(async () => {
-      const session = await this.ensureUnlocked(scope ?? "legacy");
-      return scope === undefined ? session.context : session;
-    });
+  ensure(scope: string): Promise<ManagedPlaywrightSession<Context>> {
+    return this.withPermit(() => this.ensureUnlocked(scope));
   }
 
   current(scope: string): ManagedPlaywrightSession<Context> | null {

--- a/services/agent-runtime/src/browser-host/playwright.ts
+++ b/services/agent-runtime/src/browser-host/playwright.ts
@@ -1,13 +1,12 @@
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import os from "node:os";
 import path from "node:path";
-import { chromium, type BrowserContext } from "playwright-core";
+import { Effect, Semaphore } from "effect";
+import { chromium, type Browser, type BrowserContext } from "playwright-core";
 import { getGlobalSingleton } from "../instances";
 
 const LAUNCH_TIMEOUT_MS = 15_000;
-
-const browserDataDirectory = (): string => path.join(os.tmpdir(), "local-studio-browser-profile");
+const REVOCATION_TIMEOUT_MS = 5_000;
 
 const resolveOnPath = (binary: string): string | null => {
   try {
@@ -69,63 +68,200 @@ export const findBrowserBinary = (): string | null => {
   return platformBrowserCandidates().find((candidate) => existsSync(candidate)) ?? null;
 };
 
-class PlaywrightManager {
-  private context: BrowserContext | null = null;
-  private launching: Promise<BrowserContext> | null = null;
+export type ManagedPlaywrightSession<Context> = {
+  close: () => Promise<void>;
+  closed: () => boolean;
+  context: Context;
+  generation: number;
+  onClose: (listener: () => void) => void;
+};
 
-  isAvailable(): boolean {
-    return findBrowserBinary() !== null;
+export type LaunchPlaywrightSession<Context> = (
+  executablePath: string,
+) => Promise<Omit<ManagedPlaywrightSession<Context>, "generation">>;
+
+export type PlaywrightManagerOptions<Context> = {
+  closeTimeoutMs?: number;
+  launch: LaunchPlaywrightSession<Context>;
+  resolveBinary?: () => string | null;
+};
+
+export const createPlaywrightSessionLauncher = (): LaunchPlaywrightSession<BrowserContext> => {
+  let browser: Browser | null = null;
+  let launching: Promise<Browser> | null = null;
+  const contexts = new Set<BrowserContext>();
+
+  const ensureBrowser = (executablePath: string): Promise<Browser> => {
+    if (browser?.isConnected()) return Promise.resolve(browser);
+    launching ??= chromium
+      .launch({
+        executablePath,
+        headless: true,
+        timeout: LAUNCH_TIMEOUT_MS,
+        args: ["--no-first-run", "--no-default-browser-check", "--disable-dev-shm-usage"],
+      })
+      .then((launched) => {
+        browser = launched;
+        launched.once("disconnected", () => {
+          if (browser === launched) browser = null;
+        });
+        return launched;
+      })
+      .finally(() => {
+        launching = null;
+      });
+    return launching;
+  };
+
+  return async (executablePath) => {
+    const activeBrowser = await ensureBrowser(executablePath);
+    const context = await activeBrowser.newContext({ viewport: { width: 1280, height: 800 } });
+    contexts.add(context);
+    let isClosed = false;
+    const listeners = new Set<() => void>();
+    context.once("close", () => {
+      isClosed = true;
+      contexts.delete(context);
+      for (const listener of listeners) listener();
+      listeners.clear();
+      if (contexts.size === 0 && browser === activeBrowser) {
+        browser = null;
+        void activeBrowser.close().catch(() => undefined);
+      }
+    });
+    return {
+      close: () => context.close(),
+      closed: () => isClosed,
+      context,
+      onClose: (listener) => listeners.add(listener),
+    };
+  };
+};
+
+const launchPlaywrightSession = createPlaywrightSessionLauncher();
+
+export class PlaywrightManager<Context = BrowserContext> {
+  private readonly active = new Map<string, ManagedPlaywrightSession<Context>>();
+  private generation = 0;
+  private poisoned: unknown = null;
+  private stopped = false;
+  private readonly transitionLock = Semaphore.makeUnsafe(1);
+  private readonly closeTimeoutMs: number;
+  private readonly launch: LaunchPlaywrightSession<Context>;
+  private readonly resolveBinary: () => string | null;
+
+  constructor({
+    closeTimeoutMs = REVOCATION_TIMEOUT_MS,
+    launch,
+    resolveBinary = findBrowserBinary,
+  }: PlaywrightManagerOptions<Context>) {
+    this.closeTimeoutMs = closeTimeoutMs;
+    this.launch = launch;
+    this.resolveBinary = resolveBinary;
   }
 
-  async ensure(): Promise<BrowserContext> {
-    if (this.context) return this.context;
-    if (this.launching) return this.launching;
-    const executablePath = findBrowserBinary();
+  isAvailable(): boolean {
+    return !this.stopped && this.poisoned === null && this.resolveBinary() !== null;
+  }
+
+  ensure(): Promise<Context>;
+  ensure(scope: string): Promise<ManagedPlaywrightSession<Context>>;
+  ensure(scope?: string): Promise<Context | ManagedPlaywrightSession<Context>> {
+    return this.withPermit(async () => {
+      const session = await this.ensureUnlocked(scope ?? "legacy");
+      return scope === undefined ? session.context : session;
+    });
+  }
+
+  current(scope: string): ManagedPlaywrightSession<Context> | null {
+    return this.active.get(scope) ?? null;
+  }
+
+  release(scope: string): Promise<void> {
+    return this.withPermit(() => this.revokeActive(scope));
+  }
+
+  stop(): Promise<void> {
+    return this.withPermit(() => this.stopUnlocked());
+  }
+
+  private async ensureUnlocked(scope: string): Promise<ManagedPlaywrightSession<Context>> {
+    this.assertUsable();
+    const active = this.active.get(scope);
+    if (active?.closed()) this.active.delete(scope);
+    const current = this.active.get(scope);
+    if (current) return current;
+    const executablePath = this.resolveBinary();
     if (!executablePath) {
       throw new Error("Browser unavailable: no Chromium found — set LOCAL_STUDIO_CHROME_PATH");
     }
-    const launch = (userDataDir: string): Promise<BrowserContext> =>
-      chromium.launchPersistentContext(userDataDir, {
-        executablePath,
-        headless: true,
-        viewport: { width: 1280, height: 800 },
-        timeout: LAUNCH_TIMEOUT_MS,
-        args: ["--no-first-run", "--no-default-browser-check", "--disable-dev-shm-usage"],
-      });
-    const dataDirectory = browserDataDirectory();
-    this.launching = launch(dataDirectory)
-      .catch((error: unknown) => {
-        if (!String(error).includes("ProcessSingleton")) throw error;
-        return launch(`${dataDirectory}-${process.pid}`);
-      })
-      .then((context) => {
-        this.context = context;
-        context.once("close", () => {
-          if (this.context === context) this.context = null;
-        });
-        return context;
-      })
-      .finally(() => {
-        this.launching = null;
-      });
-    return this.launching;
+    const launched = await this.launch(executablePath);
+    const session: ManagedPlaywrightSession<Context> = {
+      close: () => launched.close(),
+      closed: () => launched.closed(),
+      context: launched.context,
+      generation: ++this.generation,
+      onClose: (listener) => launched.onClose(listener),
+    };
+    session.onClose(() => {
+      if (this.active.get(scope) === session) this.active.delete(scope);
+    });
+    this.active.set(scope, session);
+    return session;
   }
 
-  stop(): void {
-    const context = this.context;
-    this.context = null;
-    if (context) void context.close().catch(() => undefined);
+  private async revokeActive(scope: string): Promise<void> {
+    const session = this.active.get(scope);
+    if (!session) return;
+    try {
+      await Effect.runPromise(
+        Effect.tryPromise({ try: session.close, catch: (error) => error }).pipe(
+          Effect.timeoutOrElse({
+            duration: this.closeTimeoutMs,
+            orElse: () => Effect.fail(new Error("Timed out confirming Chromium termination")),
+          }),
+        ),
+      );
+      if (!session.closed()) throw new Error("Chromium termination was not confirmed");
+      if (this.active.get(scope) === session) this.active.delete(scope);
+    } catch (error) {
+      this.poisoned = error;
+      throw error;
+    }
+  }
+
+  private async stopUnlocked(): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+    let failure: unknown = null;
+    for (const scope of [...this.active.keys()]) {
+      try {
+        await this.revokeActive(scope);
+      } catch (error) {
+        failure ??= error;
+      }
+    }
+    if (failure) throw failure;
+  }
+
+  private assertUsable(): void {
+    if (this.poisoned) throw this.poisoned;
+    if (this.stopped) throw new Error("Browser manager stopped");
+  }
+
+  private withPermit<A>(task: () => Promise<A>): Promise<A> {
+    return Effect.runPromise(
+      this.transitionLock.withPermit(Effect.tryPromise({ try: task, catch: (error) => error })),
+    );
   }
 }
 
 export const playwrightManager = getGlobalSingleton(
   "playwrightManager",
-  () => new PlaywrightManager(),
+  () => new PlaywrightManager({ launch: launchPlaywrightSession }),
 );
 
 getGlobalSingleton("playwrightExitHook", () => {
-  if (typeof process !== "undefined") {
-    process.on("exit", () => playwrightManager.stop());
-  }
+  if (typeof process !== "undefined") process.on("exit", () => void playwrightManager.stop());
   return true;
 });

--- a/services/agent-runtime/src/browser-host/playwright.ts
+++ b/services/agent-runtime/src/browser-host/playwright.ts
@@ -86,6 +86,11 @@ export type PlaywrightManagerOptions<Context> = {
   resolveBinary?: () => string | null;
 };
 
+type SessionRevocation<Context> = {
+  session: ManagedPlaywrightSession<Context>;
+  settlement: Promise<void>;
+};
+
 export const createPlaywrightSessionLauncher = (): LaunchPlaywrightSession<BrowserContext> => {
   let browser: Browser | null = null;
   let launching: Promise<Browser> | null = null;
@@ -142,8 +147,10 @@ const launchPlaywrightSession = createPlaywrightSessionLauncher();
 
 export class PlaywrightManager<Context = BrowserContext> {
   private readonly active = new Map<string, ManagedPlaywrightSession<Context>>();
+  private readonly revocations = new Map<string, SessionRevocation<Context>>();
   private generation = 0;
-  private poisoned: unknown = null;
+  private poison: { error: unknown } | null = null;
+  private stopping: Promise<void> | null = null;
   private stopped = false;
   private readonly transitionLock = Semaphore.makeUnsafe(1);
   private readonly closeTimeoutMs: number;
@@ -161,7 +168,7 @@ export class PlaywrightManager<Context = BrowserContext> {
   }
 
   isAvailable(): boolean {
-    return !this.stopped && this.poisoned === null && this.resolveBinary() !== null;
+    return !this.stopped && this.poison === null && this.resolveBinary() !== null;
   }
 
   ensure(scope: string): Promise<ManagedPlaywrightSession<Context>> {
@@ -177,7 +184,8 @@ export class PlaywrightManager<Context = BrowserContext> {
   }
 
   stop(): Promise<void> {
-    return this.withPermit(() => this.stopUnlocked());
+    this.stopping ??= this.withPermit(() => this.stopUnlocked());
+    return this.stopping;
   }
 
   private async ensureUnlocked(scope: string): Promise<ManagedPlaywrightSession<Context>> {
@@ -186,6 +194,7 @@ export class PlaywrightManager<Context = BrowserContext> {
     if (active?.closed()) this.active.delete(scope);
     const current = this.active.get(scope);
     if (current) return current;
+    this.revocations.delete(scope);
     const executablePath = this.resolveBinary();
     if (!executablePath) {
       throw new Error("Browser unavailable: no Chromium found — set LOCAL_STUDIO_CHROME_PATH");
@@ -207,7 +216,25 @@ export class PlaywrightManager<Context = BrowserContext> {
 
   private async revokeActive(scope: string): Promise<void> {
     const session = this.active.get(scope);
+    const cached = this.revocations.get(scope);
+    if (cached && (!session || cached.session === session)) return cached.settlement;
     if (!session) return;
+    const settlement = this.revokeSession(scope, session);
+    const revocation = { session, settlement };
+    this.revocations.set(scope, revocation);
+    void settlement.then(
+      () => {
+        if (this.revocations.get(scope) === revocation) this.revocations.delete(scope);
+      },
+      () => undefined,
+    );
+    return settlement;
+  }
+
+  private async revokeSession(
+    scope: string,
+    session: ManagedPlaywrightSession<Context>,
+  ): Promise<void> {
     try {
       await Effect.runPromise(
         Effect.tryPromise({ try: session.close, catch: (error) => error }).pipe(
@@ -220,27 +247,26 @@ export class PlaywrightManager<Context = BrowserContext> {
       if (!session.closed()) throw new Error("Chromium termination was not confirmed");
       if (this.active.get(scope) === session) this.active.delete(scope);
     } catch (error) {
-      this.poisoned = error;
+      this.poison = { error };
       throw error;
     }
   }
 
   private async stopUnlocked(): Promise<void> {
-    if (this.stopped) return;
     this.stopped = true;
-    let failure: unknown = null;
+    let failure = this.poison;
     for (const scope of [...this.active.keys()]) {
       try {
         await this.revokeActive(scope);
       } catch (error) {
-        failure ??= error;
+        failure ??= { error };
       }
     }
-    if (failure) throw failure;
+    if (failure) throw failure.error;
   }
 
   private assertUsable(): void {
-    if (this.poisoned) throw this.poisoned;
+    if (this.poison) throw this.poison.error;
     if (this.stopped) throw new Error("Browser manager stopped");
   }
 

--- a/services/agent-runtime/src/http/app.ts
+++ b/services/agent-runtime/src/http/app.ts
@@ -116,10 +116,10 @@ export function createAgentRuntimeApp() {
   app.post("/api/agent/terminal/pty/resize", (c) => handlePtyResize(c.req.raw));
   app.post("/api/agent/terminal/pty/close", (c) => handlePtyClose(c.req.raw));
   app.get("/api/agent/browser/fetch", (c) => handleBrowserFetch(c.req.raw));
-  app.get("/api/agent/browser/frame", () => handleBrowserFrame());
+  app.get("/api/agent/browser/frame", (c) => handleBrowserFrame(c.req.raw));
   app.post("/api/agent/browser/input", (c) => handleBrowserInput(c.req.raw));
   app.get("/api/agent/browser/localhosts", (c) => handleBrowserLocalhosts(c.req.raw));
-  app.get("/api/agent/browser/state", () => handleBrowserState());
+  app.get("/api/agent/browser/state", (c) => handleBrowserState(c.req.raw));
   app.post("/api/agent/browser/viewport", (c) => handleBrowserViewport(c.req.raw));
   app.post("/api/agent/browser/:verb", (c) => handleBrowserVerb(c.req.raw, c.req.param("verb")));
 

--- a/services/agent-runtime/src/http/browser-handlers.ts
+++ b/services/agent-runtime/src/http/browser-handlers.ts
@@ -1,7 +1,13 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { Schema } from "effect";
+import {
+  BROWSER_SESSION_HEADER,
+  type BrowserSessionKey,
+} from "../../../../shared/agent/browser-session";
 import { sanitizeBrowserPaneUrl } from "../../../../shared/agent/sanitize-embedded-browser-url";
-import { browserHost, type KeyInput, type MouseInput } from "../browser-host/browser-host";
+import { BrowserHost, browserHost, type BrowserFallbackResult } from "../browser-host/browser-host";
+import { decodeBrowserSessionKey } from "../browser-host/browser-session";
 import { fetchReadable } from "../browser-host/reader";
 
 const ALLOWED_VERBS = new Set([
@@ -20,101 +26,162 @@ const ALLOWED_VERBS = new Set([
 
 const UNAVAILABLE_ERROR = "Browser unavailable: no Chromium found — set LOCAL_STUDIO_CHROME_PATH";
 
-let lastFallbackUrl = "";
-
 type VerbResult = { ok: boolean; data?: unknown; error?: string };
+const VerbPayloadSchema = Schema.Record(Schema.String, Schema.Unknown);
 
-export async function handleBrowserVerb(request: Request, verb: string): Promise<Response> {
+export function browserSessionKeyFromRequest(request: Request): BrowserSessionKey {
+  return decodeBrowserSessionKey(request.headers.get(BROWSER_SESSION_HEADER));
+}
+
+function invalidBrowserSession(): Response {
+  return Response.json(
+    { ok: false, error: `A valid ${BROWSER_SESSION_HEADER} header is required` },
+    { status: 400 },
+  );
+}
+
+type BrowserSessionResult =
+  | { type: "invalid"; response: Response }
+  | { type: "valid"; session: BrowserSessionKey };
+
+function requestBrowserSession(request: Request): BrowserSessionResult {
+  try {
+    return { type: "valid", session: browserSessionKeyFromRequest(request) };
+  } catch {
+    return { type: "invalid", response: invalidBrowserSession() };
+  }
+}
+
+export async function handleBrowserVerb(
+  request: Request,
+  verb: string,
+  host: BrowserHost = browserHost,
+  reader: typeof fetchReadable = fetchReadable,
+): Promise<Response> {
+  const sessionResult = requestBrowserSession(request);
+  if (sessionResult.type === "invalid") return sessionResult.response;
+  const { session } = sessionResult;
   if (!ALLOWED_VERBS.has(verb)) {
     return Response.json({ ok: false, error: `Unknown browser verb: ${verb}` }, { status: 400 });
   }
-  const payload = await readPayload(request);
   try {
-    const result = await dispatchVerb(verb, payload);
+    const payload = await readPayload(request);
+    const result = await dispatchVerb(host, session, verb, payload, reader);
     return Response.json(result);
   } catch (error) {
-    return Response.json({
-      ok: false,
-      error: error instanceof Error ? error.message : "Browser command failed",
-    });
+    const payloadError = error instanceof BrowserPayloadError;
+    return Response.json(
+      {
+        ok: false,
+        error: error instanceof Error ? error.message : "Browser command failed",
+      },
+      payloadError ? { status: 400 } : undefined,
+    );
   }
+}
+
+class BrowserPayloadError extends Error {}
+
+function rejectBodySessionId(body: unknown): unknown {
+  if (typeof body === "object" && body !== null && Object.hasOwn(body, "sessionId")) {
+    throw new BrowserPayloadError(`Use ${BROWSER_SESSION_HEADER} instead of body sessionId`);
+  }
+  return body;
 }
 
 async function readPayload(request: Request): Promise<Record<string, unknown>> {
   try {
-    const body = (await request.json()) as Record<string, unknown> | null;
-    if (body && typeof body === "object") {
-      // sessionId was a renderer-bridge affinity hint; the host is global now.
-      const { sessionId: _sessionId, ...rest } = body;
-      return rest;
-    }
-  } catch {
-    // empty body is fine
+    const text = await request.text();
+    if (!text.trim()) return {};
+    return Schema.decodeUnknownSync(VerbPayloadSchema)(rejectBodySessionId(JSON.parse(text)));
+  } catch (error) {
+    if (error instanceof BrowserPayloadError) throw error;
+    throw new BrowserPayloadError("Invalid browser command JSON");
   }
-  return {};
 }
 
-async function dispatchVerb(verb: string, payload: Record<string, unknown>): Promise<VerbResult> {
-  if (!browserHost.isAvailable()) return fallbackVerb(verb, payload);
+async function dispatchVerb(
+  host: BrowserHost,
+  session: BrowserSessionKey,
+  verb: string,
+  payload: Record<string, unknown>,
+  reader: typeof fetchReadable,
+): Promise<VerbResult> {
+  if (!host.isAvailable()) return fallbackVerb(host, session, verb, payload, reader);
   try {
-    return await runHostVerb(verb, payload);
+    return await runHostVerb(host, session, verb, payload);
   } catch (error) {
     // A launch/connection failure for the reading verbs still degrades to
     // reading mode rather than failing the tool call outright.
-    if (verb === "navigate" || verb === "get-text") return fallbackVerb(verb, payload);
+    if (verb === "navigate" || verb === "get-text") {
+      return fallbackVerb(host, session, verb, payload, reader);
+    }
     throw error;
   }
 }
 
-async function runHostVerb(verb: string, payload: Record<string, unknown>): Promise<VerbResult> {
+async function runHostVerb(
+  host: BrowserHost,
+  session: BrowserSessionKey,
+  verb: string,
+  payload: Record<string, unknown>,
+): Promise<VerbResult> {
   switch (verb) {
     case "navigate":
-      return navigateVerb(payload);
+      return navigateVerb(host, session, payload);
     case "get-url":
-      return { ok: true, data: await browserHost.getUrl() };
+      return { ok: true, data: await host.getUrl(session) };
     case "get-text":
-      return { ok: true, data: { text: await browserHost.getText() } };
+      return { ok: true, data: { text: await host.getText(session) } };
     case "get-html":
-      return { ok: true, data: { html: await browserHost.getHtml() } };
+      return { ok: true, data: { html: await host.getHtml(session) } };
     case "screenshot":
-      return { ok: true, data: { dataUri: await browserHost.screenshot() } };
+      return { ok: true, data: { dataUri: await host.screenshot(session) } };
     case "click":
-      return selectorVerb(await browserHost.click({ selector: requireSelector(payload) }));
+      return selectorVerb(await host.click(session, { selector: requireSelector(payload) }));
     case "fill":
       return selectorVerb(
-        await browserHost.fill({
+        await host.fill(session, {
           selector: requireSelector(payload),
           value: String(payload.value ?? ""),
         }),
       );
     case "scroll":
-      return scrollVerb(payload);
+      return scrollVerb(host, session, payload);
     case "back":
-      await browserHost.goBack();
-      return { ok: true, data: await browserHost.getState() };
+      await host.goBack(session);
+      return { ok: true, data: await host.getState(session) };
     case "forward":
-      await browserHost.goForward();
-      return { ok: true, data: await browserHost.getState() };
+      await host.goForward(session);
+      return { ok: true, data: await host.getState(session) };
     case "reload":
-      await browserHost.reload();
-      return { ok: true, data: await browserHost.getState() };
+      await host.reload(session);
+      return { ok: true, data: await host.getState(session) };
     default:
       return { ok: false, error: `Unsupported browser verb: ${verb}` };
   }
 }
 
-async function navigateVerb(payload: Record<string, unknown>): Promise<VerbResult> {
+async function navigateVerb(
+  host: BrowserHost,
+  session: BrowserSessionKey,
+  payload: Record<string, unknown>,
+): Promise<VerbResult> {
   // Pane rules: public web plus loopback (previewing local dev servers is the
   // pane's main job); other private ranges stay blocked.
-  const url = sanitizeBrowserPaneUrl(String(payload.url ?? ""));
-  if (!url) return { ok: false, error: "valid public or localhost http(s) url required" };
-  const result = await browserHost.navigate(url);
+  const navigation = sanitizeBrowserPaneUrl(String(payload.url ?? ""));
+  if (!navigation) return { ok: false, error: "valid public or localhost http(s) url required" };
+  const result = await host.navigate(session, navigation);
   return { ok: true, data: result };
 }
 
-async function scrollVerb(payload: Record<string, unknown>): Promise<VerbResult> {
+async function scrollVerb(
+  host: BrowserHost,
+  session: BrowserSessionKey,
+  payload: Record<string, unknown>,
+): Promise<VerbResult> {
   const deltaY = Number(payload.deltaY ?? 0);
-  const result = await browserHost.scroll({ deltaY: Number.isFinite(deltaY) ? deltaY : 0 });
+  const result = await host.scroll(session, { deltaY: Number.isFinite(deltaY) ? deltaY : 0 });
   return { ok: true, data: { deltaY: result.deltaY, scrollY: result.scrollY } };
 }
 
@@ -137,27 +204,58 @@ function requireSelector(payload: Record<string, unknown>): string {
 // without a url arg); every other verb returns the clear unavailable error. The
 // fallback honors pane rules (public + loopback) so local dev servers stay
 // previewable even when there's no headless Chromium to drive a full surface.
-async function fallbackVerb(verb: string, payload: Record<string, unknown>): Promise<VerbResult> {
+async function fallbackVerb(
+  host: BrowserHost,
+  session: BrowserSessionKey,
+  verb: string,
+  payload: Record<string, unknown>,
+  reader: typeof fetchReadable,
+): Promise<VerbResult> {
+  if (verb !== "navigate" && verb !== "get-url" && verb !== "get-text" && verb !== "get-html") {
+    return { ok: false, error: UNAVAILABLE_ERROR };
+  }
+  return host.withFallbackSession(session, (fallback) =>
+    fallbackSessionVerb(verb, payload, fallback, reader),
+  );
+}
+
+async function fallbackSessionVerb(
+  verb: string,
+  payload: Record<string, unknown>,
+  fallbackUrl: string | null,
+  reader: typeof fetchReadable,
+): Promise<BrowserFallbackResult<VerbResult>> {
   if (verb === "navigate") {
-    const url = sanitizeBrowserPaneUrl(String(payload.url ?? ""));
-    if (!url) return { ok: false, error: "valid public or localhost http(s) url required" };
-    const reader = await fetchReadable(url);
-    lastFallbackUrl = reader.url;
-    return { ok: true, data: { url: reader.url, title: reader.title, readingMode: true } };
+    const navigation = sanitizeBrowserPaneUrl(String(payload.url ?? ""));
+    if (!navigation) {
+      return { result: { ok: false, error: "valid public or localhost http(s) url required" } };
+    }
+    const result = await reader(navigation);
+    return {
+      url: result.url,
+      result: {
+        ok: true,
+        data: { url: result.url, title: result.title, readingMode: true },
+      },
+    };
   }
   if (verb === "get-url") {
-    return { ok: true, data: { url: lastFallbackUrl, title: "" } };
+    return { result: { ok: true, data: { url: fallbackUrl ?? "", title: "" } } };
   }
   if (verb === "get-text" || verb === "get-html") {
-    const url = sanitizeBrowserPaneUrl(String(payload.url ?? "")) || lastFallbackUrl;
-    if (!url) return { ok: false, error: UNAVAILABLE_ERROR };
-    const reader = await fetchReadable(url);
-    lastFallbackUrl = reader.url;
-    return verb === "get-text"
-      ? { ok: true, data: { text: reader.text, readingMode: true } }
-      : { ok: true, data: { html: reader.markdown ?? reader.text, readingMode: true } };
+    const requested = sanitizeBrowserPaneUrl(String(payload.url ?? ""));
+    const navigation = requested ?? fallbackUrl;
+    if (!navigation) return { result: { ok: false, error: UNAVAILABLE_ERROR } };
+    const result = await reader(navigation);
+    return {
+      url: result.url,
+      result:
+        verb === "get-text"
+          ? { ok: true, data: { text: result.text, readingMode: true } }
+          : { ok: true, data: { html: result.markdown ?? result.text, readingMode: true } },
+    };
   }
-  return { ok: false, error: UNAVAILABLE_ERROR };
+  return { result: { ok: false, error: UNAVAILABLE_ERROR } };
 }
 
 export async function handleBrowserFetch(request: Request): Promise<Response> {
@@ -181,12 +279,18 @@ export async function handleBrowserFetch(request: Request): Promise<Response> {
 // Next's standalone server buffers locally-built event streams, and polling
 // survives buffering proxies for remote deploys).
 
-export async function handleBrowserFrame(): Promise<Response> {
-  if (!browserHost.isAvailable()) {
+export async function handleBrowserFrame(
+  request: Request,
+  host: BrowserHost = browserHost,
+): Promise<Response> {
+  const sessionResult = requestBrowserSession(request);
+  if (sessionResult.type === "invalid") return sessionResult.response;
+  const { session } = sessionResult;
+  if (!host.isAvailable()) {
     return Response.json({ ok: false, error: UNAVAILABLE_ERROR }, { status: 503 });
   }
   try {
-    const { frame, state } = await browserHost.pollFrame();
+    const { frame, state } = await host.pollFrame(session);
     return Response.json({
       ok: true,
       data: {
@@ -205,23 +309,71 @@ export async function handleBrowserFrame(): Promise<Response> {
   }
 }
 
-type InputBody =
-  | ({ kind: "mouse" } & Omit<MouseInput, "type"> & { type: MouseInput["type"] })
-  | ({ kind: "wheel" } & Omit<MouseInput, "type">)
-  | ({ kind: "key" } & KeyInput);
+const MouseButtonSchema = Schema.Union([
+  Schema.Literal("left"),
+  Schema.Literal("right"),
+  Schema.Literal("middle"),
+]);
+const MouseTypeSchema = Schema.Union([
+  Schema.Literal("down"),
+  Schema.Literal("up"),
+  Schema.Literal("move"),
+]);
+const KeyTypeSchema = Schema.Union([
+  Schema.Literal("down"),
+  Schema.Literal("up"),
+  Schema.Literal("char"),
+]);
+const InputBodySchema = Schema.Union([
+  Schema.Struct({
+    kind: Schema.Literal("mouse"),
+    type: MouseTypeSchema,
+    x: Schema.Number,
+    y: Schema.Number,
+    button: Schema.optional(MouseButtonSchema),
+    clickCount: Schema.optional(Schema.Number),
+  }),
+  Schema.Struct({
+    kind: Schema.Literal("wheel"),
+    x: Schema.Number,
+    y: Schema.Number,
+    deltaX: Schema.optional(Schema.Number),
+    deltaY: Schema.optional(Schema.Number),
+  }),
+  Schema.Struct({
+    kind: Schema.Literal("key"),
+    type: KeyTypeSchema,
+    key: Schema.String,
+    code: Schema.String,
+    text: Schema.optional(Schema.String),
+  }),
+]);
+type InputBody = typeof InputBodySchema.Type;
 
-export async function handleBrowserInput(request: Request): Promise<Response> {
-  if (!browserHost.isAvailable()) {
-    return Response.json({ ok: false, error: "Browser unavailable" }, { status: 503 });
-  }
+export async function handleBrowserInput(
+  request: Request,
+  host: BrowserHost = browserHost,
+): Promise<Response> {
+  const sessionResult = requestBrowserSession(request);
+  if (sessionResult.type === "invalid") return sessionResult.response;
+  const { session } = sessionResult;
   let body: InputBody;
   try {
-    body = (await request.json()) as InputBody;
-  } catch {
-    return Response.json({ ok: false, error: "Invalid JSON" }, { status: 400 });
+    body = Schema.decodeUnknownSync(InputBodySchema)(rejectBodySessionId(await request.json()));
+  } catch (error) {
+    return Response.json(
+      {
+        ok: false,
+        error: error instanceof BrowserPayloadError ? error.message : "Invalid JSON",
+      },
+      { status: 400 },
+    );
+  }
+  if (!host.isAvailable()) {
+    return Response.json({ ok: false, error: "Browser unavailable" }, { status: 503 });
   }
   try {
-    await dispatchInput(body);
+    await dispatchInput(host, session, body);
     return Response.json({ ok: true });
   } catch (error) {
     return Response.json({
@@ -231,9 +383,13 @@ export async function handleBrowserInput(request: Request): Promise<Response> {
   }
 }
 
-async function dispatchInput(body: InputBody): Promise<void> {
+async function dispatchInput(
+  host: BrowserHost,
+  session: BrowserSessionKey,
+  body: InputBody,
+): Promise<void> {
   if (body.kind === "key") {
-    await browserHost.dispatchKey({
+    await host.dispatchKey(session, {
       type: body.type,
       key: body.key,
       code: body.code,
@@ -241,7 +397,7 @@ async function dispatchInput(body: InputBody): Promise<void> {
     return;
   }
   if (body.kind === "wheel") {
-    await browserHost.dispatchMouse({
+    await host.dispatchMouse(session, {
       type: "wheel",
       x: Number(body.x) || 0,
       y: Number(body.y) || 0,
@@ -250,7 +406,7 @@ async function dispatchInput(body: InputBody): Promise<void> {
     });
     return;
   }
-  await browserHost.dispatchMouse({
+  await host.dispatchMouse(session, {
     type: body.type,
     x: Number(body.x) || 0,
     y: Number(body.y) || 0,
@@ -381,12 +537,18 @@ export async function handleBrowserLocalhosts(request: Request): Promise<Respons
 
 // ─── GET /api/agent/browser/state ─────────────────────────────────────────
 
-export async function handleBrowserState(): Promise<Response> {
-  if (!browserHost.isAvailable()) {
+export async function handleBrowserState(
+  request: Request,
+  host: BrowserHost = browserHost,
+): Promise<Response> {
+  const sessionResult = requestBrowserSession(request);
+  if (sessionResult.type === "invalid") return sessionResult.response;
+  const { session } = sessionResult;
+  if (!host.isAvailable()) {
     return Response.json({ ok: false, error: "Browser unavailable" }, { status: 503 });
   }
   try {
-    return Response.json({ ok: true, data: await browserHost.peekState() });
+    return Response.json({ ok: true, data: await host.peekState(session) });
   } catch (error) {
     return Response.json({
       ok: false,
@@ -400,15 +562,29 @@ export async function handleBrowserState(): Promise<Response> {
 // Sets the headless Chromium viewport so it matches the visible panel's
 // dimensions. Body: { width, height }.
 
-export async function handleBrowserViewport(request: Request): Promise<Response> {
-  if (!browserHost.isAvailable()) {
-    return Response.json({ ok: false, error: "Browser unavailable" }, { status: 503 });
-  }
-  let body: { width?: unknown; height?: unknown };
+const ViewportBodySchema = Schema.Struct({ width: Schema.Number, height: Schema.Number });
+
+export async function handleBrowserViewport(
+  request: Request,
+  host: BrowserHost = browserHost,
+): Promise<Response> {
+  const sessionResult = requestBrowserSession(request);
+  if (sessionResult.type === "invalid") return sessionResult.response;
+  const { session } = sessionResult;
+  let body: typeof ViewportBodySchema.Type;
   try {
-    body = (await request.json()) as { width?: unknown; height?: unknown };
-  } catch {
-    return Response.json({ ok: false, error: "Invalid JSON" }, { status: 400 });
+    body = Schema.decodeUnknownSync(ViewportBodySchema)(rejectBodySessionId(await request.json()));
+  } catch (error) {
+    return Response.json(
+      {
+        ok: false,
+        error: error instanceof BrowserPayloadError ? error.message : "Invalid JSON",
+      },
+      { status: 400 },
+    );
+  }
+  if (!host.isAvailable()) {
+    return Response.json({ ok: false, error: "Browser unavailable" }, { status: 503 });
   }
   const width = Number(body.width);
   const height = Number(body.height);
@@ -416,7 +592,7 @@ export async function handleBrowserViewport(request: Request): Promise<Response>
     return Response.json({ ok: false, error: "width and height are required" }, { status: 400 });
   }
   try {
-    await browserHost.setViewport(width, height);
+    await host.setViewport(session, width, height);
     return Response.json({
       ok: true,
       data: { width: Math.round(width), height: Math.round(height) },

--- a/services/agent-runtime/src/http/browser-handlers.ts
+++ b/services/agent-runtime/src/http/browser-handlers.ts
@@ -319,11 +319,7 @@ const MouseTypeSchema = Schema.Union([
   Schema.Literal("up"),
   Schema.Literal("move"),
 ]);
-const KeyTypeSchema = Schema.Union([
-  Schema.Literal("down"),
-  Schema.Literal("up"),
-  Schema.Literal("char"),
-]);
+const KeyTypeSchema = Schema.Union([Schema.Literal("down"), Schema.Literal("up")]);
 const InputBodySchema = Schema.Union([
   Schema.Struct({
     kind: Schema.Literal("mouse"),
@@ -345,7 +341,6 @@ const InputBodySchema = Schema.Union([
     type: KeyTypeSchema,
     key: Schema.String,
     code: Schema.String,
-    text: Schema.optional(Schema.String),
   }),
 ]);
 type InputBody = typeof InputBodySchema.Type;

--- a/services/agent-runtime/src/pi-runtime-helpers.ts
+++ b/services/agent-runtime/src/pi-runtime-helpers.ts
@@ -2,7 +2,9 @@ import { existsSync, readFileSync } from "node:fs";
 import { realpath, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
-import { Effect } from "effect";
+import { Effect, Semaphore } from "effect";
+import { BROWSER_SESSION_HEADER } from "../../../shared/agent/browser-session";
+import { decodeBrowserSessionKey } from "./browser-host/browser-session";
 import { listProjectsFromStore, resolveAllowedWorkspace } from "./projects-store";
 import { hasEnabledConnectorsSync } from "./connectors-service";
 import type { AgentThinkingLevel, AgentToolAccess } from "../../../shared/agent/agent-turn";
@@ -302,12 +304,19 @@ function runtimeEnvInjections(
 ): Record<string, string> {
   const frontendBase = env.LOCAL_STUDIO_FRONTEND_BASE ?? deriveFrontendBase(env);
   const relay = readSitegeistRelayEnv(env);
+  const browserSessionId = options.browserSessionId
+    ? decodeBrowserSessionKey(options.browserSessionId)
+    : "";
+  if (options.browserToolEnabled === true && !browserSessionId) {
+    throw new Error("A valid browser session id is required when the browser tool is enabled");
+  }
   return {
-    LOCAL_STUDIO_BROWSER_SESSION_ID: options.browserSessionId ?? "",
+    LOCAL_STUDIO_BROWSER_SESSION_HEADER: BROWSER_SESSION_HEADER,
+    LOCAL_STUDIO_BROWSER_SESSION_ID: browserSessionId,
     LOCAL_STUDIO_FRONTEND_BASE: frontendBase,
     SITEGEIST_RELAY_URL: env.SITEGEIST_RELAY_URL ?? relay.SITEGEIST_RELAY_URL ?? "",
     SITEGEIST_RELAY_TOKEN: env.SITEGEIST_RELAY_TOKEN ?? relay.SITEGEIST_RELAY_TOKEN ?? "",
-    SITEGEIST_RELAY_SESSION_ID: options.browserSessionId ?? "",
+    SITEGEIST_RELAY_SESSION_ID: browserSessionId,
   };
 }
 
@@ -344,6 +353,50 @@ export function applyRuntimeEnvInjections(
   env: NodeJS.ProcessEnv = process.env,
 ): void {
   for (const [key, value] of Object.entries(envInjections)) env[key] = value;
+}
+
+const runtimeEnvLock = Semaphore.makeUnsafe(1);
+
+type EnvironmentSnapshot = Record<
+  string,
+  { present: true; value: string | undefined } | { present: false }
+>;
+
+function environmentSnapshot(
+  envInjections: Record<string, string>,
+  env: NodeJS.ProcessEnv,
+): EnvironmentSnapshot {
+  return Object.fromEntries(
+    Object.keys(envInjections).map((key) => [
+      key,
+      Object.hasOwn(env, key) ? { present: true, value: env[key] } : { present: false },
+    ]),
+  );
+}
+
+function restoreEnvironment(snapshot: EnvironmentSnapshot, env: NodeJS.ProcessEnv): void {
+  for (const [key, entry] of Object.entries(snapshot)) {
+    if (entry.present) env[key] = entry.value;
+    else delete env[key];
+  }
+}
+
+export function withRuntimeEnvInjections<A, E, R>(
+  envInjections: Record<string, string>,
+  effect: Effect.Effect<A, E, R>,
+  env: NodeJS.ProcessEnv = process.env,
+): Effect.Effect<A, E, R> {
+  return runtimeEnvLock.withPermit(
+    Effect.acquireUseRelease(
+      Effect.sync(() => {
+        const snapshot = environmentSnapshot(envInjections, env);
+        applyRuntimeEnvInjections(envInjections, env);
+        return snapshot;
+      }),
+      () => effect,
+      (snapshot) => Effect.sync(() => restoreEnvironment(snapshot, env)),
+    ),
+  );
 }
 
 export function buildAgentSessionOptionsSync(input: AgentSessionOptionsInput): AgentSessionOptions {

--- a/services/agent-runtime/src/pi-runtime.ts
+++ b/services/agent-runtime/src/pi-runtime.ts
@@ -16,10 +16,10 @@ import { Effect } from "effect";
 import type { AgentImageInput } from "../../../shared/agent/agent-image-input";
 import type { AgentQueueAction } from "../../../shared/agent/agent-turn";
 import {
-  applyRuntimeEnvInjections,
   buildAgentSessionOptionsSync,
   runtimeOptionsFingerprint,
   resolveAgentCwdEffect,
+  withRuntimeEnvInjections,
   type RuntimeStartOptions,
 } from "./pi-runtime-helpers";
 import { refreshPiModels, resolvePiModelSelection } from "./pi-runtime-models";
@@ -348,10 +348,6 @@ class PiSdkSession extends EventEmitter implements PiAgentSession {
         });
 
         const sessionOptions = buildAgentSessionOptionsSync({ options });
-        applyRuntimeEnvInjections(sessionOptions.envInjections);
-        // Expose the current session's model so the automations extension can
-        // default a scheduled run to the same model the user is talking to.
-        applyRuntimeEnvInjections({ LOCAL_STUDIO_MODEL_ID: modelId });
         const sessionDir = configuredPiSessionDir(resolvedCwd);
         const resumeFile = desiredSessionId ? findSessionFile(resolvedCwd, desiredSessionId) : null;
         const sessionManager = resumeFile
@@ -361,7 +357,7 @@ class PiSdkSession extends EventEmitter implements PiAgentSession {
         const agentDir = getAgentDir();
         const extensionUiContext = this.extensionUiContext();
         const recordExtensionEvent = (event: PiEvent) => this.recordEvent(event);
-        const runtime = yield* Effect.tryPromise({
+        const runtimeEffect = Effect.tryPromise({
           try: () =>
             createAgentSessionRuntime(
               ({ cwd, agentDir, sessionManager, sessionStartEvent }) =>
@@ -484,6 +480,10 @@ class PiSdkSession extends EventEmitter implements PiAgentSession {
             ),
           catch: (error) => error,
         });
+        const runtime = yield* withRuntimeEnvInjections(
+          { ...sessionOptions.envInjections, LOCAL_STUDIO_MODEL_ID: modelId },
+          runtimeEffect,
+        );
 
         this.runtime = runtime;
         this.agentDir = agentDir;

--- a/services/agent-runtime/src/runtime-shutdown.ts
+++ b/services/agent-runtime/src/runtime-shutdown.ts
@@ -1,0 +1,48 @@
+export type RuntimeShutdown = () => Promise<void>;
+
+type RuntimeSignalProcess = {
+  exit: (code?: number) => unknown;
+  once: (event: "SIGINT" | "SIGTERM", listener: () => void) => unknown;
+};
+
+type RuntimeSignalShutdownOptions = {
+  dispose: () => void;
+  process: RuntimeSignalProcess;
+  reportError: (error: unknown) => void;
+  stop: () => Promise<void>;
+};
+
+export function createRuntimeShutdown(
+  stop: () => Promise<void>,
+  dispose: () => void,
+): RuntimeShutdown {
+  let stopping: Promise<void> | null = null;
+  return () => {
+    stopping ??= Promise.resolve().then(stop).finally(dispose);
+    return stopping;
+  };
+}
+
+export function installRuntimeSignalShutdown({
+  dispose,
+  process: runtimeProcess,
+  reportError,
+  stop,
+}: RuntimeSignalShutdownOptions): RuntimeShutdown {
+  const shutdown = createRuntimeShutdown(stop, dispose);
+  let signaled = false;
+  const onSignal = () => {
+    if (signaled) return;
+    signaled = true;
+    void shutdown().then(
+      () => runtimeProcess.exit(0),
+      (error) => {
+        reportError(error);
+        runtimeProcess.exit(1);
+      },
+    );
+  };
+  runtimeProcess.once("SIGINT", onSignal);
+  runtimeProcess.once("SIGTERM", onSignal);
+  return shutdown;
+}

--- a/services/agent-runtime/src/server.ts
+++ b/services/agent-runtime/src/server.ts
@@ -1,6 +1,8 @@
 import { serve } from "@hono/node-server";
 import { startAutomationScheduler } from "./automation-scheduler";
+import { browserHost } from "./browser-host/browser-host";
 import { createAgentRuntimeApp } from "./http/app";
+import { installRuntimeSignalShutdown } from "./runtime-shutdown";
 
 startAutomationScheduler();
 
@@ -14,6 +16,17 @@ serve({ fetch: app.fetch, port, hostname: "127.0.0.1" }, (info) => {
   );
 });
 
-process.once("exit", () => litterBridgeGateway.dispose());
-process.once("SIGINT", () => process.exit(0));
-process.once("SIGTERM", () => process.exit(0));
+let gatewayDisposed = false;
+const disposeGateway = () => {
+  if (gatewayDisposed) return;
+  gatewayDisposed = true;
+  litterBridgeGateway.dispose();
+};
+
+process.once("exit", disposeGateway);
+installRuntimeSignalShutdown({
+  dispose: disposeGateway,
+  process,
+  reportError: (error) => console.error("[agent-runtime] shutdown failed", error),
+  stop: () => browserHost.stop(),
+});

--- a/services/agent-runtime/test/browser-host-sessions.test.ts
+++ b/services/agent-runtime/test/browser-host-sessions.test.ts
@@ -418,11 +418,17 @@ test("concurrent release callers share one failing close settlement", async () =
   const failure = new Error("release failed");
   manager.failNextRelease(failure);
   const releases = Array.from({ length: 20 }, () => host.releaseSession(SESSION));
-  assert.equal(releases.every((release) => release === releases[0]), true);
+  assert.equal(
+    releases.every((release) => release === releases[0]),
+    true,
+  );
   await pending.started.promise;
   pending.release.resolve();
   const results = await Promise.allSettled(releases);
-  assert.deepEqual(results.map((result) => result.status), Array(20).fill("rejected"));
+  assert.deepEqual(
+    results.map((result) => result.status),
+    Array(20).fill("rejected"),
+  );
   assert.equal(
     results.every((result) => result.status === "rejected" && result.reason === failure),
     true,
@@ -431,6 +437,45 @@ test("concurrent release callers share one failing close settlement", async () =
   assert.equal(repeatedRelease, releases[0]);
   await assert.rejects(repeatedRelease, (error) => error === failure);
   assert.equal(manager.releaseCalls, 1);
+  await host.stop();
+});
+
+test("a recreated same-key record owns its release settlement", async () => {
+  const manager = new FakeManager();
+  const host = hostFor(manager);
+  await host.withFallbackSession(SESSION, async () => ({ result: undefined }));
+  const records = Reflect.get(host, "sessions") as Map<string, unknown>;
+  const pending = Reflect.get(host, "pendingAcquisitions") as Map<string, unknown>;
+  const settlements = Reflect.get(host, "releaseSettlements") as Map<string, unknown>;
+  const firstRelease = host.releaseSession(SESSION);
+  let recreation: Promise<void> | null = null;
+  let secondRelease: Promise<void> | null = null;
+  await new Promise<void>((resolve, reject) => {
+    let turns = 0;
+    const observeRemoval = (): void => {
+      if (!records.has(SESSION)) {
+        recreation = host.withFallbackSession(SESSION, async () => ({ result: undefined }));
+        secondRelease = host.releaseSession(SESSION);
+        resolve();
+        return;
+      }
+      turns += 1;
+      if (turns > 100) {
+        reject(new Error("Old browser session record was not removed"));
+        return;
+      }
+      queueMicrotask(observeRemoval);
+    };
+    queueMicrotask(observeRemoval);
+  });
+  assert.ok(recreation);
+  assert.ok(secondRelease);
+  assert.notEqual(secondRelease, firstRelease);
+  await Promise.all([firstRelease, recreation, secondRelease]);
+  assert.equal(manager.releaseCalls, 2);
+  assert.equal(records.has(SESSION), false);
+  assert.equal(pending.size, 0);
+  assert.equal(settlements.size, 0);
   await host.stop();
 });
 

--- a/services/agent-runtime/test/browser-host-sessions.test.ts
+++ b/services/agent-runtime/test/browser-host-sessions.test.ts
@@ -208,6 +208,7 @@ class FakeSession implements ManagedPlaywrightSession<BrowserContextSurface<RawP
 class FakeManager implements BrowserHostManager<RawPage> {
   readonly launches: string[] = [];
   readonly sessions: FakeSession[] = [];
+  releaseCalls = 0;
   stops = 0;
   private readonly active = new Map<string, FakeSession>();
   private generation = 0;
@@ -217,6 +218,7 @@ class FakeManager implements BrowserHostManager<RawPage> {
   private readonly navigationBarriers: Barrier[] = [];
   private readonly pageCreationBarriers: Barrier[] = [];
   private readonly releaseBarriers: Barrier[] = [];
+  private releaseFailure: Error | null = null;
 
   blockNextEnsure(): Barrier {
     const next = barrier();
@@ -240,6 +242,10 @@ class FakeManager implements BrowserHostManager<RawPage> {
     const next = barrier();
     this.releaseBarriers.push(next);
     return next;
+  }
+
+  failNextRelease(error: Error): void {
+    this.releaseFailure = error;
   }
 
   async ensure(scope: string): Promise<FakeSession> {
@@ -271,11 +277,15 @@ class FakeManager implements BrowserHostManager<RawPage> {
   }
 
   async release(scope: string): Promise<void> {
+    this.releaseCalls += 1;
     const active = this.active.get(scope);
     await active?.close();
     const pending = this.releaseBarriers.shift();
     pending?.started.resolve();
     await pending?.release.promise;
+    const failure = this.releaseFailure;
+    this.releaseFailure = null;
+    if (failure) throw failure;
     if (this.active.get(scope) === active) this.active.delete(scope);
   }
 
@@ -397,6 +407,30 @@ test("release rejects work that arrives while context closure is pending", async
   await Promise.allSettled([request]);
   assert.equal(settlement.status, "rejected");
   assert.match(String(settlement.status === "rejected" ? settlement.error : ""), /releasing/u);
+  await host.stop();
+});
+
+test("concurrent release callers share one failing close settlement", async () => {
+  const manager = new FakeManager();
+  const host = hostFor(manager);
+  await host.navigate(SESSION, "https://public.test/page");
+  const pending = manager.blockNextRelease();
+  const failure = new Error("release failed");
+  manager.failNextRelease(failure);
+  const releases = Array.from({ length: 20 }, () => host.releaseSession(SESSION));
+  assert.equal(releases.every((release) => release === releases[0]), true);
+  await pending.started.promise;
+  pending.release.resolve();
+  const results = await Promise.allSettled(releases);
+  assert.deepEqual(results.map((result) => result.status), Array(20).fill("rejected"));
+  assert.equal(
+    results.every((result) => result.status === "rejected" && result.reason === failure),
+    true,
+  );
+  const repeatedRelease = host.releaseSession(SESSION);
+  assert.equal(repeatedRelease, releases[0]);
+  await assert.rejects(repeatedRelease, (error) => error === failure);
+  assert.equal(manager.releaseCalls, 1);
   await host.stop();
 });
 
@@ -533,6 +567,7 @@ test("release is idempotent and permits later same-key recreation", async () => 
   await host.navigate(SESSION, "https://public.test/a");
   const firstRelease = host.releaseSession(SESSION);
   const secondRelease = host.releaseSession(SESSION);
+  assert.equal(firstRelease, secondRelease);
   await Promise.all([firstRelease, secondRelease]);
   assert.deepEqual(await host.navigate(SESSION, "https://public.test/recreated"), {
     title: "https://public.test/recreated",

--- a/services/agent-runtime/test/browser-host-sessions.test.ts
+++ b/services/agent-runtime/test/browser-host-sessions.test.ts
@@ -1,0 +1,529 @@
+import assert from "node:assert/strict";
+import { test } from "bun:test";
+import {
+  BrowserHost,
+  type BrowserContextSurface,
+  type BrowserHostManager,
+  type BrowserPage,
+  type KeyInput,
+  type MouseInput,
+  type PageState,
+  type ScreencastFrame,
+} from "../src/browser-host/browser-host";
+import type { ManagedPlaywrightSession } from "../src/browser-host/playwright";
+
+const SESSION = "session-a";
+
+class Deferred<T> {
+  private readonly state = Promise.withResolvers<T>();
+  readonly promise = this.state.promise;
+
+  resolve(value: T): void {
+    this.state.resolve(value);
+  }
+}
+
+type Barrier = { release: Deferred<void>; started: Deferred<void> };
+
+const barrier = (): Barrier => ({
+  release: new Deferred<void>(),
+  started: new Deferred<void>(),
+});
+
+const state = (url: string): PageState => ({
+  canGoBack: false,
+  canGoForward: false,
+  loading: false,
+  title: url,
+  url,
+});
+
+type RawPage = {
+  closed: boolean;
+  id: string;
+  navigationBarrier: Barrier | null;
+  state: PageState;
+};
+
+class FakePage implements BrowserPage<RawPage> {
+  constructor(private readonly raw: RawPage) {}
+
+  get closed(): boolean {
+    return this.raw.closed;
+  }
+
+  get id(): string {
+    return this.raw.id;
+  }
+
+  captureFrame(): Promise<ScreencastFrame> {
+    return Promise.resolve({ data: `frame-${this.id}`, metadata: {} });
+  }
+
+  click(_selector: string): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
+  close(): void {
+    this.raw.closed = true;
+  }
+
+  dispatchKey(_input: KeyInput): Promise<void> {
+    return Promise.resolve();
+  }
+
+  dispatchMouse(_input: MouseInput): Promise<void> {
+    return Promise.resolve();
+  }
+
+  evaluate(_expression: string): Promise<unknown> {
+    return Promise.resolve(undefined);
+  }
+
+  fill(_selector: string, _value: string): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
+  goBack(_timeout: number): Promise<void> {
+    return Promise.resolve();
+  }
+
+  goForward(_timeout: number): Promise<void> {
+    return Promise.resolve();
+  }
+
+  html(): Promise<string> {
+    return Promise.resolve("<html></html>");
+  }
+
+  matches(page: RawPage): boolean {
+    return page === this.raw;
+  }
+
+  async navigate(url: string, _timeout: number): Promise<void> {
+    this.raw.navigationBarrier?.started.resolve();
+    await this.raw.navigationBarrier?.release.promise;
+    if (this.closed) throw new Error("Target closed");
+    this.raw.state = state(url);
+  }
+
+  readState(): Promise<PageState> {
+    if (this.closed) return Promise.reject(new Error("Target closed"));
+    return Promise.resolve(this.raw.state);
+  }
+
+  reload(_timeout: number): Promise<void> {
+    return Promise.resolve();
+  }
+
+  screenshot(_type: "png" | "jpeg", _quality?: number): Promise<string> {
+    return Promise.resolve(Buffer.from(this.id).toString("base64"));
+  }
+
+  scroll(_deltaX: number, deltaY: number): Promise<number> {
+    return Promise.resolve(deltaY);
+  }
+
+  setViewport(_width: number, _height: number): Promise<void> {
+    return Promise.resolve();
+  }
+
+  text(): Promise<string> {
+    return Promise.resolve(this.raw.state.url);
+  }
+}
+
+class FakeContext implements BrowserContextSurface<RawPage> {
+  readonly rawPages: RawPage[] = [];
+
+  constructor(
+    private readonly createRawPage: () => RawPage,
+    private readonly pageCreationBarrier: Barrier | null,
+  ) {}
+
+  async newPage(): Promise<RawPage> {
+    this.pageCreationBarrier?.started.resolve();
+    await this.pageCreationBarrier?.release.promise;
+    const page = this.createRawPage();
+    this.rawPages.push(page);
+    return page;
+  }
+
+  pages(): RawPage[] {
+    return this.rawPages.filter((page) => !page.closed);
+  }
+
+  close(): void {
+    for (const page of this.rawPages) page.closed = true;
+  }
+}
+
+class FakeSession implements ManagedPlaywrightSession<BrowserContextSurface<RawPage>> {
+  private isClosed = false;
+  private readonly listeners = new Set<() => void>();
+
+  constructor(
+    readonly context: FakeContext,
+    readonly generation: number,
+    readonly scope: string,
+  ) {}
+
+  close(): Promise<void> {
+    if (this.isClosed) return Promise.resolve();
+    this.isClosed = true;
+    this.context.close();
+    for (const listener of this.listeners) listener();
+    this.listeners.clear();
+    return Promise.resolve();
+  }
+
+  closed(): boolean {
+    return this.isClosed;
+  }
+
+  onClose(listener: () => void): void {
+    this.listeners.add(listener);
+  }
+}
+
+class FakeManager implements BrowserHostManager<RawPage> {
+  readonly launches: string[] = [];
+  readonly sessions: FakeSession[] = [];
+  stops = 0;
+  private readonly active = new Map<string, FakeSession>();
+  private generation = 0;
+  private pageSerial = 0;
+  private stopped = false;
+  private readonly ensureBarriers: Barrier[] = [];
+  private readonly navigationBarriers: Barrier[] = [];
+  private readonly pageCreationBarriers: Barrier[] = [];
+
+  blockNextEnsure(): Barrier {
+    const next = barrier();
+    this.ensureBarriers.push(next);
+    return next;
+  }
+
+  blockNextNavigation(): Barrier {
+    const next = barrier();
+    this.navigationBarriers.push(next);
+    return next;
+  }
+
+  blockNextPageCreation(): Barrier {
+    const next = barrier();
+    this.pageCreationBarriers.push(next);
+    return next;
+  }
+
+  async ensure(scope: string): Promise<FakeSession> {
+    const pending = this.ensureBarriers.shift();
+    pending?.started.resolve();
+    await pending?.release.promise;
+    if (this.stopped) throw new Error("Browser manager stopped");
+    const active = this.active.get(scope);
+    if (active && !active.closed()) return active;
+    await active?.close();
+    const context = new FakeContext(
+      () => ({
+        closed: false,
+        id: `${scope}-page-${++this.pageSerial}`,
+        navigationBarrier: this.navigationBarriers.shift() ?? null,
+        state: state("about:blank"),
+      }),
+      this.pageCreationBarriers.shift() ?? null,
+    );
+    const session = new FakeSession(context, ++this.generation, scope);
+    this.active.set(scope, session);
+    this.sessions.push(session);
+    this.launches.push(scope);
+    return session;
+  }
+
+  isAvailable(): boolean {
+    return !this.stopped;
+  }
+
+  async release(scope: string): Promise<void> {
+    const active = this.active.get(scope);
+    await active?.close();
+    if (this.active.get(scope) === active) this.active.delete(scope);
+  }
+
+  async stop(): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+    this.stops += 1;
+    await Promise.all([...this.active.values()].map((session) => session.close()));
+    this.active.clear();
+  }
+}
+
+const hostFor = (
+  manager: FakeManager,
+  options: {
+    config?: { idleMs: number; maxSessions: number };
+    now?: () => number;
+  } = {},
+): BrowserHost<RawPage> =>
+  new BrowserHost(manager, {
+    attachPage: (page) => new FakePage(page),
+    ...options,
+  });
+
+const activeRawPages = (manager: FakeManager): RawPage[] =>
+  manager.sessions.flatMap((session) => session.context.rawPages).filter((page) => !page.closed);
+
+async function concurrentStartup(first: "navigate" | "poll"): Promise<void> {
+  const manager = new FakeManager();
+  const host = hostFor(manager);
+  const pending = manager.blockNextEnsure();
+  const fixture = "https://public.test/visible";
+  const firstRequest = first === "poll" ? host.pollFrame(SESSION) : host.navigate(SESSION, fixture);
+  await pending.started.promise;
+  const secondRequest =
+    first === "poll" ? host.navigate(SESSION, fixture) : host.pollFrame(SESSION);
+  pending.release.resolve();
+  const results = await Promise.allSettled([firstRequest, secondRequest]);
+  assert.deepEqual(
+    results.map((result) => result.status),
+    ["fulfilled", "fulfilled"],
+  );
+  assert.equal((await host.getUrl(SESSION)).url, fixture);
+  assert.equal(manager.sessions.length, 1);
+  assert.equal(activeRawPages(manager).length, 1);
+  await host.stop();
+}
+
+test("first frame and navigation share one page when frame starts first", async () => {
+  await concurrentStartup("poll");
+});
+
+test("first frame and navigation share one page when navigation starts first", async () => {
+  await concurrentStartup("navigate");
+});
+
+test("navigation preserves order inside one session context", async () => {
+  const manager = new FakeManager();
+  const host = hostFor(manager);
+  const pending = manager.blockNextNavigation();
+  const first = host.navigate(SESSION, "https://public.test/first");
+  await pending.started.promise;
+  const second = host.navigate(SESSION, "http://localhost:4173/second");
+  await Promise.resolve();
+  assert.deepEqual(manager.launches, [SESSION]);
+  pending.release.resolve();
+  assert.deepEqual(await Promise.all([first, second]), [
+    { title: "https://public.test/first", url: "https://public.test/first" },
+    { title: "http://localhost:4173/second", url: "http://localhost:4173/second" },
+  ]);
+  assert.deepEqual(manager.launches, [SESSION]);
+  assert.equal(activeRawPages(manager).length, 1);
+  await host.stop();
+});
+
+test("shutdown waits for in-flight navigation and closes every context once", async () => {
+  const manager = new FakeManager();
+  const host = hostFor(manager);
+  const pending = manager.blockNextNavigation();
+  const navigation = host.navigate(SESSION, "https://public.test/page");
+  await pending.started.promise;
+  let stopped = false;
+  const stopping = host.stop().then(() => {
+    stopped = true;
+  });
+  assert.equal(host.stop(), host.stop());
+  await Promise.resolve();
+  assert.equal(stopped, false);
+  pending.release.resolve();
+  assert.deepEqual(await navigation, {
+    title: "https://public.test/page",
+    url: "https://public.test/page",
+  });
+  await stopping;
+  assert.equal(manager.stops, 1);
+  assert.equal(activeRawPages(manager).length, 0);
+  await assert.rejects(host.getState(SESSION), /Browser host stopped/u);
+});
+
+test("shutdown protects active manager and page creation", async () => {
+  for (const pending of ["ensure", "page"] as const) {
+    const manager = new FakeManager();
+    const blocked =
+      pending === "ensure" ? manager.blockNextEnsure() : manager.blockNextPageCreation();
+    const host = hostFor(manager);
+    const navigation = host.navigate(SESSION, "https://public.test/page");
+    await blocked.started.promise;
+    const stopping = host.stop();
+    blocked.release.resolve();
+    assert.deepEqual(await navigation, {
+      title: "https://public.test/page",
+      url: "https://public.test/page",
+    });
+    await stopping;
+    assert.equal(activeRawPages(manager).length, 0);
+  }
+});
+
+test("blocked top-level navigation never starts Playwright", async () => {
+  const manager = new FakeManager();
+  const host = hostFor(manager);
+  await assert.rejects(host.navigate(SESSION, "http://10.0.0.1/private"), /not allowed/u);
+  assert.equal(manager.sessions.length, 0);
+  await host.stop();
+});
+
+test("different session keys own distinct contexts and reject cross-session page ids", async () => {
+  const manager = new FakeManager();
+  const host = hostFor(manager);
+  await Promise.all([
+    host.navigate("session-a", "https://public.test/a"),
+    host.navigate("session-b", "https://public.test/b"),
+  ]);
+  const sessionA = manager.sessions.find((session) => session.scope === "session-a");
+  const sessionB = manager.sessions.find((session) => session.scope === "session-b");
+  const pageA = sessionA?.context.rawPages[0];
+  const pageB = sessionB?.context.rawPages[0];
+  assert.ok(pageA);
+  assert.ok(pageB);
+  assert.notEqual(sessionA?.context, sessionB?.context);
+  assert.notEqual(pageA.id, pageB.id);
+  assert.equal((await host.getUrl("session-a")).url, "https://public.test/a");
+  assert.equal((await host.getUrl("session-b")).url, "https://public.test/b");
+  await assert.rejects(host.getUrl("session-a", pageB.id), /does not belong to session/u);
+  await host.stop();
+});
+
+test("fallback state and ordering are isolated by session", async () => {
+  const manager = new FakeManager();
+  const host = hostFor(manager);
+  const pending = barrier();
+  const first = host.withFallbackSession("session-a", async () => {
+    pending.started.resolve();
+    await pending.release.promise;
+    return {
+      url: "https://public.test/a",
+      result: undefined,
+    };
+  });
+  await pending.started.promise;
+  let secondStarted = false;
+  const second = host.withFallbackSession("session-a", async () => {
+    secondStarted = true;
+    return {
+      url: "https://public.test/second",
+      result: undefined,
+    };
+  });
+  await host.withFallbackSession("session-b", async () => ({
+    url: "http://localhost:4173/b",
+    result: undefined,
+  }));
+  assert.equal(secondStarted, false);
+  pending.release.resolve();
+  await Promise.all([first, second]);
+  const fallbackA = await host.withFallbackSession("session-a", async (url) => ({
+    result: url,
+  }));
+  const fallbackB = await host.withFallbackSession("session-b", async (url) => ({
+    result: url,
+  }));
+  assert.equal(fallbackA, "https://public.test/second");
+  assert.equal(fallbackB, "http://localhost:4173/b");
+  assert.equal(manager.sessions.length, 0);
+  await host.stop();
+});
+
+test("capacity evicts the least-recently-used idle session", async () => {
+  const manager = new FakeManager();
+  let now = 0;
+  const host = hostFor(manager, {
+    config: { idleMs: 60_000, maxSessions: 2 },
+    now: () => now,
+  });
+  await host.navigate("session-a", "https://public.test/a");
+  now = 10;
+  await host.navigate("session-b", "https://public.test/b");
+  now = 20;
+  await host.getUrl("session-a");
+  now = 30;
+  await host.navigate("session-c", "https://public.test/c");
+  const activeScopes = manager.sessions
+    .filter((session) => !session.closed())
+    .map((session) => session.scope)
+    .sort();
+  assert.deepEqual(activeScopes, ["session-a", "session-c"]);
+  await host.stop();
+});
+
+test("capacity fails closed while every session has in-flight work", async () => {
+  const manager = new FakeManager();
+  const navigationA = manager.blockNextNavigation();
+  const navigationB = manager.blockNextNavigation();
+  const host = hostFor(manager, {
+    config: { idleMs: 60_000, maxSessions: 2 },
+  });
+  const activeA = host.navigate("session-a", "https://public.test/a");
+  const activeB = host.navigate("session-b", "https://public.test/b");
+  await Promise.all([navigationA.started.promise, navigationB.started.promise]);
+  await assert.rejects(
+    host.navigate("session-c", "https://public.test/c"),
+    /all sessions are active/u,
+  );
+  navigationA.release.resolve();
+  navigationB.release.resolve();
+  await Promise.all([activeA, activeB]);
+  await host.stop();
+});
+
+test("release waits for work, is idempotent, and serializes same-key recreation", async () => {
+  const manager = new FakeManager();
+  const navigation = manager.blockNextNavigation();
+  const host = hostFor(manager);
+  const active = host.navigate(SESSION, "https://public.test/a");
+  await navigation.started.promise;
+  let released = false;
+  const firstRelease = host.releaseSession(SESSION).then(() => {
+    released = true;
+  });
+  const secondRelease = host.releaseSession(SESSION);
+  const recreated = host.navigate(SESSION, "https://public.test/recreated");
+  await Promise.resolve();
+  assert.equal(released, false);
+  assert.equal(manager.sessions.filter((session) => session.scope === SESSION).length, 1);
+  navigation.release.resolve();
+  await active;
+  await Promise.all([firstRelease, secondRelease]);
+  assert.deepEqual(await recreated, {
+    title: "https://public.test/recreated",
+    url: "https://public.test/recreated",
+  });
+  const scoped = manager.sessions.filter((session) => session.scope === SESSION);
+  assert.equal(scoped.length, 2);
+  assert.equal(scoped[0]?.closed(), true);
+  assert.equal(scoped[1]?.closed(), false);
+  await host.stop();
+});
+
+test("idle cleanup skips active work and releases expired sessions", async () => {
+  const manager = new FakeManager();
+  let now = 0;
+  const host = hostFor(manager, {
+    config: { idleMs: 60_000, maxSessions: 2 },
+    now: () => now,
+  });
+  await host.navigate("session-idle", "https://public.test/idle");
+  now = 1;
+  const navigation = manager.blockNextNavigation();
+  const active = host.navigate("session-active", "https://public.test/active");
+  await navigation.started.promise;
+  now = 60_001;
+  await host.cleanupIdleSessions();
+  const idle = manager.sessions.find((session) => session.scope === "session-idle");
+  const busy = manager.sessions.find((session) => session.scope === "session-active");
+  assert.equal(idle?.closed(), true);
+  assert.equal(busy?.closed(), false);
+  navigation.release.resolve();
+  await active;
+  await host.stop();
+});

--- a/services/agent-runtime/test/browser-host-sessions.test.ts
+++ b/services/agent-runtime/test/browser-host-sessions.test.ts
@@ -342,6 +342,20 @@ test("first frame and navigation share one page when navigation starts first", a
   await concurrentStartup("navigate");
 });
 
+test("passive state reads do not create sessions or consume capacity", async () => {
+  const manager = new FakeManager();
+  const host = hostFor(manager, {
+    config: { idleMs: 60_000, maxSessions: 1 },
+  });
+  assert.equal(await host.peekState("session-a"), null);
+  assert.deepEqual(manager.launches, []);
+  await host.navigate("session-b", "https://public.test/b");
+  assert.equal((await host.peekState("session-b"))?.url, "https://public.test/b");
+  assert.equal(await host.peekState("session-a"), null);
+  assert.deepEqual(manager.launches, ["session-b"]);
+  await host.stop();
+});
+
 test("navigation preserves order inside one session context", async () => {
   const manager = new FakeManager();
   const host = hostFor(manager);

--- a/services/agent-runtime/test/browser-host-sessions.test.ts
+++ b/services/agent-runtime/test/browser-host-sessions.test.ts
@@ -30,6 +30,20 @@ const barrier = (): Barrier => ({
   started: new Deferred<void>(),
 });
 
+type Settlement<A> =
+  | { status: "fulfilled"; value: A }
+  | { error: unknown; status: "rejected" }
+  | { status: "timed-out" };
+
+const settleWithin = <A>(promise: Promise<A>, timeoutMs = 250): Promise<Settlement<A>> =>
+  Promise.race([
+    promise.then<Settlement<A>>(
+      (value) => ({ status: "fulfilled", value }),
+      (error: unknown) => ({ error, status: "rejected" }),
+    ),
+    Bun.sleep(timeoutMs).then<Settlement<A>>(() => ({ status: "timed-out" })),
+  ]);
+
 const state = (url: string): PageState => ({
   canGoBack: false,
   canGoForward: false,
@@ -135,6 +149,7 @@ class FakePage implements BrowserPage<RawPage> {
 
 class FakeContext implements BrowserContextSurface<RawPage> {
   readonly rawPages: RawPage[] = [];
+  private isClosed = false;
 
   constructor(
     private readonly createRawPage: () => RawPage,
@@ -144,6 +159,7 @@ class FakeContext implements BrowserContextSurface<RawPage> {
   async newPage(): Promise<RawPage> {
     this.pageCreationBarrier?.started.resolve();
     await this.pageCreationBarrier?.release.promise;
+    if (this.isClosed) throw new Error("Target closed");
     const page = this.createRawPage();
     this.rawPages.push(page);
     return page;
@@ -154,6 +170,7 @@ class FakeContext implements BrowserContextSurface<RawPage> {
   }
 
   close(): void {
+    this.isClosed = true;
     for (const page of this.rawPages) page.closed = true;
   }
 }
@@ -161,6 +178,7 @@ class FakeContext implements BrowserContextSurface<RawPage> {
 class FakeSession implements ManagedPlaywrightSession<BrowserContextSurface<RawPage>> {
   private isClosed = false;
   private readonly listeners = new Set<() => void>();
+  closeCalls = 0;
 
   constructor(
     readonly context: FakeContext,
@@ -169,6 +187,7 @@ class FakeSession implements ManagedPlaywrightSession<BrowserContextSurface<RawP
   ) {}
 
   close(): Promise<void> {
+    this.closeCalls += 1;
     if (this.isClosed) return Promise.resolve();
     this.isClosed = true;
     this.context.close();
@@ -197,6 +216,7 @@ class FakeManager implements BrowserHostManager<RawPage> {
   private readonly ensureBarriers: Barrier[] = [];
   private readonly navigationBarriers: Barrier[] = [];
   private readonly pageCreationBarriers: Barrier[] = [];
+  private readonly releaseBarriers: Barrier[] = [];
 
   blockNextEnsure(): Barrier {
     const next = barrier();
@@ -213,6 +233,12 @@ class FakeManager implements BrowserHostManager<RawPage> {
   blockNextPageCreation(): Barrier {
     const next = barrier();
     this.pageCreationBarriers.push(next);
+    return next;
+  }
+
+  blockNextRelease(): Barrier {
+    const next = barrier();
+    this.releaseBarriers.push(next);
     return next;
   }
 
@@ -247,6 +273,9 @@ class FakeManager implements BrowserHostManager<RawPage> {
   async release(scope: string): Promise<void> {
     const active = this.active.get(scope);
     await active?.close();
+    const pending = this.releaseBarriers.shift();
+    pending?.started.resolve();
+    await pending?.release.promise;
     if (this.active.get(scope) === active) this.active.delete(scope);
   }
 
@@ -322,31 +351,56 @@ test("navigation preserves order inside one session context", async () => {
   await host.stop();
 });
 
-test("shutdown waits for in-flight navigation and closes every context once", async () => {
+test("shutdown closes a context without waiting forever for hung navigation", async () => {
   const manager = new FakeManager();
   const host = hostFor(manager);
   const pending = manager.blockNextNavigation();
   const navigation = host.navigate(SESSION, "https://public.test/page");
   await pending.started.promise;
-  let stopped = false;
-  const stopping = host.stop().then(() => {
-    stopped = true;
-  });
+  const stopping = host.stop();
   assert.equal(host.stop(), host.stop());
-  await Promise.resolve();
-  assert.equal(stopped, false);
+  const settlement = await settleWithin(stopping);
   pending.release.resolve();
-  assert.deepEqual(await navigation, {
-    title: "https://public.test/page",
-    url: "https://public.test/page",
-  });
-  await stopping;
+  await Promise.allSettled([navigation, stopping]);
+  assert.equal(settlement.status, "fulfilled");
   assert.equal(manager.stops, 1);
   assert.equal(activeRawPages(manager).length, 0);
   await assert.rejects(host.getState(SESSION), /Browser host stopped/u);
 });
 
-test("shutdown protects active manager and page creation", async () => {
+test("release closes a context without waiting forever for hung page creation", async () => {
+  const manager = new FakeManager();
+  const host = hostFor(manager);
+  const pending = manager.blockNextPageCreation();
+  const navigation = host.navigate(SESSION, "https://public.test/page");
+  await pending.started.promise;
+  const releasing = host.releaseSession(SESSION);
+  const settlement = await settleWithin(releasing);
+  pending.release.resolve();
+  await Promise.allSettled([navigation, releasing]);
+  assert.equal(settlement.status, "fulfilled");
+  assert.equal(manager.sessions[0]?.closed(), true);
+  await host.stop();
+});
+
+test("release rejects work that arrives while context closure is pending", async () => {
+  const manager = new FakeManager();
+  const host = hostFor(manager);
+  await host.navigate(SESSION, "https://public.test/page");
+  const pending = manager.blockNextRelease();
+  const releasing = host.releaseSession(SESSION);
+  await pending.started.promise;
+  const request = host.navigate(SESSION, "https://public.test/recreated");
+  const settlement = await settleWithin(request);
+  pending.release.resolve();
+  await releasing;
+  await Promise.allSettled([request]);
+  assert.equal(settlement.status, "rejected");
+  assert.match(String(settlement.status === "rejected" ? settlement.error : ""), /releasing/u);
+  await host.stop();
+});
+
+test("shutdown rejects work blocked in manager and page creation", async () => {
   for (const pending of ["ensure", "page"] as const) {
     const manager = new FakeManager();
     const blocked =
@@ -356,10 +410,7 @@ test("shutdown protects active manager and page creation", async () => {
     await blocked.started.promise;
     const stopping = host.stop();
     blocked.release.resolve();
-    assert.deepEqual(await navigation, {
-      title: "https://public.test/page",
-      url: "https://public.test/page",
-    });
+    await assert.rejects(navigation, /stopped|closed/u);
     await stopping;
     assert.equal(activeRawPages(manager).length, 0);
   }
@@ -476,31 +527,43 @@ test("capacity fails closed while every session has in-flight work", async () =>
   await host.stop();
 });
 
-test("release waits for work, is idempotent, and serializes same-key recreation", async () => {
+test("release is idempotent and permits later same-key recreation", async () => {
   const manager = new FakeManager();
-  const navigation = manager.blockNextNavigation();
   const host = hostFor(manager);
-  const active = host.navigate(SESSION, "https://public.test/a");
-  await navigation.started.promise;
-  let released = false;
-  const firstRelease = host.releaseSession(SESSION).then(() => {
-    released = true;
-  });
+  await host.navigate(SESSION, "https://public.test/a");
+  const firstRelease = host.releaseSession(SESSION);
   const secondRelease = host.releaseSession(SESSION);
-  const recreated = host.navigate(SESSION, "https://public.test/recreated");
-  await Promise.resolve();
-  assert.equal(released, false);
-  assert.equal(manager.sessions.filter((session) => session.scope === SESSION).length, 1);
-  navigation.release.resolve();
-  await active;
   await Promise.all([firstRelease, secondRelease]);
-  assert.deepEqual(await recreated, {
+  assert.deepEqual(await host.navigate(SESSION, "https://public.test/recreated"), {
     title: "https://public.test/recreated",
     url: "https://public.test/recreated",
   });
   const scoped = manager.sessions.filter((session) => session.scope === SESSION);
   assert.equal(scoped.length, 2);
   assert.equal(scoped[0]?.closed(), true);
+  assert.equal(scoped[0]?.closeCalls, 1);
+  assert.equal(scoped[1]?.closed(), false);
+  await host.stop();
+  assert.equal(scoped[1]?.closeCalls, 1);
+});
+
+test("late work completion cannot remove or close a recreated same-key session", async () => {
+  const manager = new FakeManager();
+  const pending = manager.blockNextNavigation();
+  const host = hostFor(manager);
+  const oldNavigation = host.navigate(SESSION, "https://public.test/old");
+  await pending.started.promise;
+  await host.releaseSession(SESSION);
+  await host.navigate(SESSION, "https://public.test/recreated");
+  pending.release.resolve();
+  await assert.rejects(oldNavigation, /closed/u);
+  assert.deepEqual(await host.getUrl(SESSION), {
+    title: "https://public.test/recreated",
+    url: "https://public.test/recreated",
+  });
+  const scoped = manager.sessions.filter((session) => session.scope === SESSION);
+  assert.equal(scoped.length, 2);
+  assert.equal(scoped[0]?.closeCalls, 1);
   assert.equal(scoped[1]?.closed(), false);
   await host.stop();
 });

--- a/services/agent-runtime/test/browser-runtime-session.test.ts
+++ b/services/agent-runtime/test/browser-runtime-session.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { test } from "bun:test";
+import { Effect } from "effect";
+import { BROWSER_SESSION_HEADER } from "../../../shared/agent/browser-session";
+import { browserSessionConfig } from "../src/browser-host/browser-session";
+import { buildAgentSessionOptionsSync, withRuntimeEnvInjections } from "../src/pi-runtime-helpers";
+
+test("browser session configuration defaults and accepts exact boundaries", () => {
+  assert.deepEqual(browserSessionConfig({}), { idleMs: 900_000, maxSessions: 8 });
+  assert.deepEqual(
+    browserSessionConfig({
+      LOCAL_STUDIO_BROWSER_MAX_SESSIONS: "1",
+      LOCAL_STUDIO_BROWSER_SESSION_IDLE_MS: "60000",
+    }),
+    { idleMs: 60_000, maxSessions: 1 },
+  );
+  assert.deepEqual(
+    browserSessionConfig({
+      LOCAL_STUDIO_BROWSER_MAX_SESSIONS: "32",
+      LOCAL_STUDIO_BROWSER_SESSION_IDLE_MS: "86400000",
+    }),
+    { idleMs: 86_400_000, maxSessions: 32 },
+  );
+});
+
+test("browser session configuration rejects invalid explicit values", () => {
+  for (const maxSessions of ["", "0", "33", "1.5", "eight", "Infinity"]) {
+    assert.throws(() => browserSessionConfig({ LOCAL_STUDIO_BROWSER_MAX_SESSIONS: maxSessions }));
+  }
+  for (const idleMs of ["", "59999", "86400001", "60000.5", "idle", "Infinity"]) {
+    assert.throws(() => browserSessionConfig({ LOCAL_STUDIO_BROWSER_SESSION_IDLE_MS: idleMs }));
+  }
+});
+
+test("runtime options inject the canonical focused browser session", () => {
+  const result = buildAgentSessionOptionsSync({
+    options: { browserSessionId: "session-a", browserToolEnabled: true },
+    processEnv: { LOCAL_STUDIO_FRONTEND_BASE: "http://127.0.0.1:3000" },
+  });
+  assert.equal(result.envInjections.LOCAL_STUDIO_BROWSER_SESSION_HEADER, BROWSER_SESSION_HEADER);
+  assert.equal(result.envInjections.LOCAL_STUDIO_BROWSER_SESSION_ID, "session-a");
+  assert.equal(result.envInjections.SITEGEIST_RELAY_SESSION_ID, "session-a");
+  assert.throws(() =>
+    buildAgentSessionOptionsSync({
+      options: { browserSessionId: "bad key", browserToolEnabled: true },
+      processEnv: {},
+    }),
+  );
+  assert.throws(() =>
+    buildAgentSessionOptionsSync({ options: { browserToolEnabled: true }, processEnv: {} }),
+  );
+});
+
+test("runtime environment injection is serialized and restored exactly", async () => {
+  const env: NodeJS.ProcessEnv = { LOCAL_STUDIO_BROWSER_SESSION_ID: "original" };
+  const observed: string[] = [];
+  const run = (sessionId: string) =>
+    Effect.runPromise(
+      withRuntimeEnvInjections(
+        { LOCAL_STUDIO_BROWSER_SESSION_ID: sessionId, TEMPORARY_BROWSER_KEY: sessionId },
+        Effect.gen(function* () {
+          observed.push(`${sessionId}:${env.LOCAL_STUDIO_BROWSER_SESSION_ID}`);
+          yield* Effect.sleep(5);
+          observed.push(`${sessionId}:${env.LOCAL_STUDIO_BROWSER_SESSION_ID}`);
+        }),
+        env,
+      ),
+    );
+  await Promise.all([run("session-a"), run("session-b")]);
+  assert.deepEqual(observed, [
+    "session-a:session-a",
+    "session-a:session-a",
+    "session-b:session-b",
+    "session-b:session-b",
+  ]);
+  assert.equal(env.LOCAL_STUDIO_BROWSER_SESSION_ID, "original");
+  assert.equal(Object.hasOwn(env, "TEMPORARY_BROWSER_KEY"), false);
+});

--- a/services/agent-runtime/test/browser-session-chromium-canary.test.ts
+++ b/services/agent-runtime/test/browser-session-chromium-canary.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { test } from "bun:test";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { Page } from "playwright-core";
+import { BrowserHost } from "../src/browser-host/browser-host";
+import { HostedPage } from "../src/browser-host/hosted-page";
+import {
+  createPlaywrightSessionLauncher,
+  findBrowserBinary,
+  PlaywrightManager,
+} from "../src/browser-host/playwright";
+
+type Settlement<A> =
+  | { status: "fulfilled"; value: A }
+  | { error: unknown; status: "rejected" }
+  | { status: "timed-out" };
+
+const settleWithin = <A>(promise: Promise<A>, timeoutMs: number): Promise<Settlement<A>> =>
+  Promise.race([
+    promise.then<Settlement<A>>(
+      (value) => ({ status: "fulfilled", value }),
+      (error: unknown) => ({ error, status: "rejected" }),
+    ),
+    Bun.sleep(timeoutMs).then<Settlement<A>>(() => ({ status: "timed-out" })),
+  ]);
+
+const listen = (server: ReturnType<typeof createServer>): Promise<number> =>
+  new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve((server.address() as AddressInfo).port));
+  });
+
+const close = (server: ReturnType<typeof createServer>): Promise<void> => {
+  if (!server.listening) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+};
+
+test.skipIf(findBrowserBinary() === null)(
+  "keeps cookie, storage, frame, and input state isolated in real Chromium sessions",
+  async () => {
+    const executablePath = findBrowserBinary();
+    if (!executablePath) throw new Error("Chromium disappeared after test selection");
+    const hangingNavigation = Promise.withResolvers<void>();
+    const fixture = createServer((request, response) => {
+      const url = new URL(request.url ?? "/", "http://localhost");
+      if (url.pathname === "/hang") {
+        hangingNavigation.resolve();
+        return;
+      }
+      const marker = url.searchParams.get("marker");
+      if (marker !== "session-a" && marker !== "session-b") {
+        response.writeHead(400);
+        response.end();
+        return;
+      }
+      response.writeHead(200, {
+        "content-type": "text/html; charset=utf-8",
+        "set-cookie": `scope=${marker}; Path=/; SameSite=Lax`,
+      });
+      response.end(`<!doctype html>
+<html>
+<head><title>${marker}</title></head>
+<body style="background:${marker === "session-a" ? "#a11" : "#11a"};color:#fff">
+<label>${marker}<input id="entry" /></label>
+<script>localStorage.setItem("scope", ${JSON.stringify(marker)})</script>
+</body>
+</html>`);
+    });
+    const manager = new PlaywrightManager({
+      launch: createPlaywrightSessionLauncher(),
+      resolveBinary: () => executablePath,
+    });
+    const host = new BrowserHost<Page>(manager, { attachPage: HostedPage.attach });
+    try {
+      const port = await listen(fixture);
+      const origin = `http://127.0.0.1:${port}`;
+      await Promise.all([
+        host.navigate("session-a", `${origin}/?marker=session-a`),
+        host.navigate("session-b", `${origin}/?marker=session-b`),
+      ]);
+      await host.click("session-a", { selector: "#entry" });
+      await host.dispatchKey("session-a", {
+        code: "KeyA",
+        key: "a",
+        text: "typed-a",
+        type: "char",
+      });
+      const sessionBBeforeInput = await host.evaluate(
+        "session-b",
+        "document.querySelector('#entry')?.value",
+      );
+      await host.click("session-b", { selector: "#entry" });
+      await host.dispatchKey("session-b", {
+        code: "KeyB",
+        key: "b",
+        text: "typed-b",
+        type: "char",
+      });
+      const [sessionA, sessionB, frameA, frameB] = await Promise.all([
+        host.evaluate(
+          "session-a",
+          "({ cookie: document.cookie, input: document.querySelector('#entry')?.value, storage: localStorage.getItem('scope') })",
+        ),
+        host.evaluate(
+          "session-b",
+          "({ cookie: document.cookie, input: document.querySelector('#entry')?.value, storage: localStorage.getItem('scope') })",
+        ),
+        host.pollFrame("session-a"),
+        host.pollFrame("session-b"),
+      ]);
+      assert.equal(sessionBBeforeInput, "");
+      assert.deepEqual(sessionA, {
+        cookie: "scope=session-a",
+        input: "typed-a",
+        storage: "session-a",
+      });
+      assert.deepEqual(sessionB, {
+        cookie: "scope=session-b",
+        input: "typed-b",
+        storage: "session-b",
+      });
+      assert.ok((frameA.frame?.data.length ?? 0) > 100);
+      assert.ok((frameB.frame?.data.length ?? 0) > 100);
+      assert.notEqual(frameA.frame?.data, frameB.frame?.data);
+      const navigation = host.navigate("session-a", `${origin}/hang`);
+      await hangingNavigation.promise;
+      const release = host.releaseSession("session-a");
+      const [releaseResult, navigationResult] = await Promise.all([
+        settleWithin(release, 2_000),
+        settleWithin(navigation, 2_000),
+      ]);
+      assert.equal(releaseResult.status, "fulfilled");
+      assert.equal(navigationResult.status, "rejected");
+      assert.equal(manager.current("session-a"), null);
+    } finally {
+      await host.stop();
+      await close(fixture);
+    }
+  },
+);

--- a/services/agent-runtime/test/browser-session-chromium-canary.test.ts
+++ b/services/agent-runtime/test/browser-session-chromium-canary.test.ts
@@ -39,7 +39,7 @@ const close = (server: ReturnType<typeof createServer>): Promise<void> => {
 };
 
 test.skipIf(findBrowserBinary() === null)(
-  "keeps cookie, storage, frame, and input state isolated in real Chromium sessions",
+  "keeps storage, frame, input, viewport, and history isolated in real Chromium sessions",
   async () => {
     const executablePath = findBrowserBinary();
     if (!executablePath) throw new Error("Chromium disappeared after test selection");
@@ -82,31 +82,31 @@ test.skipIf(findBrowserBinary() === null)(
         host.navigate("session-b", `${origin}/?marker=session-b`),
       ]);
       await host.click("session-a", { selector: "#entry" });
-      await host.dispatchKey("session-a", {
-        code: "KeyA",
-        key: "a",
-        text: "typed-a",
-        type: "char",
-      });
+      for (const key of "typed-a") {
+        await host.dispatchKey("session-a", { code: `Key${key.toUpperCase()}`, key, type: "down" });
+        await host.dispatchKey("session-a", { code: `Key${key.toUpperCase()}`, key, type: "up" });
+      }
       const sessionBBeforeInput = await host.evaluate(
         "session-b",
         "document.querySelector('#entry')?.value",
       );
       await host.click("session-b", { selector: "#entry" });
-      await host.dispatchKey("session-b", {
-        code: "KeyB",
-        key: "b",
-        text: "typed-b",
-        type: "char",
-      });
+      for (const key of "typed-b") {
+        await host.dispatchKey("session-b", { code: `Key${key.toUpperCase()}`, key, type: "down" });
+        await host.dispatchKey("session-b", { code: `Key${key.toUpperCase()}`, key, type: "up" });
+      }
+      await Promise.all([
+        host.setViewport("session-a", 700, 500),
+        host.setViewport("session-b", 900, 650),
+      ]);
       const [sessionA, sessionB, frameA, frameB] = await Promise.all([
         host.evaluate(
           "session-a",
-          "({ cookie: document.cookie, input: document.querySelector('#entry')?.value, storage: localStorage.getItem('scope') })",
+          "({ cookie: document.cookie, input: document.querySelector('#entry')?.value, storage: localStorage.getItem('scope'), viewport: [window.innerWidth, window.innerHeight] })",
         ),
         host.evaluate(
           "session-b",
-          "({ cookie: document.cookie, input: document.querySelector('#entry')?.value, storage: localStorage.getItem('scope') })",
+          "({ cookie: document.cookie, input: document.querySelector('#entry')?.value, storage: localStorage.getItem('scope'), viewport: [window.innerWidth, window.innerHeight] })",
         ),
         host.pollFrame("session-a"),
         host.pollFrame("session-b"),
@@ -116,15 +116,26 @@ test.skipIf(findBrowserBinary() === null)(
         cookie: "scope=session-a",
         input: "typed-a",
         storage: "session-a",
+        viewport: [700, 500],
       });
       assert.deepEqual(sessionB, {
         cookie: "scope=session-b",
         input: "typed-b",
         storage: "session-b",
+        viewport: [900, 650],
       });
       assert.ok((frameA.frame?.data.length ?? 0) > 100);
       assert.ok((frameB.frame?.data.length ?? 0) > 100);
       assert.notEqual(frameA.frame?.data, frameB.frame?.data);
+      const sessionBHistoryBefore = await host.getState("session-b");
+      await host.navigate("session-a", `${origin}/second?marker=session-a`);
+      await host.goBack("session-a");
+      const [sessionAAfterBack, sessionBHistoryAfter] = await Promise.all([
+        host.getState("session-a"),
+        host.getState("session-b"),
+      ]);
+      assert.equal(sessionAAfterBack.url, `${origin}/?marker=session-a`);
+      assert.deepEqual(sessionBHistoryAfter, sessionBHistoryBefore);
       const navigation = host.navigate("session-a", `${origin}/hang`);
       await hangingNavigation.promise;
       const release = host.releaseSession("session-a");

--- a/services/agent-runtime/test/browser-session-handlers.test.ts
+++ b/services/agent-runtime/test/browser-session-handlers.test.ts
@@ -238,7 +238,7 @@ test("deferred fallback reads retain their session through idle cleanup", async 
   assert.deepEqual(body, { ok: true, data: { title: "", url: initialUrl } });
 });
 
-test("release waits for a deferred fallback fetch", async () => {
+test("release does not wait forever for a deferred fallback fetch", async () => {
   const manager = new CountingManager();
   const host = new BrowserHost(manager);
   const reader = deferredReadable();
@@ -258,7 +258,7 @@ test("release waits for a deferred fallback fetch", async () => {
   reader.resolve("https://public.test/pending");
   await Promise.all([pending, releasing]);
   await host.stop();
-  assert.equal(releasedWhilePending, false);
+  assert.equal(releasedWhilePending, true);
 });
 
 test("a deferred fallback fetch holds its session capacity", async () => {

--- a/services/agent-runtime/test/browser-session-handlers.test.ts
+++ b/services/agent-runtime/test/browser-session-handlers.test.ts
@@ -1,0 +1,315 @@
+import assert from "node:assert/strict";
+import { test } from "bun:test";
+import { BROWSER_SESSION_HEADER } from "../../../shared/agent/browser-session";
+import { decodeBrowserSessionKey } from "../src/browser-host/browser-session";
+import { BrowserHost, type BrowserHostManager } from "../src/browser-host/browser-host";
+import { fetchReadable, type ReaderResult } from "../src/browser-host/reader";
+import {
+  browserSessionKeyFromRequest,
+  handleBrowserFetch,
+  handleBrowserFrame,
+  handleBrowserInput,
+  handleBrowserLocalhosts,
+  handleBrowserState,
+  handleBrowserVerb,
+  handleBrowserViewport,
+} from "../src/http/browser-handlers";
+
+class CountingManager implements BrowserHostManager {
+  touches = 0;
+
+  ensure(_scope: string): Promise<never> {
+    this.touches += 1;
+    return Promise.reject(new Error("Unexpected context creation"));
+  }
+
+  isAvailable(): boolean {
+    this.touches += 1;
+    return false;
+  }
+
+  release(_scope: string): Promise<void> {
+    this.touches += 1;
+    return Promise.resolve();
+  }
+
+  stop(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+function request(path: string, method: "GET" | "POST", session?: string, body?: string): Request {
+  return new Request(`http://127.0.0.1${path}`, {
+    method,
+    headers: session === undefined ? undefined : { [BROWSER_SESSION_HEADER]: session },
+    body: method === "POST" ? (body ?? "{}") : undefined,
+  });
+}
+
+function readable(url: string): ReaderResult {
+  return { contentType: "text/plain", text: url, title: url, url };
+}
+
+function deferredReadable(): {
+  fetch: typeof fetchReadable;
+  reject: (error: Error) => void;
+  resolve: (url: string) => void;
+  started: Promise<void>;
+} {
+  const completed = Promise.withResolvers<ReaderResult>();
+  const started = Promise.withResolvers<void>();
+  return {
+    fetch: async () => {
+      started.resolve();
+      return completed.promise;
+    },
+    reject: completed.reject,
+    resolve: (url) => completed.resolve(readable(url)),
+    started: started.promise,
+  };
+}
+
+function navigateRequest(session: string, url: string): Request {
+  return request("/api/agent/browser/navigate", "POST", session, JSON.stringify({ url }));
+}
+
+function getTextRequest(session: string): Request {
+  return request("/api/agent/browser/get-text", "POST", session);
+}
+
+function getUrlRequest(session: string): Request {
+  return request("/api/agent/browser/get-url", "POST", session);
+}
+
+async function statefulResponses(host: BrowserHost, session?: string): Promise<Response[]> {
+  const verbs = [
+    "navigate",
+    "get-url",
+    "get-text",
+    "get-html",
+    "screenshot",
+    "click",
+    "scroll",
+    "fill",
+    "back",
+    "forward",
+    "reload",
+  ];
+  return Promise.all([
+    ...verbs.map((verb) =>
+      handleBrowserVerb(request(`/api/agent/browser/${verb}`, "POST", session, "{}"), verb, host),
+    ),
+    handleBrowserFrame(request("/api/agent/browser/frame", "GET", session), host),
+    handleBrowserState(request("/api/agent/browser/state", "GET", session), host),
+    handleBrowserInput(
+      request(
+        "/api/agent/browser/input",
+        "POST",
+        session,
+        JSON.stringify({ kind: "mouse", type: "move", x: 1, y: 1 }),
+      ),
+      host,
+    ),
+    handleBrowserViewport(
+      request(
+        "/api/agent/browser/viewport",
+        "POST",
+        session,
+        JSON.stringify({ width: 800, height: 600 }),
+      ),
+      host,
+    ),
+  ]);
+}
+
+test("every stateful endpoint rejects missing and malformed session headers before host access", async () => {
+  for (const value of [undefined, "", "bad key", "é", "a".repeat(129), "session-a,session-b"]) {
+    const manager = new CountingManager();
+    const host = new BrowserHost(manager);
+    const responses = await statefulResponses(host, value);
+    assert.equal(responses.length, 15);
+    assert.deepEqual(
+      responses.map((response) => response.status),
+      Array(15).fill(400),
+    );
+    assert.equal(manager.touches, 0);
+    await host.stop();
+  }
+});
+
+test("session schema accepts exact boundaries and rejects unstable ASCII", () => {
+  assert.equal(decodeBrowserSessionKey("a"), "a");
+  assert.equal(decodeBrowserSessionKey("a".repeat(128)), "a".repeat(128));
+  for (const value of [
+    null,
+    "",
+    "a".repeat(129),
+    " leading",
+    "trailing ",
+    "a/b",
+    "a\u0000b",
+    "☃",
+  ]) {
+    assert.throws(() => decodeBrowserSessionKey(value));
+  }
+  assert.equal(
+    browserSessionKeyFromRequest(request("/api/agent/browser/state", "GET", "session-a")),
+    "session-a",
+  );
+});
+
+test("body session affinity is rejected before host access", async () => {
+  const manager = new CountingManager();
+  const host = new BrowserHost(manager);
+  const responses = await Promise.all([
+    handleBrowserVerb(
+      request(
+        "/api/agent/browser/navigate",
+        "POST",
+        "session-a",
+        JSON.stringify({ sessionId: "session-b", url: "https://example.com" }),
+      ),
+      "navigate",
+      host,
+    ),
+    handleBrowserInput(
+      request(
+        "/api/agent/browser/input",
+        "POST",
+        "session-a",
+        JSON.stringify({ kind: "mouse", sessionId: "session-b", type: "move", x: 1, y: 1 }),
+      ),
+      host,
+    ),
+    handleBrowserViewport(
+      request(
+        "/api/agent/browser/viewport",
+        "POST",
+        "session-a",
+        JSON.stringify({ height: 600, sessionId: "session-b", width: 800 }),
+      ),
+      host,
+    ),
+  ]);
+  assert.deepEqual(
+    responses.map((response) => response.status),
+    [400, 400, 400],
+  );
+  assert.equal(manager.touches, 0);
+  await host.stop();
+});
+
+test("stateless fetch ignores browser session headers", async () => {
+  const response = await handleBrowserFetch(
+    request("/api/agent/browser/fetch", "GET", "malformed session"),
+  );
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), { error: "url is required" });
+});
+
+test("stateless localhost discovery ignores browser session headers", async () => {
+  const response = await handleBrowserLocalhosts(
+    request("/api/agent/browser/localhosts", "GET", "malformed session"),
+  );
+  assert.equal(response.status, 200);
+});
+
+test("deferred fallback reads retain their session through idle cleanup", async () => {
+  const manager = new CountingManager();
+  let now = 0;
+  const host = new BrowserHost(manager, {
+    config: { idleMs: 60_000, maxSessions: 1 },
+    now: () => now,
+  });
+  const initialUrl = "https://public.test/initial";
+  await handleBrowserVerb(navigateRequest("session-a", initialUrl), "navigate", host, async (url) =>
+    readable(url),
+  );
+  const reader = deferredReadable();
+  const pending = handleBrowserVerb(getTextRequest("session-a"), "get-text", host, reader.fetch);
+  await reader.started;
+  now = 60_001;
+  await host.cleanupIdleSessions();
+  reader.reject(new Error("deferred failure"));
+  await pending;
+  const current = await handleBrowserVerb(getUrlRequest("session-a"), "get-url", host);
+  const body = await current.json();
+  await host.stop();
+  assert.deepEqual(body, { ok: true, data: { title: "", url: initialUrl } });
+});
+
+test("release waits for a deferred fallback fetch", async () => {
+  const manager = new CountingManager();
+  const host = new BrowserHost(manager);
+  const reader = deferredReadable();
+  const pending = handleBrowserVerb(
+    navigateRequest("session-a", "https://public.test/pending"),
+    "navigate",
+    host,
+    reader.fetch,
+  );
+  await reader.started;
+  let released = false;
+  const releasing = host.releaseSession("session-a").then(() => {
+    released = true;
+  });
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  const releasedWhilePending = released;
+  reader.resolve("https://public.test/pending");
+  await Promise.all([pending, releasing]);
+  await host.stop();
+  assert.equal(releasedWhilePending, false);
+});
+
+test("a deferred fallback fetch holds its session capacity", async () => {
+  const manager = new CountingManager();
+  const host = new BrowserHost(manager, { config: { idleMs: 60_000, maxSessions: 1 } });
+  const reader = deferredReadable();
+  const pending = handleBrowserVerb(
+    navigateRequest("session-a", "https://public.test/pending"),
+    "navigate",
+    host,
+    reader.fetch,
+  );
+  await reader.started;
+  const blocked = await handleBrowserVerb(getUrlRequest("session-b"), "get-url", host);
+  const body = await blocked.json();
+  reader.resolve("https://public.test/pending");
+  await pending;
+  await host.stop();
+  assert.deepEqual(body, {
+    error: "Browser session capacity reached while all sessions are active",
+    ok: false,
+  });
+});
+
+test("later fallback navigation remains authoritative after an earlier fetch completes", async () => {
+  const manager = new CountingManager();
+  const host = new BrowserHost(manager);
+  const firstUrl = "https://public.test/first";
+  const secondUrl = "https://public.test/second";
+  const firstReader = deferredReadable();
+  let secondStarted = false;
+  const reader: typeof fetchReadable = async (url) => {
+    if (url === firstUrl) return firstReader.fetch(url);
+    secondStarted = true;
+    return readable(url);
+  };
+  const first = handleBrowserVerb(navigateRequest("session-a", firstUrl), "navigate", host, reader);
+  await firstReader.started;
+  const second = handleBrowserVerb(
+    navigateRequest("session-a", secondUrl),
+    "navigate",
+    host,
+    reader,
+  );
+  await handleBrowserVerb(getUrlRequest("session-b"), "get-url", host);
+  const secondStartedBeforeFirstCompleted = secondStarted;
+  firstReader.resolve(firstUrl);
+  await Promise.all([first, second]);
+  const current = await handleBrowserVerb(getUrlRequest("session-a"), "get-url", host);
+  const body = await current.json();
+  await host.stop();
+  assert.equal(secondStartedBeforeFirstCompleted, false);
+  assert.deepEqual(body, { ok: true, data: { title: "", url: secondUrl } });
+});

--- a/services/agent-runtime/test/browser-session-handlers.test.ts
+++ b/services/agent-runtime/test/browser-session-handlers.test.ts
@@ -199,6 +199,23 @@ test("body session affinity is rejected before host access", async () => {
   await host.stop();
 });
 
+test("key input rejects character payloads before host access", async () => {
+  const manager = new CountingManager();
+  const host = new BrowserHost(manager);
+  const response = await handleBrowserInput(
+    request(
+      "/api/agent/browser/input",
+      "POST",
+      "session-a",
+      JSON.stringify({ kind: "key", type: "char", key: "a", code: "KeyA", text: "a" }),
+    ),
+    host,
+  );
+  assert.equal(response.status, 400);
+  assert.equal(manager.touches, 0);
+  await host.stop();
+});
+
 test("stateless fetch ignores browser session headers", async () => {
   const response = await handleBrowserFetch(
     request("/api/agent/browser/fetch", "GET", "malformed session"),

--- a/services/agent-runtime/test/browser-standalone-session.test.ts
+++ b/services/agent-runtime/test/browser-standalone-session.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { type ChildProcess, execFile, spawn } from "node:child_process";
+import { once } from "node:events";
+import { createServer } from "node:net";
+import { promisify } from "node:util";
+import { test } from "bun:test";
+import { BROWSER_SESSION_HEADER } from "../../../shared/agent/browser-session";
+
+const execFileAsync = promisify(execFile);
+const INVALID_SESSION = {
+  error: `A valid ${BROWSER_SESSION_HEADER} header is required`,
+  ok: false,
+};
+const STATEFUL_REQUESTS: ReadonlyArray<{
+  body?: string;
+  method: "GET" | "POST";
+  path: string;
+}> = [
+  { body: "{}", method: "POST", path: "/api/agent/browser/get-url" },
+  { body: "not-json", method: "POST", path: "/api/agent/browser/get-url" },
+  { method: "GET", path: "/api/agent/browser/frame" },
+  { body: "not-json", method: "POST", path: "/api/agent/browser/input" },
+  { method: "GET", path: "/api/agent/browser/state" },
+  { body: "not-json", method: "POST", path: "/api/agent/browser/viewport" },
+];
+
+async function availablePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Temporary loopback server has no numeric port");
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  return address.port;
+}
+
+async function bundleStandalone(): Promise<void> {
+  const command = process.platform === "win32" ? "npm.cmd" : "npm";
+  await execFileAsync(command, ["run", "bundle", "--silent"], { cwd: process.cwd() });
+}
+
+async function startStandalone(port: number): Promise<ChildProcess> {
+  const child = spawn(process.execPath, ["dist/standalone.mjs"], {
+    cwd: process.cwd(),
+    env: { ...process.env, PORT: String(port) },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const ready = Promise.withResolvers<void>();
+  let output = "";
+  const onData = (chunk: unknown) => {
+    output += String(chunk);
+    if (output.includes("[agent-runtime] listening")) ready.resolve();
+  };
+  const onError = (error: Error) => ready.reject(error);
+  const onExit = (code: number | null, signal: NodeJS.Signals | null) =>
+    ready.reject(new Error(`Standalone exited before ready: ${code ?? signal ?? "unknown"}`));
+  child.stdout?.on("data", onData);
+  child.stderr?.on("data", onData);
+  child.once("error", onError);
+  child.once("exit", onExit);
+  const timer = setTimeout(
+    () => ready.reject(new Error(`Standalone start timed out: ${output}`)),
+    10_000,
+  );
+  try {
+    await ready.promise;
+    return child;
+  } catch (error) {
+    child.kill("SIGTERM");
+    throw error;
+  } finally {
+    clearTimeout(timer);
+    child.stdout?.off("data", onData);
+    child.stderr?.off("data", onData);
+    child.off("error", onError);
+    child.off("exit", onExit);
+  }
+}
+
+async function stopStandalone(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exited = once(child, "exit");
+  child.kill("SIGTERM");
+  await exited;
+}
+
+function sessionHeaders(session: string | undefined): HeadersInit {
+  return session === undefined ? {} : { [BROWSER_SESSION_HEADER]: session };
+}
+
+test("standalone browser routes reject invalid session keys before request parsing", async () => {
+  await bundleStandalone();
+  const port = await availablePort();
+  const child = await startStandalone(port);
+  try {
+    const origin = `http://127.0.0.1:${port}`;
+    for (const session of [undefined, "", "bad key"]) {
+      for (const request of STATEFUL_REQUESTS) {
+        const response = await fetch(`${origin}${request.path}`, {
+          ...(request.body === undefined ? {} : { body: request.body }),
+          headers: sessionHeaders(session),
+          method: request.method,
+        });
+        assert.equal(response.status, 400);
+        assert.deepEqual(await response.json(), INVALID_SESSION);
+      }
+    }
+    const valid = await fetch(`${origin}/api/agent/browser/get-url`, {
+      body: "not-json",
+      headers: sessionHeaders("session-a"),
+      method: "POST",
+    });
+    assert.equal(valid.status, 400);
+    assert.deepEqual(await valid.json(), { error: "Invalid browser command JSON", ok: false });
+    const statelessFetch = await fetch(`${origin}/api/agent/browser/fetch`, {
+      headers: sessionHeaders("bad key"),
+    });
+    assert.equal(statelessFetch.status, 400);
+    assert.deepEqual(await statelessFetch.json(), { error: "url is required" });
+    const statelessLocalhosts = await fetch(`${origin}/api/agent/browser/localhosts`, {
+      headers: sessionHeaders("bad key"),
+    });
+    assert.equal(statelessLocalhosts.status, 200);
+  } finally {
+    await stopStandalone(child);
+  }
+});

--- a/services/agent-runtime/test/playwright-session-manager.test.ts
+++ b/services/agent-runtime/test/playwright-session-manager.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { test } from "bun:test";
+import { PlaywrightManager, type ManagedPlaywrightSession } from "../src/browser-host/playwright";
+
+class Deferred<T> {
+  private readonly state = Promise.withResolvers<T>();
+  readonly promise = this.state.promise;
+
+  resolve(value: T): void {
+    this.state.resolve(value);
+  }
+}
+
+type ClosePlan = {
+  release: Deferred<void>;
+  started: Deferred<void>;
+};
+
+type FakeContext = { id: string };
+
+class FakeSession implements Omit<ManagedPlaywrightSession<FakeContext>, "generation"> {
+  private isClosed = false;
+  private readonly listeners = new Set<() => void>();
+  private nextClose: ClosePlan | null = null;
+  readonly context: FakeContext;
+
+  constructor(id: number) {
+    this.context = { id: `context-${id}` };
+  }
+
+  blockNextClose(): ClosePlan {
+    const plan = { release: new Deferred<void>(), started: new Deferred<void>() };
+    this.nextClose = plan;
+    return plan;
+  }
+
+  async close(): Promise<void> {
+    const plan = this.nextClose;
+    this.nextClose = null;
+    plan?.started.resolve();
+    await plan?.release.promise;
+    this.finishClose();
+  }
+
+  closed(): boolean {
+    return this.isClosed;
+  }
+
+  onClose(listener: () => void): void {
+    this.listeners.add(listener);
+  }
+
+  finishClose(): void {
+    if (this.isClosed) return;
+    this.isClosed = true;
+    for (const listener of this.listeners) listener();
+    this.listeners.clear();
+  }
+}
+
+class ManagerFixture {
+  readonly sessions: FakeSession[] = [];
+  private serial = 0;
+
+  manager(closeTimeoutMs = 1_000): PlaywrightManager<FakeContext> {
+    return new PlaywrightManager<FakeContext>({
+      closeTimeoutMs,
+      launch: async () => {
+        const session = new FakeSession(++this.serial);
+        this.sessions.push(session);
+        return session;
+      },
+      resolveBinary: () => "/fake/chromium",
+    });
+  }
+}
+
+test("same-scope creation is coalesced while scopes remain isolated", async () => {
+  const fixture = new ManagerFixture();
+  const manager = fixture.manager();
+  const [firstA, secondA, sessionB] = await Promise.all([
+    manager.ensure("session-a"),
+    manager.ensure("session-a"),
+    manager.ensure("session-b"),
+  ]);
+  assert.equal(firstA, secondA);
+  assert.notEqual(firstA.context, sessionB.context);
+  assert.equal(fixture.sessions.length, 2);
+  await manager.stop();
+});
+
+test("scoped contexts release independently", async () => {
+  const fixture = new ManagerFixture();
+  const manager = fixture.manager();
+  const sessionA = await manager.ensure("session-a");
+  const sessionB = await manager.ensure("session-b");
+  await manager.release("session-a");
+  assert.equal(sessionA.closed(), true);
+  assert.equal(sessionB.closed(), false);
+  assert.equal(manager.current("session-a"), null);
+  assert.equal(manager.current("session-b"), sessionB);
+  await manager.stop();
+  assert.equal(sessionB.closed(), true);
+});
+
+test("release waits for confirmed context closure", async () => {
+  const fixture = new ManagerFixture();
+  const manager = fixture.manager();
+  const session = await manager.ensure("session-a");
+  const pending = fixture.sessions[0]?.blockNextClose();
+  assert.ok(pending);
+  let released = false;
+  const release = manager.release("session-a").then(() => {
+    released = true;
+  });
+  await pending.started.promise;
+  assert.equal(released, false);
+  pending.release.resolve();
+  await release;
+  assert.equal(session.closed(), true);
+  await manager.stop();
+});
+
+test("unexpected closure permits a clean scoped relaunch", async () => {
+  const fixture = new ManagerFixture();
+  const manager = fixture.manager();
+  const first = await manager.ensure("session-a");
+  fixture.sessions[0]?.finishClose();
+  const second = await manager.ensure("session-a");
+  assert.notEqual(first.generation, second.generation);
+  assert.equal(fixture.sessions.length, 2);
+  await manager.stop();
+});
+
+test("stop closes every context once and refuses new sessions", async () => {
+  const fixture = new ManagerFixture();
+  const manager = fixture.manager();
+  await manager.ensure("session-a");
+  await manager.ensure("session-b");
+  await manager.stop();
+  await manager.stop();
+  assert.deepEqual(
+    fixture.sessions.map((session) => session.closed()),
+    [true, true],
+  );
+  await assert.rejects(manager.ensure("session-c"), /manager stopped/u);
+});

--- a/services/agent-runtime/test/playwright-session-manager.test.ts
+++ b/services/agent-runtime/test/playwright-session-manager.test.ts
@@ -22,6 +22,7 @@ class FakeSession implements Omit<ManagedPlaywrightSession<FakeContext>, "genera
   private isClosed = false;
   private readonly listeners = new Set<() => void>();
   private nextClose: ClosePlan | null = null;
+  closeCalls = 0;
   readonly context: FakeContext;
 
   constructor(id: number) {
@@ -35,6 +36,7 @@ class FakeSession implements Omit<ManagedPlaywrightSession<FakeContext>, "genera
   }
 
   async close(): Promise<void> {
+    this.closeCalls += 1;
     const plan = this.nextClose;
     this.nextClose = null;
     plan?.started.resolve();
@@ -119,6 +121,49 @@ test("release waits for confirmed context closure", async () => {
   await release;
   assert.equal(session.closed(), true);
   await manager.stop();
+});
+
+test("timeout revocation is single-flight and stop preserves its failure", async () => {
+  const fixture = new ManagerFixture();
+  const manager = fixture.manager(10);
+  const session = await manager.ensure("session-a");
+  const pending = fixture.sessions[0]?.blockNextClose();
+  assert.ok(pending);
+  const firstRelease = manager.release("session-a");
+  await pending.started.promise;
+  const secondRelease = manager.release("session-a");
+  const releases = await Promise.allSettled([firstRelease, secondRelease]);
+  assert.deepEqual(
+    releases.map((result) => result.status),
+    ["rejected", "rejected"],
+  );
+  assert.equal(
+    releases[0]?.status === "rejected" ? releases[0].reason : null,
+    releases[1]?.status === "rejected" ? releases[1].reason : null,
+  );
+  const repeatedRelease = await Promise.allSettled([manager.release("session-a")]);
+  assert.equal(repeatedRelease[0]?.status, "rejected");
+  assert.equal(
+    repeatedRelease[0]?.status === "rejected" ? repeatedRelease[0].reason : null,
+    releases[0]?.status === "rejected" ? releases[0].reason : null,
+  );
+  assert.equal(fixture.sessions[0]?.closeCalls, 1);
+  const firstStop = manager.stop();
+  const secondStop = manager.stop();
+  assert.equal(firstStop, secondStop);
+  const stops = await Promise.allSettled([firstStop, secondStop]);
+  assert.deepEqual(
+    stops.map((result) => result.status),
+    ["rejected", "rejected"],
+  );
+  assert.equal(
+    stops[0]?.status === "rejected" ? stops[0].reason : null,
+    releases[0]?.status === "rejected" ? releases[0].reason : null,
+  );
+  assert.equal(fixture.sessions[0]?.closeCalls, 1);
+  pending.release.resolve();
+  await Bun.sleep(0);
+  assert.equal(session.closed(), true);
 });
 
 test("unexpected closure permits a clean scoped relaunch", async () => {

--- a/services/agent-runtime/test/runtime-shutdown.test.ts
+++ b/services/agent-runtime/test/runtime-shutdown.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { test } from "bun:test";
+import { installRuntimeSignalShutdown } from "../src/runtime-shutdown";
+
+class Deferred {
+  private readonly state = Promise.withResolvers<void>();
+  readonly promise = this.state.promise;
+
+  resolve(): void {
+    this.state.resolve();
+  }
+}
+
+class FakeProcess {
+  readonly exits: number[] = [];
+  private readonly listeners = new Map<string, () => void>();
+
+  once(event: "SIGINT" | "SIGTERM", listener: () => void): void {
+    this.listeners.set(event, listener);
+  }
+
+  exit(code = 0): void {
+    this.exits.push(code);
+  }
+
+  signal(event: "SIGINT" | "SIGTERM"): void {
+    this.listeners.get(event)?.();
+  }
+}
+
+test("signals share one shutdown and exit only after browser cleanup", async () => {
+  const runtimeProcess = new FakeProcess();
+  const browserStopped = new Deferred();
+  let stops = 0;
+  let disposals = 0;
+  const shutdown = installRuntimeSignalShutdown({
+    dispose: () => {
+      disposals += 1;
+    },
+    process: runtimeProcess,
+    reportError: () => undefined,
+    stop: () => {
+      stops += 1;
+      return browserStopped.promise;
+    },
+  });
+
+  runtimeProcess.signal("SIGTERM");
+  runtimeProcess.signal("SIGINT");
+  const inFlight = shutdown();
+  assert.equal(shutdown(), inFlight);
+  await Promise.resolve();
+  assert.equal(stops, 1);
+  assert.equal(disposals, 0);
+  assert.deepEqual(runtimeProcess.exits, []);
+
+  browserStopped.resolve();
+  await inFlight;
+  await Promise.resolve();
+  assert.equal(disposals, 1);
+  assert.deepEqual(runtimeProcess.exits, [0]);
+});
+
+test("failed browser cleanup still disposes metadata and exits nonzero", async () => {
+  const runtimeProcess = new FakeProcess();
+  const errors: unknown[] = [];
+  let disposals = 0;
+  const shutdown = installRuntimeSignalShutdown({
+    dispose: () => {
+      disposals += 1;
+    },
+    process: runtimeProcess,
+    reportError: (error) => errors.push(error),
+    stop: () => Promise.reject(new Error("cleanup failed")),
+  });
+
+  runtimeProcess.signal("SIGTERM");
+  await assert.rejects(shutdown(), /cleanup failed/u);
+  await Promise.resolve();
+  assert.equal(disposals, 1);
+  assert.equal(errors.length, 1);
+  assert.deepEqual(runtimeProcess.exits, [1]);
+});

--- a/shared/agent/browser-session.ts
+++ b/shared/agent/browser-session.ts
@@ -1,0 +1,3 @@
+export const BROWSER_SESSION_HEADER = "x-local-studio-browser-session";
+export const BROWSER_SESSION_KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/u;
+export type BrowserSessionKey = string;


### PR DESCRIPTION
## Summary

- Require the canonical browser-session header before every stateful browser side effect.
- Isolate Chromium context, page, fallback, viewport, frame, input, storage, UI state, and prompt context by agent session.
- Bound capacity, idle eviction, release, extension calls, and runtime shutdown without allowing stale work to affect another or a recreated same-key session.

## Root cause

The original runtime discarded session affinity and shared one global browser surface. The replacement also needed session-owned frontend state, cancellation across owner transitions, passive state polling, bounded extension response bodies, and generation-safe teardown so delayed work could not leak or mutate another session.

## Solution design

A shared Effect Schema validates one stable ASCII session key at the HTTP boundary. BrowserHost owns a record per key and coordinates creation, in-flight work, TTL/LRU eviction, release, and shutdown. Teardown is bounded, close-once, failure-sticky, and identity guarded. Pending acquisition batches and published records share a unique generation token, so release waits only for the selected generation and cannot act on a later same-key record.

The frontend persists URL and input state per browser owner, aborts old frame/navigation/input/viewport traffic, rejects stale responses, preserves side-chat ownership, restores workspace ownership deterministically, and uses passive state polling without launching Chromium. Extension timeouts cover both headers and body reads.

## Validation

- Exact head: `a08af0f7a38da29061e232d2395b07147ec4351f` on `dev` `a765eb27bca4baffabc6dc84c553fc6d8be5590d`.
- `npm run check` passed: release self-tests 12/12, frontend 147/147, controller 90/90, agent runtime 139/139, plus lint, type, build, structural, dead-code, duplicate, and dependency gates.
- `npm run test:integration` passed 139/139.
- Focused frontend/session suite passed 68/68; the real-Chromium two-session canary passed.
- React Doctor reported no changed-scope issues.
- `npm --prefix frontend run desktop:dist` completed and produced the macOS DMG and ZIP artifacts.
- Direct packaged smoke passed with `GET /api/desktop-health` 200, agent runtime 200, embedded browser navigation, and PTY green.
- Electron Builder found zero valid Developer ID identities. The supported stable installer correctly refused at strict signature preflight before changing `/Applications`; signing and Gatekeeper were not bypassed.
- Independent exact-head P0/P1 review is READY with no findings.

## Acceptance criteria

- [x] Every stateful browser endpoint rejects missing, malformed, or conflicting session affinity before side effects.
- [x] Browser URL, DOM, storage, screenshots, fallback, frame, viewport, input, history, visible UI state, and prompt context are isolated per session.
- [x] Switching browser owners aborts obsolete frame, navigation, input, and viewport traffic and rejects late results.
- [x] Capacity and idle TTL are validated and enforced with LRU idle eviction.
- [x] Release and shutdown are bounded, idempotent, failure-sticky, and close each exact record once.
- [x] A new same-key acquisition cannot reuse an older generation release settlement or be removed by late cleanup.
- [x] Exact-head integration, package build, packaged smoke, and independent P0/P1 review pass.
- [ ] After prerequisites merge, rebase onto current `dev`, compose their browser policy/coordinator semantics per validated session, and repeat all exact-head gates before merge.

## Dependency and review state

Depends on #373, which itself follows #367. After those predecessors merge, rebase this branch onto current `dev`, preserve #367 DNS-pinned network policy per session, key #373 server and frontend coordination by validated session/generation, and repeat independent review plus signing-aware installed acceptance. No signing or Gatekeeper control may be bypassed.

Closes #237

Maintainer review requested in the PR discussion.