### PR TITLE
fix: surface provider models in Workbench

### DIFF
--- a/controller/src/modules/models/routes.ts
+++ b/controller/src/modules/models/routes.ts
@@ -44,6 +44,7 @@ import { notFound } from "../../core/errors";
 import { findObservedInferenceProcess } from "../../core/function-observability";
 import { parseBooleanFlag } from "../../core/validation";
 import { fetchInference } from "../../http/local-fetch";
+import { providerModels } from "../../services/provider-model-catalog";
 
 function isMockInferenceEnabled(): boolean {
   return parseBooleanFlag(process.env["LOCAL_STUDIO_MOCK_INFERENCE"]);
@@ -114,6 +115,30 @@ export const registerModelsRoutes = defineRoutes((app, context) => {
               max_model_len: maxModelLength,
               metadata: resolvedRecipeMetadata(recipe, modelId),
             });
+          }
+
+          const providerCatalogs = yield* Effect.forEach(
+            context.config.providers.filter((provider) => provider.enabled && provider.api_key),
+            (provider) => providerModels(provider, 3000).pipe(Effect.option),
+            { concurrency: "unbounded" },
+          );
+          for (const result of providerCatalogs) {
+            if (result._tag !== "Some") continue;
+            for (const model of result.value.models) {
+              const modelId = `${result.value.provider}/${model.id}`;
+              models.push({
+                id: modelId,
+                object: "model",
+                created: now,
+                owned_by: result.value.provider,
+                active: true,
+                metadata: {
+                  external: true,
+                  provider: result.value.provider,
+                  vision: resolveModelVision({ identifiers: [model.id, modelId] }),
+                },
+              });
+            }
           }
 
           if (models.length === 0 && (isMockInferenceEnabled() || current)) {

--- a/controller/src/modules/studio/provider-routes.ts
+++ b/controller/src/modules/studio/provider-routes.ts
@@ -4,6 +4,7 @@ import { decodeJsonBody } from "../../core/validation";
 import { effectHandler } from "../../http/effect-handler";
 import { documentRoute, defineRoutes, mergeRoutes } from "../../http/route-registrar";
 import { savePersistedConfig, type ProviderConfig } from "../../config/persisted-config";
+import { providerModels } from "../../services/provider-model-catalog";
 
 type ProviderView = {
   id: string;
@@ -26,10 +27,6 @@ const ProviderUpdateSchema = Schema.Struct({
   base_url: Schema.optional(Schema.String),
   api_key: Schema.optional(Schema.String),
   enabled: Schema.optional(Schema.Boolean),
-});
-
-const ProviderModelsSchema = Schema.Struct({
-  data: Schema.optional(Schema.Array(Schema.Struct({ id: Schema.optional(Schema.String) }))),
 });
 
 class ProviderPersistenceError extends Schema.TaggedErrorClass<ProviderPersistenceError>()(
@@ -65,32 +62,6 @@ const required = (
   const trimmed = value.trim();
   return trimmed ? Effect.succeed(trimmed) : Effect.fail(badRequest(`${label} is required`));
 };
-
-const providerModels = (
-  provider: ProviderConfig,
-): Effect.Effect<{ provider: string; models: Array<{ id: string }> }, unknown> =>
-  Effect.gen(function* () {
-    const url = `${provider.base_url.replace(/\/+$/, "")}/v1/models`;
-    const response = yield* Effect.tryPromise({
-      try: () =>
-        fetch(url, {
-          headers: { Authorization: `Bearer ${provider.api_key}` },
-          signal: AbortSignal.timeout(10_000),
-        }),
-      catch: (source) => source,
-    });
-    if (!response.ok) return yield* Effect.fail(response.status);
-    const payload = yield* Effect.tryPromise({
-      try: () => response.json(),
-      catch: (source) => source,
-    });
-    const decoded = yield* Schema.decodeUnknownEffect(ProviderModelsSchema)(payload);
-    const models = (decoded.data ?? []).flatMap((model) => {
-      const id = model.id?.trim();
-      return id ? [{ id }] : [];
-    });
-    return { provider: provider.id, models };
-  });
 
 export const registerStudioProviderRoutes = defineRoutes((app, context) => {
   return mergeRoutes(

--- a/controller/src/services/provider-model-catalog.ts
+++ b/controller/src/services/provider-model-catalog.ts
@@ -1,0 +1,33 @@
+import { Effect, Schema } from "effect";
+import type { ProviderConfig } from "../config/persisted-config";
+
+const ProviderModelsSchema = Schema.Struct({
+  data: Schema.optional(Schema.Array(Schema.Struct({ id: Schema.optional(Schema.String) }))),
+});
+
+export const providerModels = (
+  provider: ProviderConfig,
+  timeoutMs = 10_000,
+): Effect.Effect<{ provider: string; models: Array<{ id: string }> }, unknown> =>
+  Effect.gen(function* () {
+    const url = `${provider.base_url.replace(/\/+$/, "")}/v1/models`;
+    const response = yield* Effect.tryPromise({
+      try: () =>
+        fetch(url, {
+          headers: { Authorization: `Bearer ${provider.api_key}` },
+          signal: AbortSignal.timeout(timeoutMs),
+        }),
+      catch: (source) => source,
+    });
+    if (!response.ok) return yield* Effect.fail(response.status);
+    const payload = yield* Effect.tryPromise({
+      try: () => response.json(),
+      catch: (source) => source,
+    });
+    const decoded = yield* Schema.decodeUnknownEffect(ProviderModelsSchema)(payload);
+    const models = (decoded.data ?? []).flatMap((model) => {
+      const id = model.id?.trim();
+      return id ? [{ id }] : [];
+    });
+    return { provider: provider.id, models };
+  });

--- a/controller/tests/http-app.test.ts
+++ b/controller/tests/http-app.test.ts
@@ -119,6 +119,70 @@ describe("controller HTTP application", () => {
     expect([...documentedOperations].sort()).toEqual([...registeredOperations].sort());
   });
 
+  test("includes enabled external provider models in the OpenAI model catalog", async () => {
+    const providerServer = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: (request) => {
+        if (new URL(request.url).pathname === "/v1/models") {
+          return Response.json({ data: [{ id: "gpt-5.6-sol" }, { id: "" }, {}] });
+        }
+        return new Response("Not Found", { status: 404 });
+      },
+    });
+    context.config.providers = [
+      {
+        id: "mai",
+        name: "MRTNZ AI (MAI)",
+        base_url: providerServer.url.origin,
+        api_key: "provider-key",
+        enabled: true,
+      },
+      {
+        id: "disabled",
+        name: "Disabled Provider",
+        base_url: "https://disabled.example",
+        api_key: "disabled-key",
+        enabled: false,
+      },
+      {
+        id: "unavailable",
+        name: "Unavailable Provider",
+        base_url: `${providerServer.url.origin}/unavailable`,
+        api_key: "unavailable-key",
+        enabled: true,
+      },
+    ];
+
+    try {
+      const response = await app.request("/v1/models", {
+        headers: { "x-api-key": apiKey },
+      });
+      expect(response.status).toBe(200);
+      const payload = (await response.json()) as {
+        data: Array<{
+          id: string;
+          owned_by: string;
+          active: boolean;
+          metadata: Record<string, unknown>;
+        }>;
+      };
+      expect(payload.data).toContainEqual(
+        expect.objectContaining({
+          id: "mai/gpt-5.6-sol",
+          owned_by: "mai",
+          active: true,
+          metadata: expect.objectContaining({ external: true, provider: "mai" }),
+        }),
+      );
+      expect(payload.data.some((model) => model.id.startsWith("disabled/"))).toBe(false);
+      expect(payload.data.some((model) => model.id.startsWith("unavailable/"))).toBe(false);
+    } finally {
+      await providerServer.stop(true);
+      context.config.providers = [];
+    }
+  });
+
   test("falls back to persisted logs when a Docker container no longer exists", async () => {
     const sessionId = "stale-docker-session";
     await runtime.runPromise(


### PR DESCRIPTION
## Summary
- include enabled OpenAI-compatible provider catalogs in `GET /v1/models`
- preserve provider-qualified IDs such as `mai/gpt-5.6-sol` for existing chat routing
- share provider-catalog parsing between Studio settings and the OpenAI model catalog
- fail open when an enabled provider catalog is unavailable

## Test coverage
- enabled provider models appear with provider metadata
- disabled and unavailable providers are omitted without breaking the catalog
- 91 controller tests pass (0 failures)
- TypeScript, ESLint, Knip, duplication, dependency, and controller standards checks pass

## Deployment
- intended for the PHX Local Studio controller; no desktop bundle changes are required
