### PR TITLE
fix: tighten sidebar and stabilize desktop navigation

### DIFF
--- a/frontend/desktop/logic/update-manager.ts
+++ b/frontend/desktop/logic/update-manager.ts
@@ -14,6 +14,13 @@ function setUpdateState(nextState: DesktopUpdateSnapshot): void {
   latestUpdateState = nextState;
 }
 
+function setUpdateError(error: unknown): void {
+  installIntent.clear();
+  const message = String(error);
+  setUpdateState({ status: "error", message });
+  log.error(`Auto update error: ${message}`);
+}
+
 function resolveFeedUrl(): string | null {
   const raw = process.env.LOCAL_STUDIO_UPDATE_URL?.trim();
   if (!raw) return null;
@@ -100,7 +107,7 @@ export async function checkForUpdates(force = false): Promise<DesktopUpdateSnaps
     setUpdateState({ status: "checking" });
     autoUpdater.allowPrerelease = false;
     const result = await autoUpdater.checkForUpdates();
-    if (result?.downloadPromise) void result.downloadPromise.catch(() => undefined);
+    if (result?.downloadPromise) void result.downloadPromise.catch(setUpdateError);
     // An unpackaged app resolves null without emitting any status event; leave
     // "checking" behind and the renderer would poll forever.
     if (!result && latestUpdateState.status === "checking") {
@@ -174,7 +181,9 @@ export function initializeAutoUpdates(): void {
   autoUpdater.on("download-progress", (progress) => {
     setUpdateState({
       status: "downloading",
+      version: latestUpdateState.version,
       message: `${progress.percent.toFixed(1)}%`,
+      progress: progress.percent,
     });
   });
 
@@ -188,9 +197,7 @@ export function initializeAutoUpdates(): void {
   });
 
   autoUpdater.on("error", (error) => {
-    installIntent.clear();
-    setUpdateState({ status: "error", message: String(error) });
-    log.error(`Auto update error: ${String(error)}`);
+    setUpdateError(error);
   });
 
   if (app.isPackaged) {

--- a/frontend/desktop/types.ts
+++ b/frontend/desktop/types.ts
@@ -17,4 +17,5 @@ export interface DesktopUpdateSnapshot {
     | "error";
   version?: string;
   message?: string;
+  progress?: number;
 }

--- a/frontend/src/desktop-bridge.d.ts
+++ b/frontend/src/desktop-bridge.d.ts
@@ -9,8 +9,18 @@ interface Window {
       packaged: boolean;
       releaseChannel: "dev" | "stable";
     }>;
-    getUpdateStatus?(): Promise<{ status: string; version?: string; message?: string }>;
-    startUpdate?(): Promise<{ status: string; version?: string; message?: string }>;
+    getUpdateStatus?(): Promise<{
+      status: string;
+      version?: string;
+      message?: string;
+      progress?: number;
+    }>;
+    startUpdate?(): Promise<{
+      status: string;
+      version?: string;
+      message?: string;
+      progress?: number;
+    }>;
     getKittylitterPairingJson?(): Promise<import("../desktop/interfaces").KittylitterPairingResult>;
     copyKittylitterPairingJson?(pairingJson: string): Promise<{
       ok: boolean;

--- a/frontend/src/features/agent/ui/agent-workspace-navigation.ts
+++ b/frontend/src/features/agent/ui/agent-workspace-navigation.ts
@@ -67,7 +67,10 @@ export function workspaceNavigationAction(
     ...(sessionTitle ? { sessionTitle } : {}),
     newSession: params.newParam !== null,
     split: params.splitParam === "1",
-    replaceWorkspace: params.replaceParam === "1",
+    replaceWorkspace:
+      params.replaceParam === "1" ||
+      params.newParam !== null ||
+      (params.sessionId !== null && params.splitParam !== "1"),
     paneId: newPaneId(),
     tab,
   };

--- a/frontend/src/features/agent/workspace/pane-controller.ts
+++ b/frontend/src/features/agent/workspace/pane-controller.ts
@@ -68,14 +68,34 @@ export function claimCanonicalSession(state: WorkspaceState, canonical: Session)
       )
       .map(([id]) => id),
   );
-  if (duplicateIds.size === 0) return state;
   const sessions = new Map(state.sessions);
   for (const id of duplicateIds) sessions.delete(id);
   const panesById = new Map(state.panesById);
   for (const [paneId, pane] of panesById) {
     if (duplicateIds.has(pane.sessionId)) panesById.set(paneId, { sessionId: canonical.id });
   }
-  return { ...state, sessions, panesById };
+  const canonicalPanes = [...panesById]
+    .filter(([, pane]) => pane.sessionId === canonical.id)
+    .map(([paneId]) => paneId);
+  if (duplicateIds.size === 0 && canonicalPanes.length <= 1) return state;
+  if (canonicalPanes.length <= 1) return { ...state, sessions, panesById };
+  const keptPaneId = canonicalPanes.includes(state.focusedPaneId)
+    ? state.focusedPaneId
+    : canonicalPanes[0];
+  const nextPanes = new Map(panesById);
+  let layout = state.layout;
+  for (const paneId of canonicalPanes) {
+    if (paneId === keptPaneId) continue;
+    nextPanes.delete(paneId);
+    layout = removeLeaf(layout, paneId) ?? layout;
+  }
+  return {
+    ...state,
+    sessions,
+    panesById: nextPanes,
+    layout,
+    focusedPaneId: keptPaneId,
+  };
 }
 
 function focusExistingSession(

--- a/frontend/src/features/settings/app-version-section.tsx
+++ b/frontend/src/features/settings/app-version-section.tsx
@@ -8,13 +8,16 @@ import { useAppUpdate } from "@/features/shell/use-app-update";
 export function AppVersionSection() {
   const update = useAppUpdate();
   const devChannel = update.releaseChannel === "dev";
+  const progress = update.progress === null ? null : Math.round(update.progress);
   const onLatest = update.currentVersion && update.latestVersion && !update.updateAvailable;
   const description = devChannel
     ? "Dev builds update through the local installer."
     : update.updateAvailable
       ? update.phase === "ready"
         ? `v${update.latestVersion} is downloaded — restart to finish updating.`
-        : `v${update.latestVersion} is available on GitHub.`
+        : update.status === "downloading"
+          ? `Downloading v${update.latestVersion}${progress === null ? "." : ` — ${progress}%.`}`
+          : `v${update.latestVersion} is available on GitHub.`
       : onLatest
         ? "You are on the latest version."
         : update.latestVersion
@@ -33,18 +36,22 @@ export function AppVersionSection() {
         actions={
           update.updateAvailable ? (
             <SettingsButton onClick={update.startUpdate} tone="primary">
-              {update.phase === "working" ? (
+              {update.status === "checking" ? (
                 <Spinner size="xs" />
               ) : update.phase === "ready" ? (
                 <RefreshCw className="h-3 w-3" />
               ) : (
                 <Download className="h-3 w-3" />
               )}
-              {update.phase === "working"
-                ? "Updating…"
-                : update.phase === "ready"
-                  ? "Restart to update"
-                  : "Update"}
+              {update.status === "checking"
+                ? "Checking…"
+                : update.status === "downloading"
+                  ? progress === null
+                    ? "Downloading…"
+                    : `Downloading ${progress}%`
+                  : update.phase === "ready"
+                    ? "Restart to update"
+                    : "Update"}
             </SettingsButton>
           ) : undefined
         }

--- a/frontend/src/features/shell/left-sidebar.tsx
+++ b/frontend/src/features/shell/left-sidebar.tsx
@@ -11,7 +11,7 @@ import {
 } from "react";
 import { Menu } from "@/ui/icon-registry";
 import { useShallow } from "zustand/react/shallow";
-import { useAppStore } from "@/store";
+import { DEFAULT_SIDEBAR_WIDTH, useAppStore } from "@/store";
 import { useMountSubscription } from "@/hooks/use-mount-subscription";
 import { useOpenSessions } from "@/features/agent/ui/use-open-sessions";
 import { hrefWithOpenNonce } from "@/features/agent/ui/projects-nav/helpers";
@@ -31,10 +31,8 @@ import {
 
 const SIDEBAR_MIN_WIDTH = 180;
 const SIDEBAR_MAX_WIDTH = 520;
-const SIDEBAR_DEFAULT_WIDTH = 260;
-
 function clampSidebarWidth(width: number): number {
-  if (!Number.isFinite(width)) return SIDEBAR_DEFAULT_WIDTH;
+  if (!Number.isFinite(width)) return DEFAULT_SIDEBAR_WIDTH;
   return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, Math.round(width)));
 }
 

--- a/frontend/src/features/shell/profile-footer.tsx
+++ b/frontend/src/features/shell/profile-footer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Download, Settings, Smartphone } from "@/ui/icon-registry";
+import { Download, RefreshCw, Settings, Smartphone } from "@/ui/icon-registry";
 import { Spinner } from "@/ui";
 import { ProfileAvatar, useLocalProfile } from "@/features/shell/local-profile";
 import { useAppUpdate } from "@/features/shell/use-app-update";
@@ -9,12 +9,15 @@ import { useAppUpdate } from "@/features/shell/use-app-update";
 function UpdateButton() {
   const update = useAppUpdate();
   if (!update.updateAvailable) return null;
+  const progress = update.progress === null ? null : Math.round(update.progress);
   const label =
     update.phase === "ready"
       ? `Restart to update to v${update.latestVersion}`
-      : update.phase === "working"
-        ? `Updating to v${update.latestVersion}…`
-        : `Update to v${update.latestVersion}`;
+      : update.status === "downloading"
+        ? `Downloading v${update.latestVersion}${progress === null ? "" : ` — ${progress}%`}`
+        : update.status === "checking"
+          ? `Checking for v${update.latestVersion}…`
+          : `Update to v${update.latestVersion}`;
   return (
     <button
       type="button"
@@ -23,8 +26,12 @@ function UpdateButton() {
       aria-label={label}
       className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[var(--sidebar-row-radius)] text-(--color-primary) transition-colors hover:bg-(--hover) hover:text-(--fg)"
     >
-      {update.phase === "working" ? (
+      {update.status === "checking" ? (
         <Spinner size="xs" />
+      ) : update.status === "downloading" && progress !== null ? (
+        <span className="text-[8px] font-medium tabular-nums">{progress}%</span>
+      ) : update.phase === "ready" ? (
+        <RefreshCw className="h-3.5 w-3.5" strokeWidth={1.75} />
       ) : (
         <Download className="h-3.5 w-3.5" strokeWidth={1.75} />
       )}

--- a/frontend/src/features/shell/use-app-update.ts
+++ b/frontend/src/features/shell/use-app-update.ts
@@ -4,6 +4,14 @@ import { useCallback, useRef, useState } from "react";
 import { useMountSubscription } from "@/hooks/use-mount-subscription";
 
 export type AppUpdatePhase = "idle" | "working" | "ready" | "failed";
+export type AppUpdateStatus =
+  | "idle"
+  | "checking"
+  | "available"
+  | "not-available"
+  | "downloading"
+  | "downloaded"
+  | "error";
 
 export type AppUpdate = {
   currentVersion: string | null;
@@ -11,6 +19,8 @@ export type AppUpdate = {
   latestVersion: string | null;
   updateAvailable: boolean;
   phase: AppUpdatePhase;
+  status: AppUpdateStatus;
+  progress: number | null;
   startUpdate: () => void;
 };
 
@@ -48,11 +58,36 @@ function phaseForStatus(status: string): AppUpdatePhase {
   return "idle";
 }
 
+function normalizedStatus(status: string): AppUpdateStatus {
+  if (
+    status === "checking" ||
+    status === "available" ||
+    status === "not-available" ||
+    status === "downloading" ||
+    status === "downloaded" ||
+    status === "error"
+  ) {
+    return status;
+  }
+  return "idle";
+}
+
+function snapshotProgress(snapshot: { progress?: number; message?: string }): number | null {
+  const parsed =
+    typeof snapshot.progress === "number"
+      ? snapshot.progress
+      : Number.parseFloat(snapshot.message ?? "");
+  if (!Number.isFinite(parsed)) return null;
+  return Math.min(100, Math.max(0, parsed));
+}
+
 export function useAppUpdate(): AppUpdate {
   const [currentVersion, setCurrentVersion] = useState<string | null>(null);
   const [releaseChannel, setReleaseChannel] = useState<"dev" | "stable" | null>(null);
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
   const [phase, setPhase] = useState<AppUpdatePhase>("idle");
+  const [status, setStatus] = useState<AppUpdateStatus>("idle");
+  const [progress, setProgress] = useState<number | null>(null);
   const pollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const syncDesktopPhase = useCallback(() => {
@@ -60,14 +95,22 @@ export function useAppUpdate(): AppUpdate {
     if (!getStatus) return;
     void getStatus().then(
       (snapshot) => {
-        const next = phaseForStatus(snapshot.status);
+        const nextStatus = normalizedStatus(snapshot.status);
+        const next = phaseForStatus(nextStatus);
+        setStatus(nextStatus);
         setPhase(next);
+        setProgress(nextStatus === "downloading" ? snapshotProgress(snapshot) : null);
+        if (snapshot.version) setLatestVersion(snapshot.version);
         if (next === "working") {
           if (pollTimer.current) clearTimeout(pollTimer.current);
           pollTimer.current = setTimeout(syncDesktopPhase, 2_000);
         }
       },
-      () => setPhase("failed"),
+      () => {
+        setStatus("error");
+        setPhase("failed");
+        setProgress(null);
+      },
     );
   }, []);
 
@@ -100,11 +143,18 @@ export function useAppUpdate(): AppUpdate {
   const startUpdate = useCallback(() => {
     const desktop = bridge();
     if (!desktop.startUpdate) {
+      setStatus("error");
       setPhase("failed");
       return;
     }
+    setStatus("checking");
     setPhase("working");
-    void desktop.startUpdate().then(syncDesktopPhase, () => setPhase("failed"));
+    setProgress(null);
+    void desktop.startUpdate().then(syncDesktopPhase, () => {
+      setStatus("error");
+      setPhase("failed");
+      setProgress(null);
+    });
   }, [syncDesktopPhase]);
 
   return {
@@ -113,6 +163,8 @@ export function useAppUpdate(): AppUpdate {
     latestVersion,
     updateAvailable,
     phase,
+    status,
+    progress,
     startUpdate,
   };
 }

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -40,6 +40,15 @@ export interface AppSlice {
   setLastOpenFileByProject: (cwd: string, rel: string) => void;
 }
 
+export const DEFAULT_SIDEBAR_WIDTH = 224;
+
+const LEGACY_DEFAULT_SIDEBAR_WIDTHS = new Set([204, 220, 224, 240, 260, 275]);
+
+function restoredSidebarWidth(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return LEGACY_DEFAULT_SIDEBAR_WIDTHS.has(value) ? DEFAULT_SIDEBAR_WIDTH : value;
+}
+
 const createAppSlice: StateCreator<AppSlice, [], [], AppSlice> = (set) => ({
   sidebar: { collapsed: false, mobileOpen: false },
   setSidebarCollapsed: (collapsed) =>
@@ -56,7 +65,7 @@ const createAppSlice: StateCreator<AppSlice, [], [], AppSlice> = (set) => ({
     }),
   toggleSidebarMobileOpen: () =>
     set((state) => ({ sidebar: { ...state.sidebar, mobileOpen: !state.sidebar.mobileOpen } })),
-  sidebarWidth: 260,
+  sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
   setSidebarWidth: (sidebarWidth) => set({ sidebarWidth }),
   fileViewerFontSize: 12,
   setFileViewerFontSize: (fileViewerFontSize) => set({ fileViewerFontSize }),
@@ -150,14 +159,7 @@ export const useAppStore = create<AppStore>()(
         return {
           ...current,
           ...persistedStore,
-          sidebarWidth:
-            persistedRecord.sidebarWidth === 275 ||
-            persistedRecord.sidebarWidth === 240 ||
-            persistedRecord.sidebarWidth === 220 ||
-            persistedRecord.sidebarWidth === 224 ||
-            persistedRecord.sidebarWidth === 204
-              ? 260
-              : (persistedStore.sidebarWidth ?? current.sidebarWidth),
+          sidebarWidth: restoredSidebarWidth(persistedRecord.sidebarWidth, current.sidebarWidth),
           sidebar: {
             ...current.sidebar,
             collapsed: persistedRecord.sidebarCollapsed === true,

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -133,9 +133,21 @@ const createAppStoreImpl: StateCreator<AppStore, [], [], AppStore> = (set, ...ar
   setMobileNavOpen: (mobileNavOpen) => set({ mobileNavOpen }),
 });
 
-const storage = createJSONStorage(() =>
+let appStorePersistenceReady = false;
+
+const baseStorage = createJSONStorage(() =>
   typeof window !== "undefined" ? localStorage : (undefined as unknown as Storage),
 );
+
+const storage = baseStorage
+  ? {
+      ...baseStorage,
+      setItem: (...args: Parameters<typeof baseStorage.setItem>) =>
+        appStorePersistenceReady ? baseStorage.setItem(...args) : undefined,
+      removeItem: (...args: Parameters<typeof baseStorage.removeItem>) =>
+        appStorePersistenceReady ? baseStorage.removeItem(...args) : undefined,
+    }
+  : undefined;
 
 export const useAppStore = create<AppStore>()(
   devtools(
@@ -179,10 +191,14 @@ export const useAppStore = create<AppStore>()(
 
 if (typeof window !== "undefined") {
   void (async () => {
-    await hydrateDurableUiPreferences();
-    await useAppStore.persist.rehydrate();
-    scheduleDurableUiPreferencesSave();
-    useAppStore.subscribe(() => scheduleDurableUiPreferencesSave());
+    try {
+      await hydrateDurableUiPreferences();
+      await useAppStore.persist.rehydrate();
+    } finally {
+      appStorePersistenceReady = true;
+      scheduleDurableUiPreferencesSave();
+      useAppStore.subscribe(() => scheduleDurableUiPreferencesSave());
+    }
   })();
 }
 


### PR DESCRIPTION
## Summary
- narrow the default sidebar and migrate legacy default widths
- show download progress and surface updater failures
- keep session and new-task navigation single-pane and collapse canonical duplicates

## Validation
- npm run check
- production UI in Electron: legacy 260px width renders at 224px
- five rapid session/new/back cycles remained one pane and one session

No tests were added or run.