### PR TITLE
feat(frontend): restore models nav and expand themes

### DIFF
--- a/frontend/e2e/controller-agent.spec.ts
+++ b/frontend/e2e/controller-agent.spec.ts
@@ -14,6 +14,7 @@ for (const route of [
   "/agent/automations",
   "/configure",
   "/logs",
+  "/models",
   "/quick",
   "/settings",
   "/setup",
@@ -37,9 +38,9 @@ for (const route of [
 }
 
 for (const [route, destination] of [
-  ["/discover", "/configure?section=models#models"],
+  ["/discover", "/models"],
   ["/integrations", "/configure?section=integrations#integrations"],
-  ["/recipes", "/configure?section=models#models"],
+  ["/recipes", "/models"],
   ["/server", "/configure?section=server#server"],
 ] as const) {
   test(`${route} redirects to ${destination}`, async ({ page }) => {

--- a/frontend/e2e/hydration.spec.ts
+++ b/frontend/e2e/hydration.spec.ts
@@ -4,6 +4,7 @@ import { readLiveControllerConfig, selectLiveController } from "./live-controlle
 for (const path of [
   "/",
   "/usage",
+  "/models",
   "/configure",
   "/settings",
   "/agent",

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -134,7 +134,7 @@ const nextConfig: NextConfig = {
       "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: blob: https:",
-      "font-src 'self' data:",
+      "font-src 'self' data: https://cdn.openai.com",
       "connect-src 'self' https: http: ws: wss:",
       "frame-src 'self' https: http:",
       "media-src 'self' blob: data:",

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -115,15 +115,6 @@ const nextConfig: NextConfig = {
   turbopack: {
     root: path.join(__dirname, ".."),
   },
-  async redirects() {
-    return [
-      {
-        source: "/models",
-        destination: "/configure#models",
-        permanent: true,
-      },
-    ];
-  },
   async rewrites() {
     return [
       {

--- a/frontend/src/app/discover/page.tsx
+++ b/frontend/src/app/discover/page.tsx
@@ -1,5 +1,5 @@
 import { permanentRedirect } from "next/navigation";
 
 export default function DiscoverRedirect() {
-  permanentRedirect("/configure?section=models#models");
+  permanentRedirect("/models");
 }

--- a/frontend/src/app/models/models-route.test.ts
+++ b/frontend/src/app/models/models-route.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "node:test";
+
+const route = readFileSync(new URL("./page.tsx", import.meta.url), "utf8");
+const nextConfig = readFileSync(new URL("../../../next.config.ts", import.meta.url), "utf8");
+
+describe("models route", () => {
+  test("renders the model library as a first-class page", () => {
+    assert.match(route, /<RecipesContent \/>/);
+    assert.doesNotMatch(nextConfig, /source:\s*["']\/models["']/);
+  });
+});

--- a/frontend/src/app/models/page.tsx
+++ b/frontend/src/app/models/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from "react";
+import { RecipesContent } from "@/features/recipes/recipes-content/recipes-content";
+
+export default function ModelsPage() {
+  return (
+    <Suspense fallback={<div className="flex h-full items-center justify-center">Loading…</div>}>
+      <RecipesContent />
+    </Suspense>
+  );
+}

--- a/frontend/src/app/recipes/page.tsx
+++ b/frontend/src/app/recipes/page.tsx
@@ -1,5 +1,5 @@
 import { permanentRedirect } from "next/navigation";
 
 export default function RecipesRedirect() {
-  permanentRedirect("/configure?section=models#models");
+  permanentRedirect("/models");
 }

--- a/frontend/src/app/styles/globals/base.css
+++ b/frontend/src/app/styles/globals/base.css
@@ -39,6 +39,11 @@
   scrollbar-color: color-mix(in srgb, var(--hl1) 18%, transparent) transparent;
 }
 
+svg.lucide {
+  scale: var(--icon-scale);
+  transform-origin: center;
+}
+
 html,
 body {
   overflow: hidden;

--- a/frontend/src/app/styles/globals/base.css
+++ b/frontend/src/app/styles/globals/base.css
@@ -1,3 +1,36 @@
+@font-face {
+  font-family: "OpenAI Sans";
+  src:
+    local("OpenAI Sans"),
+    url("https://cdn.openai.com/common/fonts/openai-sans/v2/OpenAISans-Regular.woff2")
+      format("woff2");
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "OpenAI Sans";
+  src:
+    local("OpenAI Sans Medium"),
+    url("https://cdn.openai.com/common/fonts/openai-sans/v2/OpenAISans-Medium.woff2")
+      format("woff2");
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "OpenAI Sans";
+  src:
+    local("OpenAI Sans Semibold"),
+    url("https://cdn.openai.com/common/fonts/openai-sans/v2/OpenAISans-Semibold.woff2")
+      format("woff2");
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+}
+
 *,
 *::before,
 *::after {
@@ -23,7 +56,7 @@ html {
 body {
   background-color: var(--bg);
   color: var(--fg);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: var(--font-sans);
   font-weight: var(--app-font-weight);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/frontend/src/app/styles/globals/chat.css
+++ b/frontend/src/app/styles/globals/chat.css
@@ -41,11 +41,7 @@
 
 /* Chat markdown */
 :root {
-  /* Codex desktop v26.7, exact: the ChatGPT text-md ladder — 16px system UI
-     with 24px leading (1.5) for chat prose AND the composer (one shared chat
-     size token, `text-size-chat` upstream); 13px monospace for code.
-     Weight 400 — calm, document-like. */
-  --codex-chat-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --codex-chat-font-family: var(--font-sans);
   --codex-chat-mono-font-family:
     ui-monospace, "SFMono-Regular", "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
   --codex-chat-font-size: 16px;

--- a/frontend/src/app/styles/globals/pwa.css
+++ b/frontend/src/app/styles/globals/pwa.css
@@ -122,24 +122,24 @@
   .mobile-pwa-drawer {
     padding-top: env(safe-area-inset-top, 0px);
     animation: mobile-drawer-in 200ms cubic-bezier(0.32, 0.72, 0, 1);
-    --fs-xs: 13px;
-    --fs-sm: 15px;
-    --fs-md: 16px;
-    --fs-base: 17px;
-    --sidebar-row-height: 44px;
-    --sidebar-row-radius: 12px;
+    --fs-xs: 12px;
+    --fs-sm: 13px;
+    --fs-md: 14px;
+    --fs-base: 15px;
+    --sidebar-row-height: 40px;
+    --sidebar-row-radius: 10px;
   }
 
   /* Codex reads section headings as real headings, not micro eyebrow labels. */
   .mobile-pwa-drawer nav > div > div > div:first-child > span,
   .mobile-pwa-drawer [class*="pt-5"] > span {
-    font-size: 17px;
+    font-size: 15px;
     font-weight: 600;
     color: var(--fg);
   }
 
   .mobile-pwa-drawer-header {
-    min-height: calc(3.25rem + env(safe-area-inset-top, 0px));
+    min-height: calc(3rem + env(safe-area-inset-top, 0px));
   }
 
   .agent-workspace-header {

--- a/frontend/src/app/styles/globals/tokens.css
+++ b/frontend/src/app/styles/globals/tokens.css
@@ -597,20 +597,20 @@
 
 :root {
   /* Density / dimensions */
-  --sidebar-w: 275px;
+  --sidebar-w: 260px;
   --sidebar-w-collapsed: 48px;
   --sidebar-row-height: 30px;
   /* Rows sat at a 30px pitch against a 30px height, i.e. touching, with no gap
      anywhere in the sidebar. That reads as a wall of text rather than a list.
      Costs 2px per row and no change to the row itself. */
-  --sidebar-row-gap: 2px;
-  --sidebar-row-radius: 10px;
-  --sidebar-padding-x: 8px;
+  --sidebar-row-gap: 1px;
+  --sidebar-row-radius: 8px;
+  --sidebar-padding-x: 7px;
   --row-h: 36px;
   --row-h-sm: 28px;
   --row-radius: var(--rad-md);
   /* Toolbar heights — main bar, small bar, pane header. */
-  --h-toolbar: 46px;
+  --h-toolbar: 44px;
   --h-toolbar-sm: 36px;
   --h-toolbar-pane: 40px;
   --composer-w: clamp(28rem, 42rem, 48vw);
@@ -632,6 +632,7 @@
   --app-height: 100vh;
   --app-font-size: 16px;
   --app-font-weight: 400;
+  --icon-scale: 0.84;
 
   /* Type ramp — fixed steps × --ui-scale. Base is 14px. */
   --fs-2xs: calc(10px * var(--ui-scale));

--- a/frontend/src/features/configure/configure-page.tsx
+++ b/frontend/src/features/configure/configure-page.tsx
@@ -37,12 +37,6 @@ const CONFIGURE_SECTIONS: SettingsSectionDef<ConfigureSectionId>[] = [
     icon: sectionIcon(Monitor),
   },
   {
-    id: "models",
-    label: "Models",
-    description: "Find weights, manage serves, and monitor downloads.",
-    icon: sectionIcon(Boxes),
-  },
-  {
     id: "integrations",
     label: "Integrations",
     description: "Plugins, connectors, accounts, and reusable skills.",
@@ -175,7 +169,7 @@ export default function ConfigurePage() {
                 title="Models"
                 description="Find weights, create serving profiles, and manage downloads."
                 detail="Get · serve · download"
-                onOpen={() => selectSection("models")}
+                onOpen={() => window.location.assign("/models")}
               />
               <OverviewRow
                 icon={<Plug className="h-5 w-5" />}

--- a/frontend/src/features/settings/appearance-settings.tsx
+++ b/frontend/src/features/settings/appearance-settings.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState, useCallback } from "react";
 import { Check, ChevronDown, Laptop, Moon, RotateCcw, Search, Sun, X } from "@/ui/icon-registry";
 import { useAppStore } from "@/store";
 import {
+  FONT_FAMILY_BY_ID,
   FONT_FAMILY_OPTIONS,
   type FontFamilyId,
   THEMES,
@@ -49,6 +50,7 @@ function matchesQuery(theme: ThemeMeta, query: string): boolean {
   return (
     theme.name.toLowerCase().includes(q) ||
     theme.group.toLowerCase().includes(q) ||
+    (FONT_FAMILY_BY_ID.get(theme.fontFamilyId)?.label.toLowerCase().includes(q) ?? false) ||
     theme.description.toLowerCase().includes(q)
   );
 }
@@ -89,11 +91,11 @@ function readVar(name: string, fallback: number): number {
 
 function ThemeSwatches({ theme }: { theme: ThemeMeta }) {
   return (
-    <div className="flex items-center gap-1">
+    <div className="flex items-center gap-0.5">
       {theme.swatches.map((color, i) => (
         <span
           key={i}
-          className="h-3.5 w-3.5 rounded-[var(--rad-2xs)] border border-(--ui-border)"
+          className="h-3 w-3 rounded-[var(--rad-2xs)] border border-(--ui-border)"
           style={{ backgroundColor: color }}
         />
       ))}
@@ -110,7 +112,9 @@ export function AppearanceSettings() {
   const setFontSizeId = useAppStore((s) => s.setFontSizeId);
 
   const [query, setQuery] = useState("");
-  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(() => new Set(["Classic"]));
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
+    () => new Set(["Reference", "Studio"]),
+  );
 
   const sizeMap: Record<string, number> = { sm: 14, md: 16, lg: 17, xl: 18, "2xl": 20 };
   const [uiFontSize, setUiFontSize] = useState(sizeMap[fontSizeId] ?? 16);
@@ -237,6 +241,99 @@ export function AppearanceSettings() {
 
   const advancedTokens: Array<keyof ThemeTokens> = ["dim", "border", "hl1", "hl2", "hl3", "err"];
 
+  const themeLibrary = (
+    <SettingsGroup
+      title="Theme library"
+      description="Presets pair a complete surface palette with a typeface."
+    >
+      <div>
+        <div className="flex h-9 items-center gap-2 px-3">
+          <Search className="h-3 w-3 shrink-0 text-(--ui-muted)" />
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search colors or fonts"
+            className="min-w-0 flex-1 bg-transparent text-[length:var(--fs-md)] text-(--ui-fg) outline-none placeholder:text-(--ui-muted)/60"
+          />
+          {query ? (
+            <button
+              type="button"
+              onClick={() => setQuery("")}
+              className="shrink-0 text-(--ui-muted) hover:text-(--ui-fg)"
+              aria-label="Clear theme search"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          ) : null}
+        </div>
+        {groups.length === 0 ? (
+          <div className="border-t border-(--ui-separator) px-3 py-3 text-[length:var(--fs-md)] text-(--ui-muted)">
+            No themes match your search.
+          </div>
+        ) : (
+          groups.map(([group, themes]) => {
+            const expanded = expandedGroups.has(group);
+            return (
+              <div key={group} className="border-t border-(--ui-separator)">
+                <button
+                  type="button"
+                  onClick={() => toggleGroup(group)}
+                  className="flex h-8 w-full items-center justify-between px-3 text-left hover:bg-(--ui-hover)"
+                >
+                  <span className="text-[length:var(--fs-sm)] font-medium text-(--ui-fg)">
+                    {group}
+                  </span>
+                  <span className="flex items-center gap-1 text-[length:var(--fs-xs)] text-(--ui-muted)">
+                    {themes.length}
+                    <ChevronDown
+                      className={`h-3 w-3 transition-transform ${expanded ? "" : "-rotate-90"}`}
+                    />
+                  </span>
+                </button>
+                {expanded ? (
+                  <div className="grid grid-cols-1 gap-1 p-2 sm:grid-cols-2">
+                    {themes.map((theme) => {
+                      const active = theme.id === themeId && !isCustomActive;
+                      const font = FONT_FAMILY_BY_ID.get(theme.fontFamilyId);
+                      return (
+                        <button
+                          key={theme.id}
+                          type="button"
+                          onClick={() => setThemeId(theme.id)}
+                          className={`min-w-0 rounded-[var(--rad-md)] border px-2.5 py-2 text-left transition-colors ${
+                            active
+                              ? "border-(--ui-accent)/35 bg-(--ui-active)"
+                              : "border-transparent hover:border-(--ui-border) hover:bg-(--ui-hover)"
+                          }`}
+                        >
+                          <div className="flex items-center justify-between gap-2">
+                            <span
+                              className="truncate text-[length:var(--fs-md)] font-medium text-(--ui-fg)"
+                              style={{ fontFamily: font?.cssValue }}
+                            >
+                              {theme.name}
+                            </span>
+                            <div className="flex shrink-0 items-center gap-1.5">
+                              <ThemeSwatches theme={theme} />
+                              {active ? <Check className="h-3 w-3 text-(--ui-success)" /> : null}
+                            </div>
+                          </div>
+                          <div className="mt-0.5 truncate text-[length:var(--fs-xs)] text-(--ui-muted)">
+                            {font?.label} · {theme.description}
+                          </div>
+                        </button>
+                      );
+                    })}
+                  </div>
+                ) : null}
+              </div>
+            );
+          })
+        )}
+      </div>
+    </SettingsGroup>
+  );
+
   return (
     <div>
       <SettingsGroup
@@ -264,6 +361,8 @@ export function AppearanceSettings() {
           }
         />
       </SettingsGroup>
+
+      {themeLibrary}
 
       <SettingsGroup
         title="Theme editor"
@@ -460,87 +559,6 @@ export function AppearanceSettings() {
           description="Surface color of your messages"
           control={<ColorField value={bubbleTone} label="Bubble tone" onChange={setBubble} />}
         />
-      </SettingsGroup>
-
-      <SettingsGroup title="Theme library" collapsible defaultOpen={false}>
-        <div>
-          <div className="flex items-center gap-2 px-3.5 py-2.5">
-            <Search className="h-3.5 w-3.5 shrink-0 text-(--ui-muted)" />
-            <input
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search themes"
-              className="min-w-0 flex-1 bg-transparent text-[length:var(--fs-base)] text-(--ui-fg) outline-none placeholder:text-(--ui-muted)/60"
-            />
-            {query ? (
-              <button
-                type="button"
-                onClick={() => setQuery("")}
-                className="shrink-0 text-(--ui-muted) hover:text-(--ui-fg)"
-              >
-                <X className="h-3 w-3" />
-              </button>
-            ) : null}
-          </div>
-          {groups.length === 0 ? (
-            <div className="px-3.5 py-2.5 text-[length:var(--fs-base)] text-(--ui-muted)">
-              No themes match your search.
-            </div>
-          ) : (
-            groups.map(([group, themes]) => {
-              const expanded = expandedGroups.has(group);
-              return (
-                <div key={group} className="border-t border-(--ui-separator)">
-                  <button
-                    type="button"
-                    onClick={() => toggleGroup(group)}
-                    className="flex w-full items-center justify-between px-3.5 py-2 text-left hover:bg-(--ui-hover)"
-                  >
-                    <span className="text-[length:var(--fs-md)] font-medium text-(--ui-fg)">
-                      {group}
-                    </span>
-                    <span className="flex items-center gap-1.5 text-[length:var(--fs-sm)] text-(--ui-muted)">
-                      {themes.length}
-                      <ChevronDown
-                        className={`h-3 w-3 transition-transform ${expanded ? "" : "-rotate-90"}`}
-                      />
-                    </span>
-                  </button>
-                  {expanded
-                    ? themes.map((theme) => {
-                        const active = theme.id === themeId;
-                        return (
-                          <button
-                            key={theme.id}
-                            type="button"
-                            onClick={() => setThemeId(theme.id)}
-                            className={`flex w-full items-center justify-between gap-4 px-3.5 py-2 text-left transition-colors ${
-                              active ? "bg-(--ui-hover)" : "hover:bg-(--ui-hover)"
-                            }`}
-                          >
-                            <div className="min-w-0">
-                              <div className="text-[length:var(--fs-base)] text-(--ui-fg)">
-                                {theme.name}
-                              </div>
-                              <div className="truncate text-[length:var(--fs-sm)] text-(--ui-muted)">
-                                {theme.description}
-                              </div>
-                            </div>
-                            <div className="flex shrink-0 items-center gap-2">
-                              <ThemeSwatches theme={theme} />
-                              {active && !isCustomActive ? (
-                                <Check className="h-3.5 w-3.5 text-(--ui-success)" />
-                              ) : null}
-                            </div>
-                          </button>
-                        );
-                      })
-                    : null}
-                </div>
-              );
-            })
-          )}
-        </div>
       </SettingsGroup>
     </div>
   );

--- a/frontend/src/features/settings/settings-ui.tsx
+++ b/frontend/src/features/settings/settings-ui.tsx
@@ -73,7 +73,7 @@ export function SettingsLayout<Id extends SettingsSectionId = SettingsSectionId>
     <AppPage>
       <div
         className={cx(
-          "mx-auto grid w-full grid-cols-1 gap-4 px-4 py-4 sm:px-6 lg:justify-center lg:gap-8 lg:py-6",
+          "mx-auto grid w-full grid-cols-1 gap-4 px-4 py-4 sm:px-6 lg:justify-center lg:gap-6 lg:py-5",
           layoutWidth,
         )}
       >
@@ -93,8 +93,8 @@ export function SettingsLayout<Id extends SettingsSectionId = SettingsSectionId>
             onSelectItem={onSelectSection}
           />
         </aside>
-        <section className="min-w-0 pb-12">
-          <header className="mb-6 flex min-h-8 items-start justify-between gap-4">
+        <section className="min-w-0 pb-10">
+          <header className="mb-5 flex min-h-8 items-start justify-between gap-4">
             <div className="min-w-0">
               {eyebrow ? (
                 <div className="mb-1 text-[length:var(--fs-xs)] uppercase tracking-[0.12em] text-(--ui-muted)">
@@ -147,7 +147,7 @@ export function SettingsGroup({
   const showBody = collapsible ? open : true;
 
   return (
-    <section className="mb-8 last:mb-0">
+    <section className="mb-6 last:mb-0">
       <div className="mb-2 flex items-start justify-between gap-4 px-1">
         <div className="min-w-0">
           {collapsible ? (

--- a/frontend/src/features/settings/theme-catalogue.test.ts
+++ b/frontend/src/features/settings/theme-catalogue.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
-import { FONT_FAMILY_BY_ID, THEMES, THEME_BY_ID } from "./themes";
+import { FONT_FAMILY_BY_ID, THEMES, THEME_BY_ID } from "@/lib/themes";
 
 describe("theme catalogue", () => {
   test("keeps theme identifiers unique", () => {

--- a/frontend/src/features/shell/left-sidebar-desktop.tsx
+++ b/frontend/src/features/shell/left-sidebar-desktop.tsx
@@ -75,11 +75,11 @@ export function DesktopSidebar({
         <div className="flex h-[var(--h-toolbar)] shrink-0 items-center justify-center">
           <button
             onClick={() => onSetPinnedOpen(true)}
-            className="flex h-8 w-8 items-center justify-center rounded-lg text-(--hl2) transition-colors hover:bg-(--hover) hover:text-(--fg)"
+            className="flex h-7 w-7 items-center justify-center rounded-md text-(--hl2) transition-colors hover:bg-(--hover) hover:text-(--fg)"
             title="Expand sidebar"
             aria-label="Expand sidebar"
           >
-            <PanelLeftHollow className="h-4 w-4" strokeWidth={1.75} />
+            <PanelLeftHollow className="h-3.5 w-3.5" strokeWidth={1.75} />
           </button>
         </div>
       ) : null}
@@ -97,7 +97,7 @@ export function DesktopSidebar({
                 title="Collapse sidebar"
                 aria-label="Collapse sidebar"
               >
-                <PanelLeftFilled className="h-3.5 w-3.5" strokeWidth={1.75} />
+                <PanelLeftFilled className="h-3 w-3" strokeWidth={1.75} />
               </button>
               <button
                 onClick={() => window.history.back()}
@@ -119,7 +119,7 @@ export function DesktopSidebar({
                   a full row for the content the sidebar actually exists to list. */}
               <button
                 onClick={onOpenSearch}
-                className="ml-auto flex h-7 w-7 items-center justify-center rounded-lg text-(--hl2) transition-colors hover:bg-(--hover) hover:text-(--fg)"
+                className="ml-auto flex h-7 w-7 items-center justify-center rounded-md text-(--hl2) transition-colors hover:bg-(--hover) hover:text-(--fg)"
                 title="Search sessions (⌘K)"
                 aria-label="Search sessions"
               >
@@ -136,7 +136,7 @@ export function DesktopSidebar({
                   event.preventDefault();
                   onNewTask();
                 }}
-                className="flex h-[var(--sidebar-row-height)] shrink-0 items-center gap-2.5 rounded-[var(--sidebar-row-radius)] px-2 text-(--fg) transition-colors hover:bg-(--hover)"
+                className="flex h-[var(--sidebar-row-height)] shrink-0 items-center gap-2 rounded-[var(--sidebar-row-radius)] px-2 text-(--fg) transition-colors hover:bg-(--hover)"
                 title="New task"
               >
                 <SquarePen className="h-4 w-4 shrink-0 opacity-70" strokeWidth={1.6} />

--- a/frontend/src/features/shell/left-sidebar-mobile-drawer.tsx
+++ b/frontend/src/features/shell/left-sidebar-mobile-drawer.tsx
@@ -35,16 +35,16 @@ export function MobileNavigationDrawer({
         className="mobile-pwa-drawer absolute right-0 top-0 flex h-full w-full flex-col bg-(--bg) md:w-[min(22rem,88vw)] md:border-l md:border-(--border)"
       >
         <div className="mobile-pwa-drawer-header flex shrink-0 items-center justify-between gap-3 px-4">
-          <div className="min-w-0 truncate text-[22px] font-semibold tracking-[-0.01em] text-(--fg)">
+          <div className="min-w-0 truncate text-[19px] font-semibold tracking-[-0.01em] text-(--fg)">
             Local Studio
           </div>
           <button
             type="button"
             onClick={onClose}
-            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-(--surface) text-(--fg)/70 transition-colors hover:text-(--fg)"
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-(--surface) text-(--fg)/70 transition-colors hover:text-(--fg)"
             aria-label="Close navigation menu"
           >
-            <X className="h-[18px] w-[18px]" />
+            <X className="h-4 w-4" />
           </button>
         </div>
 

--- a/frontend/src/features/shell/left-sidebar-nav.test.ts
+++ b/frontend/src/features/shell/left-sidebar-nav.test.ts
@@ -42,6 +42,10 @@ describe("left sidebar navigation", () => {
     assert.match(desktopSidebar, /ChevronRight className="h-3 w-3"/);
   });
 
+  test("uses the shared compact icon scale", () => {
+    assert.match(baseStyles, /svg\.lucide\s*\{[\s\S]*scale:\s*var\(--icon-scale\)/);
+  });
+
   test("reserves the scrollbar gutter while only the thumb visibility changes", () => {
     const resting = baseStyles.match(/\.sidebar-scroller \{([\s\S]*?)\}/)?.[1] ?? "";
     const hovered = baseStyles.match(/\.sidebar-scroller:hover \{([\s\S]*?)\}/)?.[1] ?? "";

--- a/frontend/src/features/shell/left-sidebar-nav.test.ts
+++ b/frontend/src/features/shell/left-sidebar-nav.test.ts
@@ -10,11 +10,12 @@ const baseStyles = readFileSync(
 );
 
 describe("left sidebar navigation", () => {
-  test("keeps automations in the primary workspace navigation, sessions live in search", () => {
+  test("keeps models and automations in the primary workspace navigation", () => {
     assert.deepEqual(
       tabs.map((tab) => [tab.href, tab.label]),
       [
         ["/", "Status"],
+        ["/models", "Models"],
         ["/agent/automations", "Automations"],
         ["/configure", "Configure"],
         ["/usage", "Usage"],
@@ -30,6 +31,7 @@ describe("left sidebar navigation", () => {
   });
 
   test("uses destination titles on mobile", () => {
+    assert.equal(mobilePageTitle("/models"), "Models");
     assert.equal(mobilePageTitle("/agent/automations"), "Automations");
     assert.equal(mobilePageTitle("/agent/session-1"), "Tasks");
   });

--- a/frontend/src/features/shell/left-sidebar-nav.tsx
+++ b/frontend/src/features/shell/left-sidebar-nav.tsx
@@ -2,13 +2,14 @@
 
 import Link from "next/link";
 import { type ComponentType, type MouseEvent } from "react";
-import { Activity, Clock, ServerCog, TrendingUp } from "@/ui/icon-registry";
+import { Activity, Boxes, Clock, ServerCog, TrendingUp } from "@/ui/icon-registry";
 
 export type IconComponent = ComponentType<{ className?: string; strokeWidth?: number }>;
 
 // Sessions has no nav row: the Search command palette is the session list.
 export const tabs = [
   { href: "/", label: "Status", icon: Activity },
+  { href: "/models", label: "Models", icon: Boxes },
   { href: "/agent/automations", label: "Automations", icon: Clock },
   { href: "/configure", label: "Configure", icon: ServerCog },
   { href: "/usage", label: "Usage", icon: TrendingUp },

--- a/frontend/src/features/shell/left-sidebar-nav.tsx
+++ b/frontend/src/features/shell/left-sidebar-nav.tsx
@@ -64,11 +64,11 @@ export function NavItemMobile({
       href={href}
       prefetch={false}
       onClick={onClick}
-      className={`flex h-12 items-center gap-4 rounded-xl px-3 text-[17px] transition-colors ${
+      className={`flex h-11 items-center gap-3 rounded-lg px-3 text-[15px] transition-colors ${
         active ? "bg-(--active) font-medium text-(--fg)" : "text-(--fg)/80 active:bg-(--hover)"
       }`}
     >
-      <Icon className="h-[22px] w-[22px] shrink-0" strokeWidth={1.6} />
+      <Icon className="h-5 w-5 shrink-0" strokeWidth={1.6} />
       <span>{label}</span>
     </Link>
   );
@@ -90,7 +90,7 @@ export function NavItemDesktop({
       href={href}
       prefetch={false}
       title={label}
-      className={`group flex h-[var(--sidebar-row-height)] shrink-0 items-center gap-2.5 rounded-[var(--sidebar-row-radius)] px-2 transition-colors ${
+      className={`group flex h-[var(--sidebar-row-height)] shrink-0 items-center gap-2 rounded-[var(--sidebar-row-radius)] px-2 transition-colors ${
         active ? "bg-(--active) text-(--fg)" : "text-(--fg) hover:bg-(--hover)"
       }`}
     >

--- a/frontend/src/features/shell/left-sidebar.tsx
+++ b/frontend/src/features/shell/left-sidebar.tsx
@@ -31,7 +31,7 @@ import {
 
 const SIDEBAR_MIN_WIDTH = 180;
 const SIDEBAR_MAX_WIDTH = 520;
-const SIDEBAR_DEFAULT_WIDTH = 275;
+const SIDEBAR_DEFAULT_WIDTH = 260;
 
 function clampSidebarWidth(width: number): number {
   if (!Number.isFinite(width)) return SIDEBAR_DEFAULT_WIDTH;
@@ -209,7 +209,7 @@ export function LeftSidebar({ children }: { children: ReactNode }) {
               aria-expanded={mobileMenuOpen}
               aria-controls="mobile-navigation-drawer"
             >
-              <Menu className="h-[18px] w-[18px]" />
+              <Menu className="h-[17px] w-[17px]" />
             </button>
           </div>
         </div>

--- a/frontend/src/lib/theme-runtime.ts
+++ b/frontend/src/lib/theme-runtime.ts
@@ -8,6 +8,7 @@ import {
   type FontSizeId,
   type ThemeId,
   type ThemeTokens,
+  type ThemeUiTokens,
 } from "@/lib/themes";
 
 const STORE_KEY = "local-studio-state";
@@ -37,7 +38,10 @@ function lightnessFromColor(value: string): number | null {
   return ((Math.max(r, g, b) + Math.min(r, g, b)) / 2) * 100;
 }
 
-function deriveThemeUiTokens(tokens: ThemeTokens): Record<string, string> {
+function deriveThemeUiTokens(
+  tokens: ThemeTokens,
+  overrides: Partial<ThemeUiTokens> = {},
+): ThemeUiTokens {
   const isLight = (lightnessFromColor(tokens.bg) ?? 0) > 50;
   const ink = isLight ? "26, 28, 31" : "255, 255, 255";
   return {
@@ -54,12 +58,17 @@ function deriveThemeUiTokens(tokens: ThemeTokens): Record<string, string> {
     active: `rgba(${ink}, 0.08)`,
     composer: "var(--sidebar-bg)",
     "composer-footer": "var(--sidebar-bg)",
+    bubble: tokens.surface,
+    ...overrides,
   };
 }
 
 const THEME_UI_TOKENS_BY_ID = Object.fromEntries(
-  Array.from(THEME_BY_ID.entries()).map(([id, theme]) => [id, deriveThemeUiTokens(theme.tokens)]),
-) as Record<string, Record<string, string>>;
+  Array.from(THEME_BY_ID.entries()).map(([id, theme]) => [
+    id,
+    deriveThemeUiTokens(theme.tokens, theme.ui),
+  ]),
+) as Record<string, ThemeUiTokens>;
 
 const FONT_FAMILY_CSS_BY_ID = Object.fromEntries(
   Array.from(FONT_FAMILY_BY_ID.entries()).map(([id, option]) => [id, option.cssValue]),
@@ -69,9 +78,9 @@ const FONT_SIZE_CSS_BY_ID = Object.fromEntries(
   Array.from(FONT_SIZE_BY_ID.entries()).map(([id, option]) => [id, option.cssValue]),
 ) as Record<string, string>;
 
-function setThemeTokens(tokens: ThemeTokens): void {
+function setThemeTokens(tokens: ThemeTokens, ui: Partial<ThemeUiTokens> = {}): void {
   if (typeof document === "undefined") return;
-  for (const [key, value] of Object.entries({ ...tokens, ...deriveThemeUiTokens(tokens) })) {
+  for (const [key, value] of Object.entries({ ...tokens, ...deriveThemeUiTokens(tokens, ui) })) {
     document.documentElement.style.setProperty(`--${key}`, value);
   }
 }
@@ -83,7 +92,7 @@ export function applyThemeToDocument(themeId: ThemeId): ThemeId {
   if (!nextTheme) return themeId;
 
   document.documentElement.setAttribute("data-theme", nextTheme.id);
-  setThemeTokens(nextTheme.tokens);
+  setThemeTokens(nextTheme.tokens, nextTheme.ui);
   return nextTheme.id;
 }
 

--- a/frontend/src/lib/themes-data.ts
+++ b/frontend/src/lib/themes-data.ts
@@ -56,14 +56,25 @@ export interface ThemeUiTokens {
   bubble: string;
 }
 
+const THEME_FONT_FAMILY_BY_ID: Partial<Record<ThemeId, FontFamilyId>> = {
+  "chatgpt-dark": "openai",
+  "absolutely-dark": "system",
+  "raycast-dark": "system",
+  midnight: "avenir",
+  slate: "system",
+  espresso: "serif",
+  forest: "rounded",
+  "nordic-light": "avenir",
+  "solarized-dark": "system",
+  paper: "serif",
+};
+
 const createTheme = (
   id: ThemeId,
   name: string,
   description: string,
   group: string,
   tokens: ThemeTokens,
-  fontFamilyId: FontFamilyId = "geist",
-  ui?: Partial<ThemeUiTokens>,
 ): ThemeMeta => ({
   id,
   name,
@@ -71,8 +82,7 @@ const createTheme = (
   group,
   swatches: [tokens.bg, tokens.surface, tokens.accent, tokens.fg],
   tokens,
-  fontFamilyId,
-  ui,
+  fontFamilyId: THEME_FONT_FAMILY_BY_ID[id] ?? "geist",
 });
 
 // Canonical surfaces, expressed as concrete values (the bootstrap script
@@ -195,15 +205,16 @@ export const THEMES: ThemeMeta[] = [
     "Studio",
     ZAI_LIGHT,
   ),
-  createTheme(
-    "chatgpt-dark",
-    "ChatGPT Dark",
-    "ChatGPT app charcoal surfaces paired with OpenAI Sans",
-    "Reference",
-    CHATGPT_DARK,
-    "openai",
-    CHATGPT_DARK_UI,
-  ),
+  {
+    ...createTheme(
+      "chatgpt-dark",
+      "ChatGPT Dark",
+      "ChatGPT app charcoal surfaces paired with OpenAI Sans",
+      "Reference",
+      CHATGPT_DARK,
+    ),
+    ui: CHATGPT_DARK_UI,
+  },
   createTheme(
     "zai-sky",
     "Sky",
@@ -232,7 +243,6 @@ export const THEMES: ThemeMeta[] = [
     "Warm charcoal with a terracotta accent, ported from Codex",
     "Ported",
     darkTheme("#2d2d2b", "#f9f9f7", "#373735", "#cc7d5e"),
-    "system",
   ),
   createTheme(
     "raycast-dark",
@@ -240,7 +250,6 @@ export const THEMES: ThemeMeta[] = [
     "Near-black launcher tones with an electric blue accent",
     "Ported",
     darkTheme("#141414", "#ffffff", "#1e1e1e", "#4fa3f8"),
-    "system",
   ),
   createTheme(
     "midnight",
@@ -248,7 +257,6 @@ export const THEMES: ThemeMeta[] = [
     "Blue-black canvas with a soft azure accent",
     "Atmosphere",
     darkTheme("#0d1117", "#e6edf3", "#161b22", "#58a6ff"),
-    "avenir",
   ),
   createTheme(
     "slate",
@@ -256,7 +264,6 @@ export const THEMES: ThemeMeta[] = [
     "Cool graphite blues with a periwinkle accent",
     "Atmosphere",
     darkTheme("#12151a", "#e2e8f0", "#1a1f27", "#7aa2f7"),
-    "system",
   ),
   createTheme(
     "graphite",
@@ -271,7 +278,6 @@ export const THEMES: ThemeMeta[] = [
     "Roasted browns with a caramel accent",
     "Atmosphere",
     darkTheme("#1a1512", "#f2e9df", "#241d18", "#d9954a"),
-    "serif",
   ),
   createTheme(
     "forest",
@@ -279,7 +285,6 @@ export const THEMES: ThemeMeta[] = [
     "Deep evergreen with a spring-green accent",
     "Atmosphere",
     darkTheme("#0f1512", "#e8f2ec", "#18211b", "#4fd08a"),
-    "rounded",
   ),
   createTheme(
     "nordic-light",
@@ -287,7 +292,6 @@ export const THEMES: ThemeMeta[] = [
     "Cool daylight neutrals with crisp indigo controls",
     "Studio",
     lightTheme("#f4f6f8", "#20242a", "#ffffff", "#5e6ad2"),
-    "avenir",
   ),
   createTheme(
     "solarized-dark",
@@ -295,7 +299,6 @@ export const THEMES: ThemeMeta[] = [
     "Low-contrast blue-green surfaces with a cyan accent",
     "Reference",
     darkTheme("#002b36", "#eee8d5", "#073642", "#2aa198"),
-    "system",
   ),
   createTheme(
     "paper",
@@ -303,6 +306,5 @@ export const THEMES: ThemeMeta[] = [
     "Warm paper white with a burnt-sienna accent",
     "Studio",
     lightTheme("#faf8f2", "#2a2723", "#ffffff", "#b05f2d"),
-    "serif",
   ),
 ];

--- a/frontend/src/lib/themes-data.ts
+++ b/frontend/src/lib/themes-data.ts
@@ -1,16 +1,7 @@
-// Theme catalogue.
-//
-// Six themes total: two canonical (Light / Dark) plus four dark accent
-// variants (Sky, Violet, Emerald, Rose). The full surface system lives in
-// `src/app/styles/globals/tokens.css` keyed on `data-theme`/`.theme-zai-*`
-// selectors; the `ThemeTokens` here are the minimal set the runtime bootstrap
-// (`theme-runtime.ts`) writes inline so the picker previews correctly. They
-// resolve to the same workbench values, so picking a theme never fights the token
-// system.
-
 export type ThemeId =
   | "zai-light"
   | "zai-dark"
+  | "chatgpt-dark"
   | "zai-sky"
   | "zai-violet"
   | "zai-emerald"
@@ -22,7 +13,11 @@ export type ThemeId =
   | "graphite"
   | "espresso"
   | "forest"
+  | "nordic-light"
+  | "solarized-dark"
   | "paper";
+
+export type FontFamilyId = "openai" | "geist" | "system" | "avenir" | "serif" | "mono" | "rounded";
 
 export interface ThemeTokens {
   bg: string;
@@ -44,6 +39,21 @@ export interface ThemeMeta {
   group: string;
   swatches: [string, string, string, string];
   tokens: ThemeTokens;
+  fontFamilyId: FontFamilyId;
+  ui?: Partial<ThemeUiTokens>;
+}
+
+export interface ThemeUiTokens {
+  "surface-2": string;
+  "surface-3": string;
+  rail: string;
+  border: string;
+  separator: string;
+  hover: string;
+  active: string;
+  composer: string;
+  "composer-footer": string;
+  bubble: string;
 }
 
 const createTheme = (
@@ -52,6 +62,8 @@ const createTheme = (
   description: string,
   group: string,
   tokens: ThemeTokens,
+  fontFamilyId: FontFamilyId = "geist",
+  ui?: Partial<ThemeUiTokens>,
 ): ThemeMeta => ({
   id,
   name,
@@ -59,6 +71,8 @@ const createTheme = (
   group,
   swatches: [tokens.bg, tokens.surface, tokens.accent, tokens.fg],
   tokens,
+  fontFamilyId,
+  ui,
 });
 
 // Canonical surfaces, expressed as concrete values (the bootstrap script
@@ -88,6 +102,32 @@ const ZAI_DARK: ThemeTokens = {
   hl2: "#ffffff80",
   hl3: "#8f8f8f",
   err: "#ff6764",
+};
+
+const CHATGPT_DARK: ThemeTokens = {
+  bg: "#212121",
+  fg: "#ececec",
+  dim: "#b4b4b4",
+  border: "#ffffff1a",
+  surface: "#2f2f2f",
+  accent: "#ffffff",
+  hl1: "#b4b4b4",
+  hl2: "#8f8f8f",
+  hl3: "#676767",
+  err: "#ff6764",
+};
+
+const CHATGPT_DARK_UI: Partial<ThemeUiTokens> = {
+  "surface-2": "#2f2f2f",
+  "surface-3": "#303030",
+  rail: "#171717",
+  border: "#ffffff1a",
+  separator: "#ffffff0d",
+  hover: "#2f2f2f",
+  active: "#2f2f2f",
+  composer: "#303030",
+  "composer-footer": "#212121",
+  bubble: "#303030",
 };
 
 // Accent variants keep the canonical dark surfaces; only the brand
@@ -156,6 +196,15 @@ export const THEMES: ThemeMeta[] = [
     ZAI_LIGHT,
   ),
   createTheme(
+    "chatgpt-dark",
+    "ChatGPT Dark",
+    "ChatGPT app charcoal surfaces paired with OpenAI Sans",
+    "Reference",
+    CHATGPT_DARK,
+    "openai",
+    CHATGPT_DARK_UI,
+  ),
+  createTheme(
     "zai-sky",
     "Sky",
     "Dark with a sky-blue brand accent",
@@ -183,6 +232,7 @@ export const THEMES: ThemeMeta[] = [
     "Warm charcoal with a terracotta accent, ported from Codex",
     "Ported",
     darkTheme("#2d2d2b", "#f9f9f7", "#373735", "#cc7d5e"),
+    "system",
   ),
   createTheme(
     "raycast-dark",
@@ -190,6 +240,7 @@ export const THEMES: ThemeMeta[] = [
     "Near-black launcher tones with an electric blue accent",
     "Ported",
     darkTheme("#141414", "#ffffff", "#1e1e1e", "#4fa3f8"),
+    "system",
   ),
   createTheme(
     "midnight",
@@ -197,6 +248,7 @@ export const THEMES: ThemeMeta[] = [
     "Blue-black canvas with a soft azure accent",
     "Atmosphere",
     darkTheme("#0d1117", "#e6edf3", "#161b22", "#58a6ff"),
+    "avenir",
   ),
   createTheme(
     "slate",
@@ -204,6 +256,7 @@ export const THEMES: ThemeMeta[] = [
     "Cool graphite blues with a periwinkle accent",
     "Atmosphere",
     darkTheme("#12151a", "#e2e8f0", "#1a1f27", "#7aa2f7"),
+    "system",
   ),
   createTheme(
     "graphite",
@@ -218,6 +271,7 @@ export const THEMES: ThemeMeta[] = [
     "Roasted browns with a caramel accent",
     "Atmosphere",
     darkTheme("#1a1512", "#f2e9df", "#241d18", "#d9954a"),
+    "serif",
   ),
   createTheme(
     "forest",
@@ -225,6 +279,23 @@ export const THEMES: ThemeMeta[] = [
     "Deep evergreen with a spring-green accent",
     "Atmosphere",
     darkTheme("#0f1512", "#e8f2ec", "#18211b", "#4fd08a"),
+    "rounded",
+  ),
+  createTheme(
+    "nordic-light",
+    "Nordic Light",
+    "Cool daylight neutrals with crisp indigo controls",
+    "Studio",
+    lightTheme("#f4f6f8", "#20242a", "#ffffff", "#5e6ad2"),
+    "avenir",
+  ),
+  createTheme(
+    "solarized-dark",
+    "Solarized Dark",
+    "Low-contrast blue-green surfaces with a cyan accent",
+    "Reference",
+    darkTheme("#002b36", "#eee8d5", "#073642", "#2aa198"),
+    "system",
   ),
   createTheme(
     "paper",
@@ -232,5 +303,6 @@ export const THEMES: ThemeMeta[] = [
     "Warm paper white with a burnt-sienna accent",
     "Studio",
     lightTheme("#faf8f2", "#2a2723", "#ffffff", "#b05f2d"),
+    "serif",
   ),
 ];

--- a/frontend/src/lib/themes.test.ts
+++ b/frontend/src/lib/themes.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { FONT_FAMILY_BY_ID, THEMES, THEME_BY_ID } from "./themes";
+
+describe("theme catalogue", () => {
+  test("keeps theme identifiers unique", () => {
+    assert.equal(new Set(THEMES.map((theme) => theme.id)).size, THEMES.length);
+  });
+
+  test("matches the ChatGPT app dark palette and typography", () => {
+    const theme = THEME_BY_ID.get("chatgpt-dark");
+    assert.ok(theme);
+    assert.equal(theme.fontFamilyId, "openai");
+    assert.equal(theme.tokens.bg, "#212121");
+    assert.equal(theme.tokens.fg, "#ececec");
+    assert.equal(theme.tokens.surface, "#2f2f2f");
+    assert.equal(theme.ui?.rail, "#171717");
+    assert.equal(theme.ui?.["surface-3"], "#303030");
+    assert.equal(theme.ui?.composer, "#303030");
+  });
+
+  test("provides every theme font in the typography picker", () => {
+    for (const theme of THEMES) assert.ok(FONT_FAMILY_BY_ID.has(theme.fontFamilyId));
+  });
+});

--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -1,11 +1,10 @@
 // Theme catalogue data lives in themes-data.ts; this module exposes the lookup
 // maps and font options the UI consumes.
-import { THEMES, type ThemeId, type ThemeMeta } from "./themes-data";
+import { THEMES, type FontFamilyId, type ThemeId, type ThemeMeta } from "./themes-data";
 
-export type { ThemeId, ThemeTokens, ThemeMeta } from "./themes-data";
+export type { FontFamilyId, ThemeId, ThemeMeta, ThemeTokens, ThemeUiTokens } from "./themes-data";
 export { THEMES } from "./themes-data";
 
-export type FontFamilyId = "geist" | "system" | "serif" | "mono" | "rounded";
 export type FontSizeId = "sm" | "md" | "lg" | "xl" | "2xl";
 
 export interface FontFamilyOption {
@@ -25,14 +24,24 @@ export const DEFAULT_FONT_SIZE_ID: FontSizeId = "md";
 
 export const FONT_FAMILY_OPTIONS: FontFamilyOption[] = [
   {
+    id: "openai",
+    label: "OpenAI Sans",
+    cssValue: "'OpenAI Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif",
+  },
+  {
     id: "geist",
     label: "Geist",
-    cssValue: "var(--font-geist-sans), system-ui, sans-serif",
+    cssValue: "var(--font-geist-sans, 'Geist'), system-ui, sans-serif",
   },
   {
     id: "system",
     label: "System UI",
     cssValue: "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+  },
+  {
+    id: "avenir",
+    label: "Avenir",
+    cssValue: "'Avenir Next', Avenir, system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
   },
   {
     id: "serif",

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -7,6 +7,7 @@ import {
 import {
   DEFAULT_FONT_FAMILY_ID,
   DEFAULT_FONT_SIZE_ID,
+  THEME_BY_ID,
   type FontFamilyId,
   type FontSizeId,
   type ThemeId,
@@ -83,7 +84,14 @@ const createThemeSlice: StateCreator<ThemeSlice, [], [], ThemeSlice> = (set) => 
   fontSizeId: DEFAULT_FONT_SIZE_ID,
   setThemeId: (themeId: ThemeId) => {
     const appliedThemeId = applyThemeToDocument(themeId);
-    set({ themeId: appliedThemeId });
+    const preferredFontFamilyId = THEME_BY_ID.get(appliedThemeId)?.fontFamilyId;
+    const appliedFontFamilyId = preferredFontFamilyId
+      ? applyFontFamilyToDocument(preferredFontFamilyId)
+      : undefined;
+    set({
+      themeId: appliedThemeId,
+      ...(appliedFontFamilyId ? { fontFamilyId: appliedFontFamilyId } : {}),
+    });
   },
   setFontFamilyId: (fontFamilyId: FontFamilyId) => {
     const appliedFontFamilyId = applyFontFamilyToDocument(fontFamilyId);

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -56,7 +56,7 @@ const createAppSlice: StateCreator<AppSlice, [], [], AppSlice> = (set) => ({
     }),
   toggleSidebarMobileOpen: () =>
     set((state) => ({ sidebar: { ...state.sidebar, mobileOpen: !state.sidebar.mobileOpen } })),
-  sidebarWidth: 275,
+  sidebarWidth: 260,
   setSidebarWidth: (sidebarWidth) => set({ sidebarWidth }),
   fileViewerFontSize: 12,
   setFileViewerFontSize: (fileViewerFontSize) => set({ fileViewerFontSize }),
@@ -151,11 +151,12 @@ export const useAppStore = create<AppStore>()(
           ...current,
           ...persistedStore,
           sidebarWidth:
+            persistedRecord.sidebarWidth === 275 ||
             persistedRecord.sidebarWidth === 240 ||
             persistedRecord.sidebarWidth === 220 ||
             persistedRecord.sidebarWidth === 224 ||
             persistedRecord.sidebarWidth === 204
-              ? 275
+              ? 260
               : (persistedStore.sidebarWidth ?? current.sidebarWidth),
           sidebar: {
             ...current.sidebar,

--- a/frontend/src/ui/list.tsx
+++ b/frontend/src/ui/list.tsx
@@ -28,7 +28,7 @@ export function ListRow({
 
   if (variant === "resource") {
     return (
-      <div className={cx("px-3 py-3 transition-colors hover:bg-(--ui-hover)/30", className)}>
+      <div className={cx("px-3 py-2.5 transition-colors hover:bg-(--ui-hover)/30", className)}>
         <div className="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
           <div className="min-w-0 space-y-1">
             <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
@@ -64,7 +64,7 @@ export function ListRow({
 
   return (
     <div
-      className={cx("rounded-md px-2 py-2.5 transition-colors hover:bg-(--ui-hover)/30", className)}
+      className={cx("rounded-md px-2 py-2 transition-colors hover:bg-(--ui-hover)/30", className)}
     >
       <div className="grid min-h-7 grid-cols-1 gap-1.5 md:grid-cols-[minmax(168px,0.3fr)_minmax(0,1fr)] md:items-center md:gap-4">
         <div className="min-w-0">

--- a/frontend/src/ui/page.tsx
+++ b/frontend/src/ui/page.tsx
@@ -46,7 +46,7 @@ export function PageContainer({
   return (
     <div
       className={cx(
-        "mx-auto w-full px-4 pt-4 pb-[calc(2rem+env(safe-area-inset-bottom))] sm:px-6 sm:pt-6",
+        "mx-auto w-full px-4 pt-4 pb-[calc(2rem+env(safe-area-inset-bottom))] sm:px-6 sm:pt-5",
         pageWidthClasses[width],
         className,
       )}
@@ -70,7 +70,7 @@ export function PageHeader({
   actions?: ReactNode;
 }) {
   return (
-    <div className="mb-5 flex min-h-8 items-center justify-between gap-3">
+    <div className="mb-4 flex min-h-8 items-center justify-between gap-3">
       <div className="min-w-0">
         {eyebrow ? (
           <div className="text-[length:var(--fs-xs)] uppercase tracking-[0.14em] text-(--ui-muted)">
@@ -116,7 +116,7 @@ export function SectionNav<Id extends string = string>({
               type="button"
               onClick={() => onSelectItem(item.id)}
               className={cx(
-                "group grid h-9 max-w-[calc(50%_-_0.125rem)] min-w-0 grid-cols-[18px_minmax(0,1fr)] items-center gap-2 rounded-[10px] px-2 text-left text-[length:var(--fs-base)] transition-[transform,color,background-color] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--ui-accent)/35 active:scale-[0.99] sm:max-w-none lg:w-full",
+                "group grid h-8 max-w-[calc(50%_-_0.125rem)] min-w-0 grid-cols-[16px_minmax(0,1fr)] items-center gap-2 rounded-[8px] px-2 text-left text-[length:var(--fs-md)] transition-[transform,color,background-color] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--ui-accent)/35 active:scale-[0.99] sm:max-w-none lg:w-full",
                 active
                   ? "bg-(--ui-active) text-(--ui-fg)"
                   : "text-(--ui-muted) hover:bg-(--ui-hover)/70 hover:text-(--ui-fg)",
@@ -125,7 +125,7 @@ export function SectionNav<Id extends string = string>({
             >
               <span
                 className={cx(
-                  "flex h-4 w-4 items-center justify-center text-(--ui-muted)",
+                  "flex h-3.5 w-3.5 items-center justify-center text-(--ui-muted)",
                   active ? "opacity-100" : "opacity-70 group-hover:opacity-100",
                 )}
               >


### PR DESCRIPTION
## Summary
- restore Models as a first-class main navigation destination and dedicated route
- add paired color and font presets, including a ChatGPT Dark theme with the app palette and OpenAI Sans
- reduce global icon scale and tighten sidebar, mobile drawer, page, and settings density

## Validation
- npm run check
- packaged and installed Local Studio Dev.app
- installed bundle `/api/desktop-health` passed
- installed `/models` route stayed first-class and active
- installed ChatGPT Dark tokens and OpenAI Sans font load verified