### PR TITLE
fix(agent): open fresh chats and show all controller models

### DIFF
--- a/frontend/e2e/controller-agent.config.ts
+++ b/frontend/e2e/controller-agent.config.ts
@@ -6,6 +6,7 @@ import { defineConfig } from "@playwright/test";
 const frontendPort = 43_220;
 const runtimePort = 43_221;
 const controllerPort = 43_222;
+const secondaryControllerPort = 43_223;
 const baseURL = `http://127.0.0.1:${frontendPort}`;
 const dataDir = mkdtempSync(path.join(os.tmpdir(), "local-studio-controller-e2e-data-"));
 const homeDir = mkdtempSync(path.join(os.tmpdir(), "local-studio-controller-e2e-home-"));
@@ -67,6 +68,12 @@ export default defineConfig({
     {
       command: `PORT=${controllerPort} node ${controllerScript}`,
       url: `http://127.0.0.1:${controllerPort}/health`,
+      timeout: 15_000,
+      reuseExistingServer: false,
+    },
+    {
+      command: `PORT=${secondaryControllerPort} MODEL_ID=secondary-model node ${controllerScript}`,
+      url: `http://127.0.0.1:${secondaryControllerPort}/health`,
       timeout: 15_000,
       reuseExistingServer: false,
     },

--- a/frontend/e2e/controller-agent.spec.ts
+++ b/frontend/e2e/controller-agent.spec.ts
@@ -73,6 +73,41 @@ test("Pi defaults to the active controller and reveals other models on request",
   await expect(page.getByText("Controller scoped Pi reply.")).toBeVisible({ timeout: 60_000 });
 });
 
+test("new task replaces the current chat with a fresh session", async ({ page }) => {
+  const composer = await openControllerChat(page, "Replace current chat");
+  await composer.fill("Keep this chat out of the new session.");
+  await composer.press("Enter");
+  await expect(page.getByText("Controller scoped Pi reply.")).toBeVisible({ timeout: 60_000 });
+
+  await page.getByRole("link", { name: "New task" }).click();
+
+  await expect(page.getByPlaceholder(/Do anything|Ask for follow-up changes/)).toHaveCount(1);
+  await expect(page.locator("[data-multi-pane=true]")).toHaveCount(0);
+  await expect(page.getByText("Controller scoped Pi reply.")).toHaveCount(0);
+});
+
+test("model picker includes models from every saved controller", async ({ page }) => {
+  await page.addInitScript(() => {
+    const primaryUrl = "http://127.0.0.1:43222";
+    localStorage.setItem("localstudio_backend_url", primaryUrl);
+    localStorage.setItem(
+      "local-studio.controllers",
+      JSON.stringify([
+        { name: "Primary", url: primaryUrl },
+        { name: "Secondary", url: "http://127.0.0.1:43223" },
+      ]),
+    );
+  });
+  await page.goto(`/agent?new=${encodeURIComponent("All controller models")}`);
+  const picker = page.getByRole("button", { name: /^Model:/ }).first();
+  await expect(picker).toBeEnabled({ timeout: 60_000 });
+  await picker.click();
+  await page.getByRole("menuitem", { name: /^Model\b/ }).click();
+
+  await expect(page.getByRole("menuitemradio", { name: /controller-model/ })).toBeVisible();
+  await expect(page.getByRole("menuitemradio", { name: /secondary-model/ })).toBeVisible();
+});
+
 test("messages containing /goal reach Pi as ordinary text", async ({ page }) => {
   const composer = await openControllerChat(page, "Goal text chat");
   const transcript = page.getByRole("article");

--- a/frontend/e2e/fixtures/fake-controller.mjs
+++ b/frontend/e2e/fixtures/fake-controller.mjs
@@ -1,6 +1,7 @@
 import { createServer } from "node:http";
 
 const port = Number(process.env.PORT) || 43220;
+const modelId = process.env.MODEL_ID || "controller-model";
 
 function json(response, status, body) {
   response.writeHead(status, { "content-type": "application/json" });
@@ -48,7 +49,7 @@ async function streamCompletion(request, response) {
     id,
     object: "chat.completion.chunk",
     created: Math.floor(Date.now() / 1000),
-    model: "controller-model",
+    model: modelId,
     choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }],
   })}\n\n`);
   for (const content of chunks) {
@@ -56,7 +57,7 @@ async function streamCompletion(request, response) {
       id,
       object: "chat.completion.chunk",
       created: Math.floor(Date.now() / 1000),
-      model: "controller-model",
+      model: modelId,
       choices: [{ index: 0, delta: { content }, finish_reason: null }],
     })}\n\n`);
     if (slow) await new Promise((resolve) => setTimeout(resolve, 150));
@@ -65,7 +66,7 @@ async function streamCompletion(request, response) {
     id,
     object: "chat.completion.chunk",
     created: Math.floor(Date.now() / 1000),
-    model: "controller-model",
+    model: modelId,
     choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
   })}\n\n`);
   response.write("data: [DONE]\n\n");
@@ -139,7 +140,7 @@ const server = createServer(async (request, response) => {
   if (url.pathname === "/v1/models") {
     return json(response, 200, {
       object: "list",
-      data: [{ id: "controller-model", object: "model" }],
+      data: [{ id: modelId, object: "model" }],
     });
   }
   if (url.pathname === "/v1/chat/completions" && request.method === "POST") {

--- a/frontend/src/features/agent/ui/use-workspace.ts
+++ b/frontend/src/features/agent/ui/use-workspace.ts
@@ -100,20 +100,26 @@ function createWorkspaceWindow(source: Window): WorkspaceWindow {
 
 function agentModelControllersPayload() {
   const activeUrl = normalizeControllerUrl(getStoredBackendUrl());
+  const saved = loadSavedControllers().flatMap((controller) => {
+    const url = normalizeControllerUrl(controller.url);
+    return url ? [{ ...controller, url }] : [];
+  });
+  const byUrl = new Map(saved.map((controller) => [controller.url, controller]));
   if (activeUrl) {
     const activeApiKey = getApiKey();
+    const savedActive = byUrl.get(activeUrl);
+    byUrl.delete(activeUrl);
     return [
       {
+        ...savedActive,
         url: activeUrl,
         ...(activeApiKey ? { apiKey: activeApiKey } : {}),
-        name: "primary",
+        name: savedActive?.name ?? "primary",
       },
+      ...byUrl.values(),
     ];
   }
-  const fallback = loadSavedControllers()[0];
-  if (!fallback) return [];
-  const url = normalizeControllerUrl(fallback.url);
-  return url ? [{ ...fallback, url }] : [];
+  return [...byUrl.values()];
 }
 
 async function loadAgentModelsPayload(): Promise<{ models?: AgentModel[]; error?: string }> {

--- a/frontend/src/features/shell/left-sidebar-desktop.tsx
+++ b/frontend/src/features/shell/left-sidebar-desktop.tsx
@@ -34,6 +34,7 @@ export function DesktopSidebar({
   onRevealProjectsNav,
   onSetPinnedOpen,
   onOpenSearch,
+  onNewTask,
 }: {
   pathname: string;
   isExpanded: boolean;
@@ -45,6 +46,7 @@ export function DesktopSidebar({
   onRevealProjectsNav: () => void;
   onSetPinnedOpen: (open: boolean) => void;
   onOpenSearch: () => void;
+  onNewTask: () => void;
 }) {
   return (
     <aside
@@ -127,8 +129,13 @@ export function DesktopSidebar({
 
             <nav className="sidebar-scroller flex min-h-0 flex-1 flex-col gap-[var(--sidebar-row-gap)] overflow-x-hidden overflow-y-auto px-[var(--sidebar-padding-x)] py-0.5 [contain:layout_paint]">
               <Link
-                href="/agent?new=1"
+                href="/agent?new=1&replace=1"
                 prefetch={false}
+                onClick={(event) => {
+                  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+                  event.preventDefault();
+                  onNewTask();
+                }}
                 className="flex h-[var(--sidebar-row-height)] shrink-0 items-center gap-2.5 rounded-[var(--sidebar-row-radius)] px-2 text-(--fg) transition-colors hover:bg-(--hover)"
                 title="New task"
               >

--- a/frontend/src/features/shell/left-sidebar-mobile-drawer.tsx
+++ b/frontend/src/features/shell/left-sidebar-mobile-drawer.tsx
@@ -14,11 +14,13 @@ export function MobileNavigationDrawer({
   projectsNavReady,
   ProjectsNavSection,
   onClose,
+  onNewTask,
 }: {
   pathname: string;
   projectsNavReady: boolean;
   ProjectsNavSection: ProjectsNavSectionComponent | null;
   onClose: () => void;
+  onNewTask: () => void;
 }) {
   return (
     <div className="fixed inset-0 z-50 md:hidden" role="dialog" aria-modal="true">
@@ -48,11 +50,16 @@ export function MobileNavigationDrawer({
 
         <nav className="min-h-0 flex-1 touch-pan-y overscroll-contain overflow-y-auto px-3 pb-4 pt-1">
           <NavItemMobile
-            href="/agent?new=1"
+            href="/agent?new=1&replace=1"
             label="New task"
             Icon={SquarePen}
             active={false}
-            onClick={onClose}
+            onClick={(event) => {
+              onClose();
+              if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+              event.preventDefault();
+              onNewTask();
+            }}
           />
           {tabs.map((tab) => (
             <NavItemMobile

--- a/frontend/src/features/shell/left-sidebar-nav.tsx
+++ b/frontend/src/features/shell/left-sidebar-nav.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { type ComponentType } from "react";
+import { type ComponentType, type MouseEvent } from "react";
 import { Activity, Clock, ServerCog, TrendingUp } from "@/ui/icon-registry";
 
 export type IconComponent = ComponentType<{ className?: string; strokeWidth?: number }>;
@@ -56,7 +56,7 @@ export function NavItemMobile({
   label: string;
   Icon: IconComponent;
   active: boolean;
-  onClick: () => void;
+  onClick: (event: MouseEvent<HTMLAnchorElement>) => void;
 }) {
   return (
     <Link

--- a/frontend/src/features/shell/left-sidebar.tsx
+++ b/frontend/src/features/shell/left-sidebar.tsx
@@ -14,6 +14,7 @@ import { useShallow } from "zustand/react/shallow";
 import { useAppStore } from "@/store";
 import { useMountSubscription } from "@/hooks/use-mount-subscription";
 import { useOpenSessions } from "@/features/agent/ui/use-open-sessions";
+import { hrefWithOpenNonce } from "@/features/agent/ui/projects-nav/helpers";
 import { DesktopSidebar } from "@/features/shell/left-sidebar-desktop";
 import {
   loadProjectsNavSection,
@@ -165,6 +166,10 @@ export function LeftSidebar({ children }: { children: ReactNode }) {
     },
     [clampedSidebarWidth, isExpanded, setSidebarWidth],
   );
+  const openNewTask = useCallback(
+    () => window.location.assign(hrefWithOpenNonce("/agent?new=1&replace=1")),
+    [],
+  );
 
   if (hidesAppSidebar) {
     return <div className="h-full w-full">{children}</div>;
@@ -185,6 +190,7 @@ export function LeftSidebar({ children }: { children: ReactNode }) {
         }}
         onSetPinnedOpen={setDesktopSidebarPinnedOpen}
         onOpenSearch={() => setSearchOpen(true)}
+        onNewTask={openNewTask}
       />
 
       {chatSessionRoute ? null : (
@@ -215,6 +221,7 @@ export function LeftSidebar({ children }: { children: ReactNode }) {
           projectsNavReady={projectsNavReady}
           ProjectsNavSection={ProjectsNavSection}
           onClose={() => setMobileMenuOpen(false)}
+          onNewTask={openNewTask}
         />
       ) : null}
 

--- a/services/agent-runtime/src/pi-runtime-models.ts
+++ b/services/agent-runtime/src/pi-runtime-models.ts
@@ -205,10 +205,14 @@ function mergeControllers(
   settings: ApiSettings,
   requested: PiControllerModelsRequest[] = [],
 ): PiControllerConfig[] {
-  const requestedController = requested
+  const requestedControllers = requested
     .map(normalizeControllerInput)
-    .find((controller): controller is PiControllerConfig => controller !== null);
-  if (requestedController) return [requestedController];
+    .filter((controller): controller is PiControllerConfig => controller !== null);
+  if (requestedControllers.length > 0) {
+    return [
+      ...new Map(requestedControllers.map((controller) => [controller.url, controller])).values(),
+    ];
+  }
   const primary = normalizeControllerInput({
     url: settings.backendUrl,
     apiKey: settings.apiKey,


### PR DESCRIPTION
## Summary
- make New task replace the current workspace with a genuinely fresh session instead of opening beside or restoring the old chat
- load and deduplicate models from the active controller and every saved controller
- add end-to-end coverage with two independent fake controllers

## Validation
- `npm run check`
- `npm run test:integration`
- `playwright test --config frontend/e2e/controller-agent.config.ts` (21 passed)