### PR TITLE
chore(perf): establish campaign control plane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ frontend/dist-desktop-dev/
 frontend/dist-installers/
 .vercel
 .env*
+/evidence/*/.raw/

--- a/evidence/2026-08-09-task-00-control-plane/manifest.json
+++ b/evidence/2026-08-09-task-00-control-plane/manifest.json
@@ -7,8 +7,9 @@
     "workpack": "work/local-studio-performance-program/tasks/task-00.md"
   },
   "createdAt": "2026-08-09T20:52:46-04:00",
+  "updatedAt": "2026-08-09T21:43:08-04:00",
   "timezone": "America/New_York (EDT, UTC-04:00)",
-  "state": "control_plane_in_progress_phase_a_awaiting_codex",
+  "state": "implementation_complete_awaiting_codex_review",
   "classification": "CONTROL PLANE ONLY — NO PRODUCT ACCEPTANCE",
   "campaign": {
     "program": "local-studio-performance-program",
@@ -28,8 +29,11 @@
     "childExactBaseSha": "6bdf748a4da0d5634aa944417dcf362023f7ddf8",
     "incorporatedWorkpackHead": "4844b159a80aeb1720a44f2150f87ea6e8d9aea2",
     "intendedPrTarget": "codex/local-studio-performance-integration-20260809",
-    "childPrUrl": null,
-    "childPrNote": "Codex creates the child PR after authorizing the Phase A push; the URL is recorded in Phase B"
+    "childPrUrl": "https://github.com/sybil-solutions/local-studio/pull/385",
+    "childPrState": "draft; head codex/ls-perf-w00-task-00-control-plane at c30a9216d1cd35824889a3d6009d237e939313ea into codex/local-studio-performance-integration-20260809; created by Codex",
+    "phaseACommit": "c30a9216d1cd35824889a3d6009d237e939313ea",
+    "phaseACommitParent": "6bdf748a4da0d5634aa944417dcf362023f7ddf8",
+    "push": "explicit refspec git push origin codex/ls-perf-w00-task-00-control-plane:codex/ls-perf-w00-task-00-control-plane; all hooks enforced; remote ref equals local HEAD; working tree clean after push; lockfiles unchanged"
   },
   "repositorySnapshots": [
     {
@@ -60,10 +64,10 @@
         },
         {
           "ref": "refs/heads/codex/ls-perf-w00-task-00-control-plane",
-          "sha": null,
-          "observedAt": "2026-08-10T00:45:06Z",
+          "sha": "c30a9216d1cd35824889a3d6009d237e939313ea",
+          "observedAt": "2026-08-10T01:37:52Z",
           "method": "git ls-remote",
-          "note": "absent on origin at manifest creation; the push waits for Codex authorization"
+          "note": "Phase A commit pushed with all hooks enforced; equals local HEAD"
         }
       ],
       "pullRequests": [
@@ -175,6 +179,13 @@
       }
     }
   ],
+  "validation": {
+    "phaseACommit": "c30a9216d1cd35824889a3d6009d237e939313ea; parent 6bdf748a4da0d5634aa944417dcf362023f7ddf8; git diff --check clean; commit-msg and pre-commit hooks passed; commit trailer identifies Claude Fable 5",
+    "npmRunCheck": "exit 0; run once unpiped after frozen-lockfile installs with PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 and ELECTRON_SKIP_BINARY_DOWNLOAD=1; all seven aggregate constituents ran; frontend unit tests 127 passed",
+    "lockfiles": "shared, controller, services/agent-runtime (bun frozen lockfile) and frontend (npm ci) SHA-256 identical before and after installs",
+    "push": "pre-push hooks enforced: commit-range check, frontend check:static, check:cleanup, assert-standalone; no browser, Electron, Playwright binary, or product service launched",
+    "scope": "control-plane evidence only; not product acceptance"
+  },
   "requirementMapping": {
     "R01": {
       "requirement": "Canonical dated plan/status referenced by AGENTS",

--- a/evidence/2026-08-09-task-00-control-plane/manifest.json
+++ b/evidence/2026-08-09-task-00-control-plane/manifest.json
@@ -1,0 +1,304 @@
+{
+  "schemaVersion": "1.0.0",
+  "runId": "2026-08-09-task-00-control-plane",
+  "task": {
+    "id": "00",
+    "title": "Establish the campaign control plane",
+    "workpack": "work/local-studio-performance-program/tasks/task-00.md"
+  },
+  "createdAt": "2026-08-09T20:52:46-04:00",
+  "timezone": "America/New_York (EDT, UTC-04:00)",
+  "state": "control_plane_in_progress_phase_a_awaiting_codex",
+  "classification": "CONTROL PLANE ONLY — NO PRODUCT ACCEPTANCE",
+  "campaign": {
+    "program": "local-studio-performance-program",
+    "canonicalLedger": "work/local-studio-performance-program/status.md",
+    "integrationBranch": "codex/local-studio-performance-integration-20260809",
+    "integrationBranchOwner": "Codex",
+    "integrationBaseFromOriginDev": "88b56e36bd5c84930dbe364296ba4ae669f72689",
+    "umbrellaDraftPr": {
+      "url": "https://github.com/sybil-solutions/local-studio/pull/382",
+      "base": "dev",
+      "head": "codex/local-studio-performance-integration-20260809",
+      "state": "open draft; final merge into dev stays user/reviewer controlled",
+      "observedAt": "2026-08-10T00:45:10Z"
+    },
+    "childBranch": "codex/ls-perf-w00-task-00-control-plane",
+    "childBranchOwner": "Fable implementation session ls-perf-w00-task00-control-plane (sole owner)",
+    "childExactBaseSha": "6bdf748a4da0d5634aa944417dcf362023f7ddf8",
+    "incorporatedWorkpackHead": "4844b159a80aeb1720a44f2150f87ea6e8d9aea2",
+    "intendedPrTarget": "codex/local-studio-performance-integration-20260809",
+    "childPrUrl": null,
+    "childPrNote": "Codex creates the child PR after authorizing the Phase A push; the URL is recorded in Phase B"
+  },
+  "repositorySnapshots": [
+    {
+      "repository": "local-studio",
+      "remote": "https://github.com/sybil-solutions/local-studio",
+      "verification": "verified read-only by this session",
+      "refs": [
+        {
+          "ref": "refs/heads/dev",
+          "sha": "88b56e36bd5c84930dbe364296ba4ae669f72689",
+          "observedAt": "2026-08-10T00:45:06Z",
+          "method": "git ls-remote",
+          "note": "unchanged since planning; the integration branch still derives from current origin/dev"
+        },
+        {
+          "ref": "refs/heads/main",
+          "sha": "52c2b20f2994be07186b42da54e2836234785e8a",
+          "observedAt": "2026-08-10T00:45:06Z",
+          "method": "git ls-remote",
+          "note": "unchanged since planning; not the campaign base"
+        },
+        {
+          "ref": "refs/heads/codex/local-studio-performance-integration-20260809",
+          "sha": "6bdf748a4da0d5634aa944417dcf362023f7ddf8",
+          "observedAt": "2026-08-10T00:45:06Z",
+          "method": "git ls-remote",
+          "note": "equals the local integration worktree HEAD and this run's child base"
+        },
+        {
+          "ref": "refs/heads/codex/ls-perf-w00-task-00-control-plane",
+          "sha": null,
+          "observedAt": "2026-08-10T00:45:06Z",
+          "method": "git ls-remote",
+          "note": "absent on origin at manifest creation; the push waits for Codex authorization"
+        }
+      ],
+      "pullRequests": [
+        {
+          "number": 383,
+          "url": "https://github.com/sybil-solutions/local-studio/pull/383",
+          "role": "workpack revision child PR",
+          "state": "MERGED",
+          "mergedAt": "2026-08-10T00:35:12Z",
+          "mergeCommit": "6bdf748a4da0d5634aa944417dcf362023f7ddf8",
+          "observedAt": "2026-08-10T00:45:10Z",
+          "method": "gh pr view (read-only)"
+        },
+        {
+          "number": 382,
+          "url": "https://github.com/sybil-solutions/local-studio/pull/382",
+          "role": "umbrella draft integration PR into dev",
+          "state": "OPEN draft",
+          "combinedCi": "all status-check rollup entries for head 6bdf748a (gates, controller, agent-runtime, frontend, desktop-package, Secret Scanning (TruffleHog), CodeQL Analysis, Dependency Review, CodeQL) completed SUCCESS by 2026-08-10T00:41:32Z",
+          "observedAt": "2026-08-10T00:45:10Z",
+          "method": "gh pr view (read-only)"
+        }
+      ],
+      "campaignWorktrees": [
+        {
+          "path": "~/.codex/worktrees/0b96/vllm-studio",
+          "owner": "Codex",
+          "branch": "codex/local-studio-performance-integration-20260809",
+          "head": "6bdf748a4da0d5634aa944417dcf362023f7ddf8",
+          "clean": true,
+          "inSyncWithOrigin": true,
+          "observedAt": "2026-08-10T00:52:46Z",
+          "method": "git status --porcelain (read-only)"
+        },
+        {
+          "path": "~/.codex/worktrees/ls-perf-w00-task-00-control-plane",
+          "owner": "Fable session ls-perf-w00-task00-control-plane",
+          "branch": "codex/ls-perf-w00-task-00-control-plane",
+          "headAtStart": "6bdf748a4da0d5634aa944417dcf362023f7ddf8",
+          "cleanAtStart": true,
+          "branchCheckedOutNowhereElse": true,
+          "observedAt": "2026-08-10T00:41:52Z",
+          "method": "git status --porcelain; git worktree list --porcelain"
+        }
+      ],
+      "workpackAncestry": {
+        "workpackHead": "4844b159a80aeb1720a44f2150f87ea6e8d9aea2",
+        "isAncestorOfChildBase": true,
+        "observedAt": "2026-08-10T00:41:52Z",
+        "method": "git merge-base --is-ancestor"
+      },
+      "nonCampaignWorktrees": "inventoried in the status ledger execution snapshot; existence observed only, untouched, outside campaign clean assertions"
+    },
+    {
+      "repository": "litter",
+      "verification": "Codex-verified read-only facts supplied to this session during the Phase A review",
+      "suppliedAt": "2026-08-09T21:02:54-04:00",
+      "refs": [
+        {
+          "ref": "origin/main",
+          "sha": "5f651a475a16c93c273501fd370627f826c5e06f",
+          "note": "proposed clean integration base; unchanged from planning"
+        },
+        {
+          "ref": "primary checkout codex/post-github-cleanup-20260804",
+          "sha": "9ebb405bb329866e3e3f6e9d16b45a5bb1a91706",
+          "note": "user-owned; dirty only at modified submodules shared/third_party/codex and shared/third_party/ghostty plus untracked prompt.md; excluded from campaign cleanup; do not touch"
+        },
+        {
+          "ref": "Litter's Alleycat pin",
+          "sha": "417f2a9fe38cbed63754f0af7df61f32ec3034e6",
+          "source": "planning snapshot, observed 2026-08-09T18:39:37-04:00",
+          "note": "release lineage; divergent from Alleycat main"
+        }
+      ],
+      "pullRequests": [
+        {
+          "number": 239,
+          "role": "review prerequisite",
+          "state": "OPEN; clean/mergeable at a4cbf2df005dd45633d00377678d6adc9cc3146a; required shared-prep/android/ios/release checks successful or intentionally skipped; disposition pending; commit-by-commit review not yet performed"
+        },
+        {
+          "number": 240,
+          "role": "planning reference only",
+          "state": "OPEN; clean/mergeable at b277efd34d9962d3482372067618a3d6bc992e10; consolidate requirements into the ledger, do not merge"
+        }
+      ]
+    },
+    {
+      "repository": "alleycat",
+      "verification": "Codex-verified read-only facts supplied to this session during the Phase A review",
+      "suppliedAt": "2026-08-09T21:02:54-04:00",
+      "refs": [
+        {
+          "ref": "origin/main",
+          "sha": "3f0f84422e977f32cbc98de7a1d6c4e26fb240d1",
+          "note": "one candidate authority"
+        },
+        {
+          "ref": "staged checkout codex/local-studio-prod-runtime",
+          "sha": "d584a006c75fe744def6cb3f41bcef4991b86b5f",
+          "note": "user-owned; exactly 14 staged files (5829 insertions, 18 deletions); audit only, do not touch"
+        }
+      ],
+      "protocolAuthority": {
+        "state": "not_selected",
+        "decisionRequired": "select exactly one truthful protocol path — the scoped pair-token Pi bridge or a fully enforced signed grant protocol — on one lineage: origin/main 3f0f8442, the pinned release lineage 417f2a9f, or a reviewed recut of the staged d584a006 grant work",
+        "effect": "the Alleycat integration worktree/PR and authority-dependent Task 05 work remain blocked until the decision is recorded"
+      }
+    }
+  ],
+  "requirementMapping": {
+    "R01": {
+      "requirement": "Canonical dated plan/status referenced by AGENTS",
+      "tasks": ["00"],
+      "contributionThisRun": "canonical ledger execution snapshot appended and this evidence manifest created on the Task 00 child branch",
+      "state": "in_progress",
+      "acceptanceSurface": "source/review PR",
+      "productAcceptance": false
+    },
+    "R02": {
+      "requirement": "One integration branch/PR with child worktrees and clean history",
+      "tasks": ["00", "15"],
+      "contributionThisRun": "integration branch and umbrella draft PR topology recorded with verified refs; one dedicated child worktree/branch with a single Fable owner registered",
+      "state": "in_progress",
+      "acceptanceSurface": "GitHub/local refs/CI",
+      "productAcceptance": false
+    },
+    "R16": {
+      "requirement": "Screenshots, videos, reports, hashes, and no leftover trash",
+      "tasks": ["15"],
+      "contributionThisRun": "evidence schema, run directory, ignored .raw staging rule, and redaction checklist established; no artifacts captured",
+      "state": "planned_schema_established",
+      "acceptanceSurface": "evidence manifest + clean worktrees",
+      "productAcceptance": false
+    },
+    "R17": {
+      "requirement": "One browser/profile total, no fan-out",
+      "tasks": ["all UI tasks"],
+      "contributionThisRun": "single campaign browser lease recorded with Codex as sole owner; reserved, not started; this session is browserless",
+      "state": "enforced_reserved_not_started",
+      "acceptanceSurface": "browser lease log",
+      "productAcceptance": false
+    }
+  },
+  "browserLease": {
+    "owner": "Codex",
+    "ownerRole": "sole campaign browser/evidence owner",
+    "logicalProfileId": "codex-campaign-browser-profile-01",
+    "state": "reserved_not_started",
+    "browserProcessStarted": false,
+    "leaseStartedAt": null,
+    "leaseEndedAt": null,
+    "journeys": [],
+    "rule": "exactly one persistent browser profile/session for the entire campaign, used serially, one journey or tab flow at a time; every Fable session, worker, and benchmark lane is browserless; a replacement browser may start only after the previous process is closed and the replacement is recorded"
+  },
+  "redactionChecklist": {
+    "appliesTo": "every artifact added to this manifest",
+    "reviewedBy": null,
+    "items": [
+      {
+        "id": "no-credentials",
+        "rule": "no credentials, API keys, or tokens",
+        "state": "no_artifacts_captured"
+      },
+      {
+        "id": "no-pairing-material",
+        "rule": "no pairing JSON, pair tokens, or node secrets",
+        "state": "no_artifacts_captured"
+      },
+      {
+        "id": "no-auth-prompts",
+        "rule": "no authentication prompts or sign-in surfaces",
+        "state": "no_artifacts_captured"
+      },
+      {
+        "id": "no-private-transcripts",
+        "rule": "no private transcripts or user conversation content",
+        "state": "no_artifacts_captured"
+      },
+      {
+        "id": "no-unrelated-desktop",
+        "rule": "no desktop notifications or unrelated windows",
+        "state": "no_artifacts_captured"
+      },
+      {
+        "id": "no-private-paths",
+        "rule": "no raw private absolute paths beyond declared campaign worktrees",
+        "state": "no_artifacts_captured"
+      },
+      {
+        "id": "raw-staging-discipline",
+        "rule": "raw captures staged only under the ignored evidence/<run-id>/.raw/ directory, uploaded and hashed, then removed before handoff",
+        "state": "no_artifacts_captured"
+      }
+    ]
+  },
+  "artifacts": [],
+  "artifactEntryContract": {
+    "description": "Every future artifacts[] entry must provide all required fields before it may be listed; an unlisted file in this run directory is garbage and must not remain at handoff",
+    "requiredFields": [
+      "requirementOrTaskId",
+      "repository",
+      "branch",
+      "sourceCommitFullSha",
+      "dirtyStateAssertion",
+      "timestamp",
+      "timezone",
+      "acceptanceSurface",
+      "host",
+      "device",
+      "osVersion",
+      "appVersion",
+      "controllerTarget",
+      "executionTarget",
+      "runtime",
+      "model",
+      "commandOrJourney",
+      "expectedResult",
+      "artifactPathOrImmutableUrl",
+      "mimeType",
+      "byteSize",
+      "sha256",
+      "result",
+      "reviewer",
+      "redactionStatus",
+      "knownGap"
+    ]
+  },
+  "explicitNonClaims": [
+    "no browser, Chrome integration, Playwright, Electron, simulator, device, or mobile surface was launched or validated by this run",
+    "no deployment, controller, model, GPU, GLM, or live DGX Spark state was mutated, and no live host was probed",
+    "no product acceptance surface was exercised; source and control-plane checks never promote to product acceptance",
+    "2x/4x DGX Spark availability is UNKNOWN: no fresh read-only discovery result has been supplied and this session performed none; the user's screenshot records the target example, not live proof",
+    "Alleycat protocol authority is not selected; dependent integration work is blocked",
+    "this manifest lists no artifacts and does not self-hash; integrity comes from Git history and Codex review"
+  ]
+}

--- a/work/local-studio-performance-program/status.md
+++ b/work/local-studio-performance-program/status.md
@@ -1,10 +1,10 @@
 # Local Studio performance program status
 
-Updated: 2026-08-09T20:32:14-04:00
+Updated: 2026-08-09T21:02:54-04:00
 
 Program state: `APPROVED`
 
-Feature implementation: not started; Task 00 is the next action
+Feature implementation: not started; Task 00 control plane is `IN PROGRESS` (execution snapshot below)
 
 This is the canonical campaign ledger for Local Studio, Litter, and Alleycat. It records planning, execution ownership, immutable refs, PRs, Fable sessions, acceptance surfaces, evidence, blockers, and rollback state. `scope.md` defines the architecture and twelve-hour cut; `rules.md` defines how work may be executed; `tasks/` is the dependency-ordered implementation blueprint.
 
@@ -69,6 +69,22 @@ Review and revision sessions, all `claude-fable-5` and browserless:
 
 Implementation sessions will be appended here; never replace or reuse an identity for a different objective.
 
+Task 00 implementation session, `claude-fable-5` and browserless:
+
+| Field | Value |
+|---|---|
+| Objective | Task 00 control plane: repository-contained artifacts and canonical ledger update |
+| Name | `ls-perf-w00-task00-control-plane` (assigned worker name) |
+| Short ID | `90ed8b8d` — verified by Codex |
+| Full UUID | `90ed8b8d-57dc-42fc-8d79-0746b98669c5` — verified by Codex |
+| Repository / worktree / branch | Local Studio; `~/.codex/worktrees/ls-perf-w00-task-00-control-plane`; `codex/ls-perf-w00-task-00-control-plane` (sole owner; checked out nowhere else) |
+| Model | `claude-fable-5` (Fable 5); model proof verified by Codex |
+| Permission mode | safe mode, `acceptEdits`, max effort, no Chrome; repository hooks enforced; no bypass flags |
+| Browser | disabled; browserless per campaign rule |
+| Owner | Fable implementer for in-repo Task 00 artifacts; Codex owns integration, PRs, merges, browser, and evidence capture |
+| Start | 2026-08-09T20:41:52-04:00 (first verified read-only inspection in the assigned worktree) |
+| State | `IN PROGRESS` — Phase A edits authored; commit and push await Codex authorization; final commit/push/PR facts land in Phase B |
+
 ## Hard resource rule
 
 Exactly one persistent browser profile/session may exist for the entire campaign. Codex is the only browser/evidence owner. All Fable sessions and implementation agents are browserless. Browser, Electron, simulator/device, screenshot, and video work is queued and serialized; automated browser work uses one worker. A replacement browser may start only after the previous process is closed and the replacement is recorded.
@@ -92,8 +108,8 @@ All live observations are time-sensitive and must be revalidated at execution ti
 
 | ID | Requirement | Task(s) | State | Required acceptance surface |
 |---|---|---|---|---|
-| R01 | Canonical dated plan/status referenced by AGENTS | 00 | `PLANNED` | source/review PR |
-| R02 | One integration branch/PR with child worktrees and clean history | 00, 15 | `PLANNED` | GitHub/local refs/CI |
+| R01 | Canonical dated plan/status referenced by AGENTS | 00 | `IN PROGRESS — CONTROL PLANE ONLY` | source/review PR |
+| R02 | One integration branch/PR with child worktrees and clean history | 00, 15 | `IN PROGRESS — CONTROL PLANE ONLY` | GitHub/local refs/CI |
 | R03 | Reproducible 50-session and long-chat performance baselines | 01 | `PLANNED` | hermetic + Pop lab + device |
 | R04 | Instant Local Studio old-chat open, smooth scroll, bounded memory/DOM | 02, 03 | `PLANNED` | benchmark + installed Electron |
 | R05 | Instant Litter inventory/chat open and smooth native scrolling | 04 | `PLANNED` | installed iOS and Android |
@@ -117,7 +133,7 @@ All live observations are time-sensitive and must be revalidated at execution ti
 
 | Task | Title | Dependency | State | Planned owner |
 |---|---|---|---|---|
-| 00 | Control plane, refs, worktrees, PRs, evidence schema | approval | `NOT STARTED` | Codex |
+| 00 | Control plane, refs, worktrees, PRs, evidence schema | approval | `IN PROGRESS` | Codex + Fable `ls-perf-w00-task00-control-plane` (in-repo artifacts) |
 | 01 | Deterministic corpus and clean baseline | 00 | `NOT STARTED` | Fable implementer + Codex measurement |
 | 02 | Runtime inventory and hydration hot path | 01 | `NOT STARTED` | Fable implementer |
 | 03 | Electron session store, timeline, inspector, scroll | 01, 02 | `NOT STARTED` | Fable implementer |
@@ -139,17 +155,18 @@ All live observations are time-sensitive and must be revalidated at execution ti
 | Repository | Integration branch | Target | PR | State |
 |---|---|---|---|---|
 | Local Studio | `codex/local-studio-performance-integration-20260809` | `dev` | [#382](https://github.com/sybil-solutions/local-studio/pull/382) | draft; planning only |
-| Local Studio workpack revision child | `codex/ls-perf-plan-revision-20260809` | `codex/local-studio-performance-integration-20260809` | [#383](https://github.com/sybil-solutions/local-studio/pull/383) | draft; awaiting Codex integration review |
+| Local Studio workpack revision child | `codex/ls-perf-plan-revision-20260809` | `codex/local-studio-performance-integration-20260809` | [#383](https://github.com/sybil-solutions/local-studio/pull/383) | merged 2026-08-10T00:35:12Z as integration commit `6bdf748a`; verified read-only 2026-08-10T00:45:10Z |
+| Local Studio Task 00 child | `codex/ls-perf-w00-task-00-control-plane` | `codex/local-studio-performance-integration-20260809` | pending — Codex creates it after the authorized push | Phase A edits authored; commit and push await Codex authorization |
 | Litter | create after approval from recorded `origin/main` | `main` | pending | not created |
 | Alleycat | create after authority decision | selected protected branch | pending | blocked by authority |
 
 ## Evidence ledger
 
-No execution evidence exists yet. Planning research is not feature acceptance. Use `evidence/<run-id>/manifest.json` and link each run here.
+The Task 00 control-plane run below is `CONTROL PLANE ONLY — NO PRODUCT ACCEPTANCE`; no product execution evidence exists yet. Planning research is not feature acceptance. Use `evidence/<run-id>/manifest.json` and link each run here.
 
 | Run ID | Commit | Surface | Requirements | Result | Manifest |
 |---|---|---|---|---|---|
-| — | — | — | — | `NOT RUN` | — |
+| `2026-08-09-task-00-control-plane` | child branch `codex/ls-perf-w00-task-00-control-plane` from base `6bdf748a4da0d5634aa944417dcf362023f7ddf8` | control plane only — no product surface | R01, R02, R16, R17 | `IN PROGRESS — CONTROL PLANE ONLY — NO PRODUCT ACCEPTANCE` | [manifest.json](../../evidence/2026-08-09-task-00-control-plane/manifest.json) |
 
 ## Known blockers and stop conditions
 
@@ -165,3 +182,48 @@ No execution evidence exists yet. Planning research is not feature acceptance. U
 ## Next transition
 
 Approval is recorded above. Task 00 starts the twelve-hour clock: it creates clean cross-repository worktrees, records fresh refs, confirms 2x/4x Spark availability through read-only discovery, and opens the integration review topology. Wave 1 (Tasks 01, 05, 12) follows; the Task 12 serving-contract merge gates the creation of Task 13 and Task 14 branches. Separate gates above remain in force.
+
+## Task 00 execution snapshot — 2026-08-09 (Phase A)
+
+Recorded: 2026-08-09T21:02:54-04:00 (America/New_York, EDT). Task 00 in-repo control-plane work is `IN PROGRESS` on the dedicated child branch below. This snapshot records control-plane facts only; R03–R20 and every product acceptance surface remain planned, pending, blocked, unknown, or not run as recorded above.
+
+Twelve-hour clock: this workstream's first verified read-only inspection ran at 2026-08-09T20:41:52-04:00; the canonical campaign-wide kickoff time is Codex's to confirm.
+
+### Verified campaign refs (read-only)
+
+| Fact | Value | Observed |
+|---|---|---|
+| Integration branch `codex/local-studio-performance-integration-20260809` (remote) | `6bdf748a4da0d5634aa944417dcf362023f7ddf8` | 2026-08-10T00:45:06Z, `git ls-remote` |
+| Integration worktree `~/.codex/worktrees/0b96/vllm-studio` (Codex) | same commit; clean; in sync with origin | 2026-08-10T00:52:46Z, `git status` |
+| `origin/dev` | `88b56e36bd5c84930dbe364296ba4ae669f72689`; unchanged — integration still derives from current `origin/dev` | 2026-08-10T00:45:06Z |
+| `origin/main` | `52c2b20f2994be07186b42da54e2836234785e8a`; unchanged | 2026-08-10T00:45:06Z |
+| Workpack revision child PR [#383](https://github.com/sybil-solutions/local-studio/pull/383) | `MERGED` 2026-08-10T00:35:12Z as merge commit `6bdf748a4da0d5634aa944417dcf362023f7ddf8` | 2026-08-10T00:45:10Z, `gh pr view` |
+| Umbrella draft PR [#382](https://github.com/sybil-solutions/local-studio/pull/382) | open draft into `dev`; combined CI for head `6bdf748a`: all rollup checks (gates, controller, agent-runtime, frontend, desktop-package, secret scanning, CodeQL, dependency review) `SUCCESS` by 2026-08-10T00:41:32Z | 2026-08-10T00:45:10Z |
+| Task 00 child branch `codex/ls-perf-w00-task-00-control-plane` | worktree `~/.codex/worktrees/ls-perf-w00-task-00-control-plane`; started clean at exact base `6bdf748a4da0d5634aa944417dcf362023f7ddf8`; checked out nowhere else; not yet on origin | 2026-08-10T00:41:52Z and 00:45:06Z |
+| Incorporated workpack head | `4844b159a80aeb1720a44f2150f87ea6e8d9aea2` is an ancestor of the child base | 2026-08-10T00:41:52Z |
+
+### Control-plane artifacts added by this task
+
+Run manifest [manifest.json](../../evidence/2026-08-09-task-00-control-plane/manifest.json) (`CONTROL PLANE ONLY — NO PRODUCT ACCEPTANCE`) plus the single `.gitignore` staging rule `/evidence/*/.raw/`; ignore behavior proven in both directions with `git check-ignore`.
+
+### Browser lease
+
+`reserved_not_started`. Codex solely owns the single campaign lease, logical profile `codex-campaign-browser-profile-01`; no campaign browser, profile, or process has started; all workers stay browserless.
+
+### Decisions required and unknowns
+
+- Alleycat protocol authority: `NOT SELECTED`. Required decision: exactly one truthful protocol path — the scoped pair-token Pi bridge or a fully enforced signed grant protocol — on one lineage: `origin/main` `3f0f8442`, the pinned release lineage `417f2a9f`, or a reviewed recut of the staged `d584a006` grant work. Until recorded: no Alleycat integration worktree/PR, and authority-dependent Task 05 work stays blocked.
+- 2x/4x DGX Spark availability: `UNKNOWN`. No fresh read-only discovery result has been supplied and this session performed none; the user-provided screenshot records the target example, not live proof. Live Spark mutation remains gated.
+- Codex-verified read-only cross-repo facts (supplied 2026-08-09T21:02:54-04:00): Litter `origin/main` `5f651a475a16c93c273501fd370627f826c5e06f`; Litter primary checkout `codex/post-github-cleanup-20260804` at `9ebb405bb329866e3e3f6e9d16b45a5bb1a91706`, user-owned, dirty only at modified submodules `shared/third_party/codex` and `shared/third_party/ghostty` plus untracked `prompt.md`; Litter PR #239 `OPEN`, clean/mergeable at `a4cbf2df005dd45633d00377678d6adc9cc3146a`, required shared-prep/android/ios/release checks successful or intentionally skipped, disposition still pending (commit-by-commit review not yet performed); Litter PR #240 `OPEN`, clean/mergeable at `b277efd34d9962d3482372067618a3d6bc992e10`, planning reference only; Alleycat `origin/main` `3f0f84422e977f32cbc98de7a1d6c4e26fb240d1`; Alleycat staged checkout `codex/local-studio-prod-runtime` at `d584a006c75fe744def6cb3f41bcef4991b86b5f`, exactly 14 staged files (5829 insertions, 18 deletions). No cross-repository worktree was created; Litter integration worktree creation remains a Codex-owned step.
+
+### Worktree inventory (observed 2026-08-10T00:41:52Z)
+
+Clean assertions are scoped to the two campaign worktrees actually checked (refs table above); the prior workpack revision worktree and its merged child branch were removed after integration (Codex-supplied). Eleven stale `/private/tmp` registrations with missing gitdirs and every other non-campaign worktree — including the primary checkout and the detached historical reference `repo-comparison-review-35c382` — were observed only, sit outside campaign clean assertions, and were not altered; pruning is not authorized for this session.
+
+### Validation state (Phase A)
+
+- Passed locally: `git diff --check`; manifest JSON parse; ignore-rule proof in both directions (`evidence/<run-id>/.raw/` ignored, the manifest tracked); diff scope limited to the three owned paths; and the dependency-free gates `check:automation`, `check:contracts`, `check:structure`, and `check:release`, each run as a separate unpiped command with exit 0.
+- Root `npm run check` aggregate: `NOT RUN — PENDING`. Dependencies are absent (no `node_modules` anywhere in this fresh worktree), and the aggregate's `check:frontend → check:quality` chain includes a full frontend `npm run build`; a lockfile install and that build each need explicit Codex authorization before this session may run them.
+- Pre-push hook (`.githooks/pre-push`) unconditionally runs frontend `check:static`, `check:cleanup`, and `assert-standalone`, which requires a prior local frontend build. The child-branch push therefore waits for Codex authorization; hooks are never bypassed.
+- Commit hooks `commit-msg` and `pre-commit` (protected-branch guard, 15-file/600-source-line limit) apply to the Phase A commit; their outcomes are reported in the Phase A handoff.
+- Context only, never a substitute for the local aggregate: PR #382 combined CI passed on `6bdf748a`, the exact tree this child branch starts from.

--- a/work/local-studio-performance-program/status.md
+++ b/work/local-studio-performance-program/status.md
@@ -1,10 +1,10 @@
 # Local Studio performance program status
 
-Updated: 2026-08-09T21:02:54-04:00
+Updated: 2026-08-09T21:43:08-04:00
 
 Program state: `APPROVED`
 
-Feature implementation: not started; Task 00 control plane is `IN PROGRESS` (execution snapshot below)
+Feature implementation: not started; Task 00 control plane is `IMPLEMENTATION COMPLETE — AWAITING CODEX REVIEW` (execution snapshot below)
 
 This is the canonical campaign ledger for Local Studio, Litter, and Alleycat. It records planning, execution ownership, immutable refs, PRs, Fable sessions, acceptance surfaces, evidence, blockers, and rollback state. `scope.md` defines the architecture and twelve-hour cut; `rules.md` defines how work may be executed; `tasks/` is the dependency-ordered implementation blueprint.
 
@@ -83,7 +83,7 @@ Task 00 implementation session, `claude-fable-5` and browserless:
 | Browser | disabled; browserless per campaign rule |
 | Owner | Fable implementer for in-repo Task 00 artifacts; Codex owns integration, PRs, merges, browser, and evidence capture |
 | Start | 2026-08-09T20:41:52-04:00 (first verified read-only inspection in the assigned worktree) |
-| State | `IN PROGRESS` — Phase A edits authored; commit and push await Codex authorization; final commit/push/PR facts land in Phase B |
+| State | `IMPLEMENTATION COMPLETE — AWAITING CODEX REVIEW` — commit `c30a9216` pushed via the authorized explicit refspec; child draft PR [#385](https://github.com/sybil-solutions/local-studio/pull/385) open; control-plane only |
 
 ## Hard resource rule
 
@@ -133,7 +133,7 @@ All live observations are time-sensitive and must be revalidated at execution ti
 
 | Task | Title | Dependency | State | Planned owner |
 |---|---|---|---|---|
-| 00 | Control plane, refs, worktrees, PRs, evidence schema | approval | `IN PROGRESS` | Codex + Fable `ls-perf-w00-task00-control-plane` (in-repo artifacts) |
+| 00 | Control plane, refs, worktrees, PRs, evidence schema | approval | `IMPLEMENTATION COMPLETE — AWAITING CODEX REVIEW` | Codex + Fable `ls-perf-w00-task00-control-plane` (in-repo artifacts) |
 | 01 | Deterministic corpus and clean baseline | 00 | `NOT STARTED` | Fable implementer + Codex measurement |
 | 02 | Runtime inventory and hydration hot path | 01 | `NOT STARTED` | Fable implementer |
 | 03 | Electron session store, timeline, inspector, scroll | 01, 02 | `NOT STARTED` | Fable implementer |
@@ -156,7 +156,7 @@ All live observations are time-sensitive and must be revalidated at execution ti
 |---|---|---|---|---|
 | Local Studio | `codex/local-studio-performance-integration-20260809` | `dev` | [#382](https://github.com/sybil-solutions/local-studio/pull/382) | draft; planning only |
 | Local Studio workpack revision child | `codex/ls-perf-plan-revision-20260809` | `codex/local-studio-performance-integration-20260809` | [#383](https://github.com/sybil-solutions/local-studio/pull/383) | merged 2026-08-10T00:35:12Z as integration commit `6bdf748a`; verified read-only 2026-08-10T00:45:10Z |
-| Local Studio Task 00 child | `codex/ls-perf-w00-task-00-control-plane` | `codex/local-studio-performance-integration-20260809` | pending — Codex creates it after the authorized push | Phase A edits authored; commit and push await Codex authorization |
+| Local Studio Task 00 child | `codex/ls-perf-w00-task-00-control-plane` | `codex/local-studio-performance-integration-20260809` | [#385](https://github.com/sybil-solutions/local-studio/pull/385) | draft; head `c30a9216` pushed with all hooks enforced; awaiting Codex review/integration |
 | Litter | create after approval from recorded `origin/main` | `main` | pending | not created |
 | Alleycat | create after authority decision | selected protected branch | pending | blocked by authority |
 
@@ -166,7 +166,7 @@ The Task 00 control-plane run below is `CONTROL PLANE ONLY — NO PRODUCT ACCEPT
 
 | Run ID | Commit | Surface | Requirements | Result | Manifest |
 |---|---|---|---|---|---|
-| `2026-08-09-task-00-control-plane` | child branch `codex/ls-perf-w00-task-00-control-plane` from base `6bdf748a4da0d5634aa944417dcf362023f7ddf8` | control plane only — no product surface | R01, R02, R16, R17 | `IN PROGRESS — CONTROL PLANE ONLY — NO PRODUCT ACCEPTANCE` | [manifest.json](../../evidence/2026-08-09-task-00-control-plane/manifest.json) |
+| `2026-08-09-task-00-control-plane` | `c30a9216d1cd35824889a3d6009d237e939313ea` on `codex/ls-perf-w00-task-00-control-plane` from base `6bdf748a4da0d5634aa944417dcf362023f7ddf8` | control plane only — no product surface | R01, R02, R16, R17 | `CONTROL PLANE ONLY — AWAITING CODEX REVIEW — NO PRODUCT ACCEPTANCE` | [manifest.json](../../evidence/2026-08-09-task-00-control-plane/manifest.json) |
 
 ## Known blockers and stop conditions
 
@@ -181,13 +181,13 @@ The Task 00 control-plane run below is `CONTROL PLANE ONLY — NO PRODUCT ACCEPT
 
 ## Next transition
 
-Approval is recorded above. Task 00 starts the twelve-hour clock: it creates clean cross-repository worktrees, records fresh refs, confirms 2x/4x Spark availability through read-only discovery, and opens the integration review topology. Wave 1 (Tasks 01, 05, 12) follows; the Task 12 serving-contract merge gates the creation of Task 13 and Task 14 branches. Separate gates above remain in force.
+Approval is recorded above. Task 00's in-repo control plane is delivered on child draft PR [#385](https://github.com/sybil-solutions/local-studio/pull/385) and awaits Codex review/integration; the remaining Task 00 items stay with Codex — PR #239 disposition, the Alleycat authority decision, read-only 2x/4x Spark discovery, and any cross-repository worktrees/PRs. A separate Fable revision session incorporates the active dependency review; this session leaves the dependency graph untouched. Wave 1 (Tasks 01, 05, 12) follows once Task 00 is accepted; the Task 12 serving-contract merge gates the creation of Task 13 and Task 14 branches. Separate gates above remain in force.
 
-## Task 00 execution snapshot — 2026-08-09 (Phase A)
+## Task 00 execution snapshot — 2026-08-09
 
-Recorded: 2026-08-09T21:02:54-04:00 (America/New_York, EDT). Task 00 in-repo control-plane work is `IN PROGRESS` on the dedicated child branch below. This snapshot records control-plane facts only; R03–R20 and every product acceptance surface remain planned, pending, blocked, unknown, or not run as recorded above.
+Recorded: 2026-08-09T21:43:08-04:00 (America/New_York, EDT). Task 00 in-repo control-plane work is `IMPLEMENTATION COMPLETE — AWAITING CODEX REVIEW`: commit `c30a9216d1cd35824889a3d6009d237e939313ea` (parent `6bdf748a4da0d5634aa944417dcf362023f7ddf8`; Claude Fable 5 co-author trailer) is pushed and delivered as child draft PR [#385](https://github.com/sybil-solutions/local-studio/pull/385) into the integration branch. This snapshot records control-plane facts only; R03–R20 and every product acceptance surface remain planned, pending, blocked, unknown, or not run as recorded above.
 
-Twelve-hour clock: this workstream's first verified read-only inspection ran at 2026-08-09T20:41:52-04:00; the canonical campaign-wide kickoff time is Codex's to confirm.
+Twelve-hour clock: campaign kickoff 2026-08-09T20:41:52-04:00, confirmed by Codex at Phase B.
 
 ### Verified campaign refs (read-only)
 
@@ -199,7 +199,8 @@ Twelve-hour clock: this workstream's first verified read-only inspection ran at 
 | `origin/main` | `52c2b20f2994be07186b42da54e2836234785e8a`; unchanged | 2026-08-10T00:45:06Z |
 | Workpack revision child PR [#383](https://github.com/sybil-solutions/local-studio/pull/383) | `MERGED` 2026-08-10T00:35:12Z as merge commit `6bdf748a4da0d5634aa944417dcf362023f7ddf8` | 2026-08-10T00:45:10Z, `gh pr view` |
 | Umbrella draft PR [#382](https://github.com/sybil-solutions/local-studio/pull/382) | open draft into `dev`; combined CI for head `6bdf748a`: all rollup checks (gates, controller, agent-runtime, frontend, desktop-package, secret scanning, CodeQL, dependency review) `SUCCESS` by 2026-08-10T00:41:32Z | 2026-08-10T00:45:10Z |
-| Task 00 child branch `codex/ls-perf-w00-task-00-control-plane` | worktree `~/.codex/worktrees/ls-perf-w00-task-00-control-plane`; started clean at exact base `6bdf748a4da0d5634aa944417dcf362023f7ddf8`; checked out nowhere else; not yet on origin | 2026-08-10T00:41:52Z and 00:45:06Z |
+| Task 00 child branch `codex/ls-perf-w00-task-00-control-plane` | started clean at exact base `6bdf748a4da0d5634aa944417dcf362023f7ddf8` in sole worktree `~/.codex/worktrees/ls-perf-w00-task-00-control-plane`; after the hook-enforced push, remote ref and local HEAD both `c30a9216d1cd35824889a3d6009d237e939313ea` | 2026-08-10T01:37:52Z, `git ls-remote` |
+| Task 00 child draft PR [#385](https://github.com/sybil-solutions/local-studio/pull/385) | head `codex/ls-perf-w00-task-00-control-plane` at `c30a9216` into `codex/local-studio-performance-integration-20260809`; created by Codex | Codex-supplied, Phase B |
 | Incorporated workpack head | `4844b159a80aeb1720a44f2150f87ea6e8d9aea2` is an ancestor of the child base | 2026-08-10T00:41:52Z |
 
 ### Control-plane artifacts added by this task
@@ -214,16 +215,15 @@ Run manifest [manifest.json](../../evidence/2026-08-09-task-00-control-plane/man
 
 - Alleycat protocol authority: `NOT SELECTED`. Required decision: exactly one truthful protocol path — the scoped pair-token Pi bridge or a fully enforced signed grant protocol — on one lineage: `origin/main` `3f0f8442`, the pinned release lineage `417f2a9f`, or a reviewed recut of the staged `d584a006` grant work. Until recorded: no Alleycat integration worktree/PR, and authority-dependent Task 05 work stays blocked.
 - 2x/4x DGX Spark availability: `UNKNOWN`. No fresh read-only discovery result has been supplied and this session performed none; the user-provided screenshot records the target example, not live proof. Live Spark mutation remains gated.
-- Codex-verified read-only cross-repo facts (supplied 2026-08-09T21:02:54-04:00): Litter `origin/main` `5f651a475a16c93c273501fd370627f826c5e06f`; Litter primary checkout `codex/post-github-cleanup-20260804` at `9ebb405bb329866e3e3f6e9d16b45a5bb1a91706`, user-owned, dirty only at modified submodules `shared/third_party/codex` and `shared/third_party/ghostty` plus untracked `prompt.md`; Litter PR #239 `OPEN`, clean/mergeable at `a4cbf2df005dd45633d00377678d6adc9cc3146a`, required shared-prep/android/ios/release checks successful or intentionally skipped, disposition still pending (commit-by-commit review not yet performed); Litter PR #240 `OPEN`, clean/mergeable at `b277efd34d9962d3482372067618a3d6bc992e10`, planning reference only; Alleycat `origin/main` `3f0f84422e977f32cbc98de7a1d6c4e26fb240d1`; Alleycat staged checkout `codex/local-studio-prod-runtime` at `d584a006c75fe744def6cb3f41bcef4991b86b5f`, exactly 14 staged files (5829 insertions, 18 deletions). No cross-repository worktree was created; Litter integration worktree creation remains a Codex-owned step.
+- Codex-verified read-only cross-repo facts (supplied 2026-08-09T21:02:54-04:00; reconfirmed by Codex at Phase B): Litter `origin/main` `5f651a475a16c93c273501fd370627f826c5e06f`; Litter primary checkout `codex/post-github-cleanup-20260804` at `9ebb405bb329866e3e3f6e9d16b45a5bb1a91706`, user-owned, dirty only at modified submodules `shared/third_party/codex` and `shared/third_party/ghostty` plus untracked `prompt.md`; Litter PR #239 `OPEN`, clean/mergeable at `a4cbf2df005dd45633d00377678d6adc9cc3146a`, required shared-prep/android/ios/release checks successful or intentionally skipped, disposition still pending (commit-by-commit review not yet performed); Litter PR #240 `OPEN`, clean/mergeable at `b277efd34d9962d3482372067618a3d6bc992e10`, planning reference only; Alleycat `origin/main` `3f0f84422e977f32cbc98de7a1d6c4e26fb240d1`; Alleycat staged checkout `codex/local-studio-prod-runtime` at `d584a006c75fe744def6cb3f41bcef4991b86b5f`, exactly 14 staged files (5829 insertions, 18 deletions). No cross-repository worktree was created; Litter integration worktree creation remains a Codex-owned step.
 
 ### Worktree inventory (observed 2026-08-10T00:41:52Z)
 
 Clean assertions are scoped to the two campaign worktrees actually checked (refs table above); the prior workpack revision worktree and its merged child branch were removed after integration (Codex-supplied). Eleven stale `/private/tmp` registrations with missing gitdirs and every other non-campaign worktree — including the primary checkout and the detached historical reference `repo-comparison-review-35c382` — were observed only, sit outside campaign clean assertions, and were not altered; pruning is not authorized for this session.
 
-### Validation state (Phase A)
+### Validation state
 
-- Passed locally: `git diff --check`; manifest JSON parse; ignore-rule proof in both directions (`evidence/<run-id>/.raw/` ignored, the manifest tracked); diff scope limited to the three owned paths; and the dependency-free gates `check:automation`, `check:contracts`, `check:structure`, and `check:release`, each run as a separate unpiped command with exit 0.
-- Root `npm run check` aggregate: `NOT RUN — PENDING`. Dependencies are absent (no `node_modules` anywhere in this fresh worktree), and the aggregate's `check:frontend → check:quality` chain includes a full frontend `npm run build`; a lockfile install and that build each need explicit Codex authorization before this session may run them.
-- Pre-push hook (`.githooks/pre-push`) unconditionally runs frontend `check:static`, `check:cleanup`, and `assert-standalone`, which requires a prior local frontend build. The child-branch push therefore waits for Codex authorization; hooks are never bypassed.
-- Commit hooks `commit-msg` and `pre-commit` (protected-branch guard, 15-file/600-source-line limit) apply to the Phase A commit; their outcomes are reported in the Phase A handoff.
-- Context only, never a substitute for the local aggregate: PR #382 combined CI passed on `6bdf748a`, the exact tree this child branch starts from.
+- Phase A commit `c30a9216d1cd35824889a3d6009d237e939313ea`: exactly the three owned paths (375 insertions, 8 deletions); `git diff --check` clean; `commit-msg` and `pre-commit` hooks passed; manifest JSON parse and both `git check-ignore` directions proven.
+- Root `npm run check`: exit 0, run once unpiped after Codex-authorized frozen-lockfile installs (`bun install --frozen-lockfile` in `shared/`, `controller/`, `services/agent-runtime/`; `npm ci --legacy-peer-deps` in `frontend/` with `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` and `ELECTRON_SKIP_BINARY_DOWNLOAD=1`). All seven constituents ran; frontend unit tests 127 passed; all four lockfile SHA-256 values identical before and after; no browser, Electron, Playwright binary, or product service launched.
+- Push: `git push origin codex/ls-perf-w00-task-00-control-plane:codex/ls-perf-w00-task-00-control-plane` completed with every hook enforced (commit-range check, frontend `check:static`, `check:cleanup`, `assert-standalone`); remote ref equals local HEAD; working tree clean after push.
+- Context only, never a substitute for the local aggregate: umbrella PR #382 combined CI green at integration head `6bdf748a`.


### PR DESCRIPTION
## Summary

- establish the Task 00 campaign control plane and machine-readable manifest
- record worktree, Fable session, browser-lease, evidence, and integration gates
- ignore campaign evidence outputs while preserving checked-in run metadata

## Validation

- npm run check
- git diff --check
- pre-push commit-range, frontend static, cleanup, and standalone gates

## Scope

Task 00 Phase A only. Phase B will append observed cross-repository and remote-state facts before integration.