### PR TITLE
fix(desktop): preserve agents across frontend restarts

### DIFF
--- a/frontend/desktop/logic/agent-runtime-server.ts
+++ b/frontend/desktop/logic/agent-runtime-server.ts
@@ -9,6 +9,7 @@ import { resolveStablePort } from "../helpers/ports";
 import { resolveAugmentedPath } from "../helpers/resolve-path";
 
 export type AgentRuntimeHandle = {
+  frontendUrl: string;
   process?: ChildProcess;
   url: string;
 };
@@ -95,7 +96,7 @@ export async function startAgentRuntime(
   const preferredUrl = options.preferredPort ? `http://127.0.0.1:${options.preferredPort}` : null;
   if (preferredUrl && (await isAgentRuntimeHealthy(preferredUrl))) {
     log.info(`Using agent runtime at ${preferredUrl}`);
-    return { url: preferredUrl };
+    return { frontendUrl: options.frontendUrl, url: preferredUrl };
   }
 
   const entry = agentRuntimeEntry();
@@ -136,11 +137,26 @@ export async function startAgentRuntime(
   currentAgentRuntime = child;
   try {
     await waitForAgentRuntime(child, url, DESKTOP_CONFIG.startupTimeoutMs);
-    return { process: child, url };
+    return { frontendUrl: options.frontendUrl, process: child, url };
   } catch (error) {
     await stopChild(child);
     throw error;
   }
+}
+
+export async function startOrReuseAgentRuntime(
+  options: StartAgentRuntimeOptions,
+  existing?: AgentRuntimeHandle,
+): Promise<AgentRuntimeHandle> {
+  if (
+    existing?.frontendUrl === options.frontendUrl &&
+    (await isAgentRuntimeHealthy(existing.url))
+  ) {
+    log.info(`Reusing agent runtime at ${existing.url}`);
+    return existing;
+  }
+  if (existing) await stopAgentRuntime(existing);
+  return startAgentRuntime(options);
 }
 
 export async function stopAgentRuntime(handle?: AgentRuntimeHandle): Promise<void> {

--- a/frontend/desktop/logic/app-server.ts
+++ b/frontend/desktop/logic/app-server.ts
@@ -9,7 +9,7 @@ import { registerOAuthVault } from "./oauth-vault";
 import { resolveStablePort } from "../helpers/ports";
 import { resolveAugmentedPath } from "../helpers/resolve-path";
 import {
-  startAgentRuntime,
+  startOrReuseAgentRuntime,
   stopAgentRuntime,
   type AgentRuntimeHandle,
 } from "./agent-runtime-server";
@@ -25,6 +25,7 @@ process.once("exit", () => {
 });
 
 interface ServerHandle {
+  agentRuntimeExitListener?: () => void;
   agentRuntime: AgentRuntimeHandle;
   runtime: DesktopServerRuntime;
   process?: ChildProcess;
@@ -37,8 +38,13 @@ type ServerExitDetails = {
 };
 
 type StartFrontendServerOptions = {
+  agentRuntime?: AgentRuntimeHandle;
   port?: number;
   onExit?: (details: ServerExitDetails) => void;
+};
+
+type StopFrontendServerOptions = {
+  stopAgentRuntime?: boolean;
 };
 
 function embeddedServerPidPath(): string {
@@ -163,7 +169,10 @@ export async function startFrontendServer(
       port: Number(new URL(DESKTOP_CONFIG.devServerUrl).port || "3000"),
       url: DESKTOP_CONFIG.devServerUrl,
     };
-    const agentRuntime = await startAgentRuntime({ frontendUrl: runtime.url, preferredPort: 8081 });
+    const agentRuntime = await startOrReuseAgentRuntime(
+      { frontendUrl: runtime.url, preferredPort: 8081 },
+      options.agentRuntime,
+    );
     return { agentRuntime, runtime };
   }
 
@@ -195,7 +204,7 @@ export async function startFrontendServer(
   const port = await resolveStablePort(options.port ?? readPersistedPort());
   persistPort(port);
   const url = `http://127.0.0.1:${port}`;
-  const agentRuntime = await startAgentRuntime({ frontendUrl: url });
+  const agentRuntime = await startOrReuseAgentRuntime({ frontendUrl: url }, options.agentRuntime);
 
   log.info(`Starting embedded frontend server from ${serverScript} on ${url}`);
 
@@ -253,25 +262,31 @@ export async function startFrontendServer(
     options.onExit?.({ code, signal, pid: child.pid });
   });
 
-  agentRuntime.process?.once("exit", () => {
+  const agentRuntimeExitListener = () => {
     if (currentEmbeddedServer === child && !child.killed) child.kill("SIGTERM");
-  });
+  };
+  agentRuntime.process?.once("exit", agentRuntimeExitListener);
 
   currentEmbeddedServer = child;
 
   try {
     await waitForServer(url, DESKTOP_CONFIG.startupTimeoutMs);
   } catch (error) {
-    await stopFrontendServer({
-      agentRuntime,
-      process: child,
-      runtime: { mode: "embedded-standalone", port, url },
-    });
+    await stopFrontendServer(
+      {
+        agentRuntime,
+        agentRuntimeExitListener,
+        process: child,
+        runtime: { mode: "embedded-standalone", port, url },
+      },
+      { stopAgentRuntime: agentRuntime !== options.agentRuntime },
+    );
     throw error;
   }
 
   return {
     agentRuntime,
+    agentRuntimeExitListener,
     runtime: {
       mode: "embedded-standalone",
       port,
@@ -281,8 +296,14 @@ export async function startFrontendServer(
   };
 }
 
-export async function stopFrontendServer(handle?: ServerHandle): Promise<void> {
+export async function stopFrontendServer(
+  handle?: ServerHandle,
+  options: StopFrontendServerOptions = {},
+): Promise<void> {
   if (!handle) return;
+  if (handle.agentRuntimeExitListener) {
+    handle.agentRuntime.process?.off("exit", handle.agentRuntimeExitListener);
+  }
   if (handle.process) {
     const child = handle.process;
     const pid = child.pid;
@@ -309,7 +330,7 @@ export async function stopFrontendServer(handle?: ServerHandle): Promise<void> {
       });
     });
   }
-  await stopAgentRuntime(handle.agentRuntime);
+  if (options.stopAgentRuntime !== false) await stopAgentRuntime(handle.agentRuntime);
 }
 
 export type { ServerHandle };

--- a/frontend/desktop/logic/frontend-restart.test.ts
+++ b/frontend/desktop/logic/frontend-restart.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { resolveFrontendRestartUrl } from "./frontend-restart";
+
+describe("desktop frontend restart", () => {
+  test("preserves the active agent route", () => {
+    expect(
+      resolveFrontendRestartUrl(
+        "http://127.0.0.1:49782",
+        "http://127.0.0.1:49782/agent?session=active#terminal",
+      ),
+    ).toBe("http://127.0.0.1:49782/agent?session=active#terminal");
+  });
+
+  test("preserves the route when the local port changes", () => {
+    expect(
+      resolveFrontendRestartUrl(
+        "http://127.0.0.1:50000",
+        "http://127.0.0.1:49782/agent?session=active",
+      ),
+    ).toBe("http://127.0.0.1:50000/agent?session=active");
+  });
+
+  test("does not carry an external route into the desktop origin", () => {
+    expect(
+      resolveFrontendRestartUrl(
+        "http://127.0.0.1:49782",
+        "https://example.com/agent?session=active",
+      ),
+    ).toBe("http://127.0.0.1:49782");
+  });
+
+  test("uses the desktop origin when the previous URL is invalid", () => {
+    expect(resolveFrontendRestartUrl("http://127.0.0.1:49782", "invalid")).toBe(
+      "http://127.0.0.1:49782",
+    );
+  });
+});

--- a/frontend/desktop/logic/frontend-restart.ts
+++ b/frontend/desktop/logic/frontend-restart.ts
@@ -1,0 +1,16 @@
+export function resolveFrontendRestartUrl(nextUrl: string, previousUrl?: string): string {
+  if (!previousUrl) return nextUrl;
+
+  try {
+    const next = new URL(nextUrl);
+    const previous = new URL(previousUrl);
+    if (previous.protocol !== next.protocol || previous.hostname !== next.hostname) return nextUrl;
+
+    next.pathname = previous.pathname;
+    next.search = previous.search;
+    next.hash = previous.hash;
+    return next.toString();
+  } catch {
+    return nextUrl;
+  }
+}

--- a/frontend/desktop/main.ts
+++ b/frontend/desktop/main.ts
@@ -18,6 +18,7 @@ import { isHttpUrl } from "./helpers/url";
 import { createMainWindow } from "./logic/window-manager";
 import { registerNavigationPolicy } from "./logic/security";
 import { startFrontendServer, stopFrontendServer, type ServerHandle } from "./logic/app-server";
+import { resolveFrontendRestartUrl } from "./logic/frontend-restart";
 import { getUpdateState, initializeAutoUpdates, startUpdate } from "./logic/update-manager";
 import { addProject, listProjectsWithMeta, removeProject } from "./logic/projects-store";
 import { deployController } from "./logic/controller-deploy";
@@ -106,6 +107,11 @@ function stopFrontendHealthMonitor(): void {
   frontendHealthFailures = 0;
 }
 
+function currentRendererUrl(): string | undefined {
+  if (!mainWindow || mainWindow.isDestroyed()) return undefined;
+  return mainWindow.webContents.getURL() || undefined;
+}
+
 function startFrontendHealthMonitor(): void {
   stopFrontendHealthMonitor();
   frontendHealthTimer = setInterval(() => {
@@ -137,6 +143,7 @@ async function checkFrontendHealth(): Promise<void> {
 
   if (frontendHealthFailures < HEALTH_FAILURE_THRESHOLD || !frontendServer) return;
   const stalledServer = frontendServer;
+  const rendererUrl = currentRendererUrl();
   frontendHealthFailures = 0;
   log.error(`Embedded frontend health check failed; restarting ${stalledServer.runtime.url}`);
   const pid = stalledServer.process?.pid;
@@ -144,9 +151,9 @@ async function checkFrontendHealth(): Promise<void> {
     expectedFrontendStopPids.add(pid);
     setTimeout(() => expectedFrontendStopPids.delete(pid), 30_000);
   }
-  await stopFrontendServer(stalledServer);
+  await stopFrontendServer(stalledServer, { stopAgentRuntime: false });
   if (frontendServer === stalledServer) frontendServer = undefined;
-  await restartFrontendServer(stalledServer.runtime.port);
+  await restartFrontendServer(stalledServer.runtime.port, stalledServer.agentRuntime, rendererUrl);
 }
 
 function handleFrontendServerExit(details: {
@@ -158,15 +165,24 @@ function handleFrontendServerExit(details: {
   if (details.pid && expectedFrontendStopPids.delete(details.pid)) return;
   if (frontendServer?.process && frontendServer.process.pid !== details.pid) return;
 
-  const previousRuntime = frontendServer?.runtime;
+  const previousServer = frontendServer;
+  const rendererUrl = currentRendererUrl();
   frontendServer = undefined;
   log.error(
     `Embedded frontend stopped unexpectedly code=${details.code ?? "null"} signal=${details.signal ?? "null"}`,
   );
-  void restartFrontendServer(previousRuntime?.port);
+  void restartFrontendServer(
+    previousServer?.runtime.port,
+    previousServer?.agentRuntime,
+    rendererUrl,
+  );
 }
 
-async function restartFrontendServer(port?: number): Promise<void> {
+async function restartFrontendServer(
+  port?: number,
+  agentRuntime?: ServerHandle["agentRuntime"],
+  rendererUrl?: string,
+): Promise<void> {
   if (restartingFrontend || appState === "stopping") return;
   restartingFrontend = true;
   appState = "starting";
@@ -183,7 +199,11 @@ async function restartFrontendServer(port?: number): Promise<void> {
       await delay(backoffMs);
       if (isAppStopping()) return;
     }
-    const started = await startFrontendServer({ port, onExit: handleFrontendServerExit });
+    const started = await startFrontendServer({
+      agentRuntime,
+      port,
+      onExit: handleFrontendServerExit,
+    });
     // Shutdown may have begun during the fork. If so, shutdown() already cleared
     // the health monitor and no-op'd the (mid-restart undefined) server stop —
     // so tear this just-started server down instead of re-arming the monitor and
@@ -196,7 +216,7 @@ async function restartFrontendServer(port?: number): Promise<void> {
     startFrontendHealthMonitor();
     const nextUrl = frontendServer.runtime.url;
     if (mainWindow && !mainWindow.isDestroyed()) {
-      await mainWindow.loadURL(nextUrl);
+      await mainWindow.loadURL(resolveFrontendRestartUrl(nextUrl, rendererUrl));
     } else {
       mainWindow = createMainWindow(nextUrl);
       mainWindow.on("closed", () => {


### PR DESCRIPTION
## What

- preserve the active renderer path, query, and hash when the embedded frontend restarts
- keep a healthy agent runtime alive across frontend-only recovery
- avoid stale runtime origins and repeated exit-listener accumulation
- add regression coverage for route restoration and local port changes

## Why

The desktop frontend watchdog restarted an unresponsive embedded Next.js process, stopped the agent runtime with it, and reloaded the window at the bare origin. Users on `/agent` were sent to the dashboard and every agent connection was severed.

## Impact

Frontend recovery now returns users to the same Agent view and reconnects to the existing runtime. Normal app shutdown still stops both processes, and an unhealthy or origin-mismatched runtime is replaced.

## Validation

- `npm run check`
- `npm run test:integration`
