### PR TITLE
fix(agent): make Gmail OAuth work for consumer accounts

### DIFF
--- a/frontend/src/features/integrations/google-account-modal.tsx
+++ b/frontend/src/features/integrations/google-account-modal.tsx
@@ -251,9 +251,9 @@ export function GoogleAccountModal({
       />
       <div className="space-y-5 px-6 py-5">
         <Alert variant="info">
-          Google&apos;s first-party Workspace MCP is in developer preview. Add a Desktop OAuth
-          client once; Local Studio encrypts it with the desktop keychain and exposes only declared
-          read-only tools.
+          {accountId === "gmail"
+            ? "Gmail uses Google’s stable API with read-only access. Add a Desktop OAuth client once; Local Studio encrypts its secret with the desktop keychain."
+            : "Google’s first-party Workspace MCP is in developer preview. Add a Desktop OAuth client once; Local Studio encrypts its secret with the desktop keychain and exposes only declared read-only tools."}
         </Alert>
         {content}
         {error && account ? <Alert variant="error">{error}</Alert> : null}

--- a/frontend/src/features/integrations/google-account-setup.tsx
+++ b/frontend/src/features/integrations/google-account-setup.tsx
@@ -5,6 +5,12 @@ import { Alert, Button, FormField, Input } from "@/ui";
 import { ExternalLink } from "@/ui/icon-registry";
 import { openExternal } from "./google-account-model";
 
+function clientSecretDescription(hasStoredSecret: boolean, needsClientSecret: boolean): string {
+  return hasStoredSecret && !needsClientSecret
+    ? "Leave blank to keep the securely stored secret."
+    : "Required by Google Desktop OAuth and stored with the desktop keychain.";
+}
+
 export function GoogleAccountSetup({
   account,
   editing,
@@ -35,6 +41,8 @@ export function GoogleAccountSetup({
   onConnect: () => void;
 }) {
   const needsClient = !account.configured || editing;
+  const needsClientSecret =
+    !account.hasClientSecret || clientId.trim() !== (account.clientId ?? "").trim();
   return (
     <div className="space-y-4">
       {needsClient ? (
@@ -52,7 +60,11 @@ export function GoogleAccountSetup({
               spellCheck={false}
             />
           </FormField>
-          <FormField label="OAuth client secret" description="Optional for some desktop clients.">
+          <FormField
+            label="OAuth client secret"
+            required={needsClientSecret}
+            description={clientSecretDescription(account.hasClientSecret, needsClientSecret)}
+          >
             <Input
               type="password"
               value={clientSecret}
@@ -113,7 +125,10 @@ export function GoogleAccountSetup({
           <Button
             onClick={onConnect}
             loading={busy && !awaiting}
-            disabled={awaiting || (needsClient && !clientId.trim())}
+            disabled={
+              awaiting ||
+              (needsClient && (!clientId.trim() || (needsClientSecret && !clientSecret.trim())))
+            }
           >
             {awaiting
               ? "Waiting for Google"

--- a/frontend/src/features/integrations/google-account-setup.tsx
+++ b/frontend/src/features/integrations/google-account-setup.tsx
@@ -42,7 +42,7 @@ export function GoogleAccountSetup({
           <FormField
             label="OAuth client ID"
             required
-            description="Use a Google Desktop OAuth client with the Workspace MCP APIs enabled."
+            description="Use a Google Desktop OAuth client with the required Google APIs enabled."
           >
             <Input
               value={clientId}

--- a/services/agent-runtime/src/connector-pool.ts
+++ b/services/agent-runtime/src/connector-pool.ts
@@ -1,6 +1,8 @@
 import { connectMcp, type McpConnection, type McpToolInfo } from "./mcp-client";
 import { connectorAuthorizationHeaders } from "./connector-auth";
 import { listConnectors, type ConnectorConfig } from "./connectors-service";
+import { connectGmailApi } from "./gmail-api-mcp";
+import { googleWorkspaceConnectorAccount } from "./google-workspace-binding";
 
 const pool = new Map<string, McpConnection>();
 
@@ -30,6 +32,14 @@ const toTarget = (connector: ConnectorConfig, signal?: AbortSignal) => {
   };
 };
 
+const connectConnector = (connector: ConnectorConfig, signal?: AbortSignal): McpConnection =>
+  googleWorkspaceConnectorAccount(connector.id) === "gmail"
+    ? connectGmailApi(
+        (forceRefresh) => connectorAuthorizationHeaders(connector, forceRefresh),
+        signal,
+      )
+    : connectMcp(toTarget(connector, signal));
+
 async function enabledConnector(connectorId: string): Promise<ConnectorConfig> {
   const connector = (await listConnectors()).find((entry) => entry.id === connectorId);
   if (!connector) throw new Error(`Unknown connector "${connectorId}"`);
@@ -54,7 +64,7 @@ export async function getPooledConnection(connectorId: string): Promise<McpConne
   const existing = pool.get(connectorId);
   if (existing) return existing;
   const connector = await enabledConnector(connectorId);
-  const connection = connectMcp(toTarget(connector));
+  const connection = connectConnector(connector);
   pool.set(connectorId, connection);
   return connection;
 }
@@ -98,7 +108,7 @@ export async function probeConnector(
 ): Promise<{ ok: boolean; tools: McpToolInfo[]; error?: string }> {
   let connection: McpConnection | null = null;
   try {
-    connection = connectMcp(toTarget(connector, signal));
+    connection = connectConnector(connector, signal);
     const tools = await connection.listTools();
     return { ok: true, tools };
   } catch (error) {

--- a/services/agent-runtime/src/connectors-service.ts
+++ b/services/agent-runtime/src/connectors-service.ts
@@ -46,11 +46,14 @@ export function protectManagedConnector(connector: ConnectorConfig): ConnectorCo
   if (!claimsGoogleWorkspace(connector)) return connector;
   const account = googleWorkspaceConnectorAccount(connector.id);
   const binding = account ? GOOGLE_WORKSPACE_BINDINGS[account] : null;
+  const endpointMatches =
+    binding !== null &&
+    (connector.url === binding.endpoint || binding.legacyEndpoints?.includes(connector.url ?? ""));
   const valid =
     account !== null &&
     binding !== null &&
     connector.transport === "http" &&
-    connector.url === binding.endpoint &&
+    endpointMatches &&
     connector.auth?.type === "oauth" &&
     connector.auth.provider === "google-workspace" &&
     connector.auth.account === account &&

--- a/services/agent-runtime/src/gmail-api-mcp.ts
+++ b/services/agent-runtime/src/gmail-api-mcp.ts
@@ -270,10 +270,7 @@ function plainText(message: typeof MessageSchema.Type): string {
     .replace(/<br\s*\/?>/gi, "\n")
     .replace(/<\/p>/gi, "\n")
     .replace(/<[^>]+>/g, "")
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">");
+    .replace(/(?:&nbsp;|&#160;)/gi, " ");
 }
 
 function renderedMessage(

--- a/services/agent-runtime/src/gmail-api-mcp.ts
+++ b/services/agent-runtime/src/gmail-api-mcp.ts
@@ -1,0 +1,474 @@
+import { Schema } from "effect";
+import type { McpConnection, McpToolInfo } from "./mcp-client";
+
+type GmailAuthorize = (forceRefresh: boolean) => Promise<Record<string, string>>;
+
+const HeaderSchema = Schema.Struct({ name: Schema.String, value: Schema.String });
+const BodySchema = Schema.Struct({
+  attachmentId: Schema.optional(Schema.String),
+  data: Schema.optional(Schema.String),
+});
+const PartSchema = Schema.Struct({
+  body: Schema.optional(BodySchema),
+  filename: Schema.optional(Schema.String),
+  headers: Schema.optional(Schema.Array(HeaderSchema)),
+  mimeType: Schema.optional(Schema.String),
+  parts: Schema.optional(Schema.Array(Schema.Unknown)),
+});
+const MessageSchema = Schema.Struct({
+  id: Schema.String,
+  internalDate: Schema.optional(Schema.String),
+  labelIds: Schema.optional(Schema.Array(Schema.String)),
+  payload: Schema.optional(PartSchema),
+  snippet: Schema.optional(Schema.String),
+  threadId: Schema.optional(Schema.String),
+});
+const ThreadSchema = Schema.Struct({
+  id: Schema.String,
+  messages: Schema.optional(Schema.Array(MessageSchema)),
+});
+const ThreadListSchema = Schema.Struct({
+  nextPageToken: Schema.optional(Schema.String),
+  resultSizeEstimate: Schema.optional(Schema.Number),
+  threads: Schema.optional(Schema.Array(Schema.Struct({ id: Schema.String }))),
+});
+const DraftListSchema = Schema.Struct({
+  drafts: Schema.optional(
+    Schema.Array(Schema.Struct({ id: Schema.String, message: Schema.optional(MessageSchema) })),
+  ),
+  nextPageToken: Schema.optional(Schema.String),
+});
+const DraftSchema = Schema.Struct({ id: Schema.String, message: MessageSchema });
+const LabelSchema = Schema.Struct({
+  color: Schema.optional(
+    Schema.Struct({
+      backgroundColor: Schema.optional(Schema.String),
+      textColor: Schema.optional(Schema.String),
+    }),
+  ),
+  id: Schema.String,
+  messagesTotal: Schema.optional(Schema.Number),
+  messagesUnread: Schema.optional(Schema.Number),
+  name: Schema.String,
+  threadsTotal: Schema.optional(Schema.Number),
+  threadsUnread: Schema.optional(Schema.Number),
+});
+const LabelsSchema = Schema.Struct({ labels: Schema.optional(Schema.Array(LabelSchema)) });
+
+const MessageFormatSchema = Schema.Union([
+  Schema.Literal("MESSAGE_FORMAT_UNSPECIFIED"),
+  Schema.Literal("MINIMAL"),
+  Schema.Literal("FULL_CONTENT"),
+  Schema.Literal("METADATA_ONLY"),
+  Schema.Literal("PLAIN_TEXT"),
+]);
+const GetMessageArgsSchema = Schema.Struct({
+  messageFormat: Schema.optional(MessageFormatSchema),
+  messageId: Schema.String,
+});
+const GetThreadArgsSchema = Schema.Struct({
+  messageFormat: Schema.optional(MessageFormatSchema),
+  threadId: Schema.String,
+});
+const SearchThreadsArgsSchema = Schema.Struct({
+  includeTrash: Schema.optional(Schema.Boolean),
+  pageSize: Schema.optional(Schema.Number),
+  pageToken: Schema.optional(Schema.String),
+  query: Schema.optional(Schema.String),
+  view: Schema.optional(
+    Schema.Union([
+      Schema.Literal("THREAD_VIEW_UNSPECIFIED"),
+      Schema.Literal("THREAD_VIEW_METADATA_ONLY"),
+      Schema.Literal("THREAD_VIEW_MINIMAL"),
+    ]),
+  ),
+});
+const ListDraftsArgsSchema = Schema.Struct({
+  pageSize: Schema.optional(Schema.Number),
+  pageToken: Schema.optional(Schema.String),
+  query: Schema.optional(Schema.String),
+  view: Schema.optional(
+    Schema.Union([
+      Schema.Literal("DRAFT_VIEW_UNSPECIFIED"),
+      Schema.Literal("DRAFT_VIEW_METADATA_ONLY"),
+      Schema.Literal("DRAFT_VIEW_FULL"),
+    ]),
+  ),
+});
+
+const readOnlyAnnotations = {
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: false,
+  readOnlyHint: true,
+};
+
+const GMAIL_TOOLS: McpToolInfo[] = [
+  {
+    name: "list_drafts",
+    description: "List draft emails from Gmail with optional search and pagination.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        pageSize: { type: "number" },
+        pageToken: { type: "string" },
+        query: { type: "string" },
+        view: {
+          type: "string",
+          enum: ["DRAFT_VIEW_UNSPECIFIED", "DRAFT_VIEW_METADATA_ONLY", "DRAFT_VIEW_FULL"],
+        },
+      },
+    },
+    annotations: { ...readOnlyAnnotations, title: "List draft emails" },
+  },
+  {
+    name: "get_thread",
+    description: "Get an email thread and its messages by thread ID.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        messageFormat: {
+          type: "string",
+          enum: [
+            "MESSAGE_FORMAT_UNSPECIFIED",
+            "MINIMAL",
+            "FULL_CONTENT",
+            "METADATA_ONLY",
+            "PLAIN_TEXT",
+          ],
+        },
+        threadId: { type: "string" },
+      },
+      required: ["threadId"],
+    },
+    annotations: { ...readOnlyAnnotations, title: "Get email thread" },
+  },
+  {
+    name: "get_message",
+    description: "Get an individual email message by message ID.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        messageFormat: {
+          type: "string",
+          enum: [
+            "MESSAGE_FORMAT_UNSPECIFIED",
+            "MINIMAL",
+            "FULL_CONTENT",
+            "METADATA_ONLY",
+            "PLAIN_TEXT",
+          ],
+        },
+        messageId: { type: "string" },
+      },
+      required: ["messageId"],
+    },
+    annotations: { ...readOnlyAnnotations, title: "Get email message" },
+  },
+  {
+    name: "search_threads",
+    description: "Search Gmail threads using Gmail search syntax.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        includeTrash: { type: "boolean" },
+        pageSize: { type: "number" },
+        pageToken: { type: "string" },
+        query: { type: "string" },
+        view: {
+          type: "string",
+          enum: ["THREAD_VIEW_UNSPECIFIED", "THREAD_VIEW_METADATA_ONLY", "THREAD_VIEW_MINIMAL"],
+        },
+      },
+    },
+    annotations: { ...readOnlyAnnotations, title: "Search email threads" },
+  },
+  {
+    name: "list_labels",
+    description: "List all labels in the authenticated Gmail account.",
+    inputSchema: { type: "object", properties: {} },
+    annotations: { ...readOnlyAnnotations, title: "List labels" },
+  },
+];
+
+const gmailUrl = (path: string, params?: URLSearchParams): string => {
+  const url = new URL(`https://gmail.googleapis.com/gmail/v1/users/me/${path}`);
+  if (params) url.search = params.toString();
+  return url.toString();
+};
+
+function requestSignal(signal?: AbortSignal): AbortSignal {
+  const timeout = AbortSignal.timeout(15_000);
+  return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+async function gmailJson<A>(
+  url: string,
+  decode: (input: unknown) => A,
+  authorize: GmailAuthorize,
+  signal?: AbortSignal,
+  fetcher: typeof fetch = fetch,
+): Promise<A> {
+  const send = async (forceRefresh: boolean): Promise<Response> => {
+    const headers = new Headers(await authorize(forceRefresh));
+    headers.set("accept", "application/json");
+    return fetcher(url, { headers, signal: requestSignal(signal) });
+  };
+  let response = await send(false);
+  if (response.status === 401) response = await send(true);
+  if (!response.ok) throw new Error(`Gmail API request failed with status ${response.status}`);
+  try {
+    return decode(await response.json());
+  } catch {
+    throw new Error("Gmail API returned invalid data");
+  }
+}
+
+function boundedPageSize(value: number | undefined): string {
+  return String(Math.max(1, Math.min(50, Math.floor(value ?? 20))));
+}
+
+function decodeBase64Url(value: string | undefined): string {
+  if (!value) return "";
+  return Buffer.from(value, "base64url").toString("utf8");
+}
+
+function allParts(input: typeof PartSchema.Type | undefined): Array<typeof PartSchema.Type> {
+  if (!input) return [];
+  const nested = (input.parts ?? []).flatMap((part) =>
+    allParts(Schema.decodeUnknownSync(PartSchema)(part)),
+  );
+  return [input, ...nested];
+}
+
+function header(message: typeof MessageSchema.Type, name: string): string {
+  const value = message.payload?.headers?.find(
+    (candidate) => candidate.name.toLowerCase() === name.toLowerCase(),
+  )?.value;
+  return value?.trim() ?? "";
+}
+
+function recipients(value: string): string[] {
+  return value
+    .split(/,(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function messageDate(message: typeof MessageSchema.Type): string {
+  const value = header(message, "Date");
+  const parsed = value ? new Date(value) : new Date(Number(message.internalDate ?? 0));
+  return Number.isNaN(parsed.getTime()) ? "" : parsed.toISOString().slice(0, 10);
+}
+
+function plainText(message: typeof MessageSchema.Type): string {
+  const parts = allParts(message.payload);
+  const text = parts.find((part) => part.mimeType === "text/plain" && part.body?.data);
+  if (text?.body?.data) return decodeBase64Url(text.body.data);
+  const html = parts.find((part) => part.mimeType === "text/html" && part.body?.data);
+  return decodeBase64Url(html?.body?.data)
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">");
+}
+
+function renderedMessage(
+  message: typeof MessageSchema.Type,
+  format: typeof MessageFormatSchema.Type | undefined,
+) {
+  const parts = allParts(message.payload);
+  const full = !format || format === "MESSAGE_FORMAT_UNSPECIFIED" || format === "FULL_CONTENT";
+  const includeText = full || format === "PLAIN_TEXT";
+  const minimal = format !== "METADATA_ONLY";
+  return {
+    id: message.id,
+    ...(message.threadId ? { threadId: message.threadId } : {}),
+    sender: header(message, "From"),
+    toRecipients: recipients(header(message, "To")),
+    ccRecipients: recipients(header(message, "Cc")),
+    bccRecipients: recipients(header(message, "Bcc")),
+    date: messageDate(message),
+    labelIds: [...(message.labelIds ?? [])],
+    ...(minimal ? { snippet: message.snippet ?? "", subject: header(message, "Subject") } : {}),
+    ...(includeText ? { plaintextBody: plainText(message) } : {}),
+    ...(full
+      ? {
+          htmlBody: decodeBase64Url(
+            parts.find((part) => part.mimeType === "text/html" && part.body?.data)?.body?.data,
+          ),
+        }
+      : {}),
+    ...(includeText
+      ? {
+          attachmentIds: parts.flatMap((part) =>
+            part.body?.attachmentId ? [part.body.attachmentId] : [],
+          ),
+          attachments: parts.flatMap((part) =>
+            part.body?.attachmentId
+              ? [
+                  {
+                    id: part.body.attachmentId,
+                    filename: part.filename ?? "",
+                    mimeType: part.mimeType ?? "application/octet-stream",
+                  },
+                ]
+              : [],
+          ),
+        }
+      : {}),
+  };
+}
+
+function toolResult(value: Record<string, unknown>): unknown {
+  return {
+    content: [{ type: "text", text: JSON.stringify(value) }],
+    structuredContent: value,
+  };
+}
+
+class GmailApiConnection implements McpConnection {
+  constructor(
+    private readonly authorize: GmailAuthorize,
+    private readonly signal?: AbortSignal,
+    private readonly fetcher: typeof fetch = fetch,
+  ) {}
+
+  async listTools(): Promise<McpToolInfo[]> {
+    return GMAIL_TOOLS;
+  }
+
+  async callTool(name: string, input: Record<string, unknown>): Promise<unknown> {
+    if (name === "list_labels") return this.listLabels();
+    if (name === "get_message") return this.getMessage(input);
+    if (name === "get_thread") return this.getThread(input);
+    if (name === "search_threads") return this.searchThreads(input);
+    if (name === "list_drafts") return this.listDrafts(input);
+    throw new Error(`Unknown Gmail tool "${name}"`);
+  }
+
+  close(): void {}
+
+  private request<A>(url: string, decode: (input: unknown) => A): Promise<A> {
+    return gmailJson(url, decode, this.authorize, this.signal, this.fetcher);
+  }
+
+  private async listLabels(): Promise<unknown> {
+    const result = await this.request(gmailUrl("labels"), Schema.decodeUnknownSync(LabelsSchema));
+    return toolResult({
+      labels: (result.labels ?? []).map((label) => ({
+        labelId: label.id,
+        name: label.name,
+        ...(label.color ? { color: label.color } : {}),
+        ...(label.messagesTotal === undefined ? {} : { messagesTotal: label.messagesTotal }),
+        ...(label.messagesUnread === undefined ? {} : { messagesUnread: label.messagesUnread }),
+        ...(label.threadsTotal === undefined ? {} : { threadsTotal: label.threadsTotal }),
+        ...(label.threadsUnread === undefined ? {} : { threadsUnread: label.threadsUnread }),
+      })),
+    });
+  }
+
+  private async getMessage(input: Record<string, unknown>): Promise<unknown> {
+    const args = Schema.decodeUnknownSync(GetMessageArgsSchema)(input);
+    const message = await this.request(
+      gmailUrl(`messages/${encodeURIComponent(args.messageId)}`, new URLSearchParams({ format: "full" })),
+      Schema.decodeUnknownSync(MessageSchema),
+    );
+    return toolResult(renderedMessage(message, args.messageFormat));
+  }
+
+  private async getThread(input: Record<string, unknown>): Promise<unknown> {
+    const args = Schema.decodeUnknownSync(GetThreadArgsSchema)(input);
+    const thread = await this.request(
+      gmailUrl(`threads/${encodeURIComponent(args.threadId)}`, new URLSearchParams({ format: "full" })),
+      Schema.decodeUnknownSync(ThreadSchema),
+    );
+    return toolResult({
+      id: thread.id,
+      messages: (thread.messages ?? []).map((message) =>
+        renderedMessage(message, args.messageFormat),
+      ),
+    });
+  }
+
+  private async searchThreads(input: Record<string, unknown>): Promise<unknown> {
+    const args = Schema.decodeUnknownSync(SearchThreadsArgsSchema)(input);
+    const params = new URLSearchParams({ maxResults: boundedPageSize(args.pageSize) });
+    if (args.query) params.set("q", args.query);
+    if (args.pageToken) params.set("pageToken", args.pageToken);
+    if (args.includeTrash) params.set("includeSpamTrash", "true");
+    const result = await this.request(
+      gmailUrl("threads", params),
+      Schema.decodeUnknownSync(ThreadListSchema),
+    );
+    const format = args.view === "THREAD_VIEW_METADATA_ONLY" ? "METADATA_ONLY" : "MINIMAL";
+    const threads = await Promise.all(
+      (result.threads ?? []).map((thread) =>
+        this.request(
+          gmailUrl(`threads/${encodeURIComponent(thread.id)}`, new URLSearchParams({ format: "full" })),
+          Schema.decodeUnknownSync(ThreadSchema),
+        ),
+      ),
+    );
+    return toolResult({
+      threads: threads.map((thread) => ({
+        id: thread.id,
+        messages: (thread.messages ?? []).map((message) => renderedMessage(message, format)),
+      })),
+      resultCountEstimate: String(result.resultSizeEstimate ?? threads.length),
+      ...(result.nextPageToken ? { nextPageToken: result.nextPageToken } : {}),
+    });
+  }
+
+  private async listDrafts(input: Record<string, unknown>): Promise<unknown> {
+    const args = Schema.decodeUnknownSync(ListDraftsArgsSchema)(input);
+    const params = new URLSearchParams({ maxResults: boundedPageSize(args.pageSize) });
+    if (args.query) params.set("q", args.query);
+    if (args.pageToken) params.set("pageToken", args.pageToken);
+    const result = await this.request(
+      gmailUrl("drafts", params),
+      Schema.decodeUnknownSync(DraftListSchema),
+    );
+    const drafts = await Promise.all(
+      (result.drafts ?? []).map((draft) =>
+        this.request(
+          gmailUrl(`drafts/${encodeURIComponent(draft.id)}`, new URLSearchParams({ format: "full" })),
+          Schema.decodeUnknownSync(DraftSchema),
+        ),
+      ),
+    );
+    const format = args.view === "DRAFT_VIEW_FULL" ? "FULL_CONTENT" : "METADATA_ONLY";
+    return toolResult({
+      drafts: drafts.map((draft) => {
+        const { id: _messageId, ...message } = renderedMessage(draft.message, format);
+        return { id: draft.id, ...message };
+      }),
+      ...(result.nextPageToken ? { nextPageToken: result.nextPageToken } : {}),
+    });
+  }
+}
+
+export function connectGmailApi(
+  authorize: GmailAuthorize,
+  signal?: AbortSignal,
+  fetcher: typeof fetch = fetch,
+): McpConnection {
+  return new GmailApiConnection(authorize, signal, fetcher);
+}
+
+export async function verifyGmailApiAccess(
+  accessToken: string,
+  signal: AbortSignal,
+  fetcher: typeof fetch = fetch,
+): Promise<void> {
+  await gmailJson(
+    gmailUrl("labels"),
+    Schema.decodeUnknownSync(LabelsSchema),
+    async () => ({ Authorization: `Bearer ${accessToken}` }),
+    signal,
+    fetcher,
+  );
+}

--- a/services/agent-runtime/src/gmail-api-mcp.ts
+++ b/services/agent-runtime/src/gmail-api-mcp.ts
@@ -261,16 +261,52 @@ function messageDate(message: typeof MessageSchema.Type): string {
   return Number.isNaN(parsed.getTime()) ? "" : parsed.toISOString().slice(0, 10);
 }
 
+function htmlPlainText(value: string): string {
+  let output = "";
+  let tag = "";
+  let quote: '"' | "'" | null = null;
+  let insideTag = false;
+  for (const character of value) {
+    if (!insideTag) {
+      if (character === "<") {
+        insideTag = true;
+        tag = "";
+      } else if (character === "&") {
+        output += "&amp;";
+      } else if (character === ">") {
+        output += "&gt;";
+      } else {
+        output += character;
+      }
+      continue;
+    }
+    if (quote) {
+      if (character === quote) quote = null;
+      tag += character;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      tag += character;
+      continue;
+    }
+    if (character === ">") {
+      if (/^\s*br\b/i.test(tag) || /^\s*\/\s*p\b/i.test(tag)) output += "\n";
+      insideTag = false;
+      tag = "";
+      continue;
+    }
+    tag += character;
+  }
+  return output.replace(/&amp;(?:nbsp|#160);/gi, " ");
+}
+
 function plainText(message: typeof MessageSchema.Type): string {
   const parts = allParts(message.payload);
   const text = parts.find((part) => part.mimeType === "text/plain" && part.body?.data);
   if (text?.body?.data) return decodeBase64Url(text.body.data);
   const html = parts.find((part) => part.mimeType === "text/html" && part.body?.data);
-  return decodeBase64Url(html?.body?.data)
-    .replace(/<br\s*\/?>/gi, "\n")
-    .replace(/<\/p>/gi, "\n")
-    .replace(/<[^>]+>/g, "")
-    .replace(/(?:&nbsp;|&#160;)/gi, " ");
+  return htmlPlainText(decodeBase64Url(html?.body?.data));
 }
 
 function renderedMessage(

--- a/services/agent-runtime/src/google-account.ts
+++ b/services/agent-runtime/src/google-account.ts
@@ -4,6 +4,7 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import { Effect, Schema, Semaphore } from "effect";
 import { connectMcp } from "./mcp-client";
+import { verifyGmailApiAccess } from "./gmail-api-mcp";
 import { listConnectors, upsertConnectors } from "./connectors-service";
 import { resolveDataDir } from "./data-dir";
 import {
@@ -54,6 +55,7 @@ const PendingSchema = Schema.Struct({
   verifier: Schema.String,
   redirectUri: Schema.String,
   resource: Schema.String,
+  authorizationResource: Schema.optional(Schema.String),
   expiresAt: Schema.Number,
 });
 
@@ -231,12 +233,14 @@ function connectionView(
   id: GoogleWorkspacePluginId,
   connection?: Connection,
 ): GoogleConnectionView {
+  const current =
+    connection?.resource === GOOGLE_WORKSPACE_BINDINGS[id].resource ? connection : undefined;
   return {
-    connected: Boolean(connection),
-    email: connection?.email ?? null,
-    scopes: connection?.scopes ?? [],
+    connected: Boolean(current),
+    email: current?.email ?? null,
+    scopes: current?.scopes ?? [],
     resource: GOOGLE_WORKSPACE_BINDINGS[id].resource,
-    connectedAt: connection?.connectedAt ?? null,
+    connectedAt: current?.connectedAt ?? null,
   };
 }
 
@@ -359,6 +363,9 @@ export function beginGoogleAuthorization(
           verifier,
           redirectUri: loopbackRedirect(redirectUri),
           resource: binding.resource,
+          ...(binding.authorizationResource
+            ? { authorizationResource: binding.authorizationResource }
+            : {}),
           expiresAt: dependencies.now() + 10 * 60 * 1000,
         };
         yield* writeVaultJson(vault, pendingKey(account), pending);
@@ -378,7 +385,7 @@ export function beginGoogleAuthorization(
           access_type: "offline",
           prompt: "consent",
           include_granted_scopes: "true",
-          resource: binding.resource,
+          ...(binding.authorizationResource ? { resource: binding.authorizationResource } : {}),
         }).toString();
         return { authorizationUrl: url.toString() };
       }),
@@ -424,7 +431,7 @@ async function exchangeAuthorizationCode(
     code_verifier: pending.verifier,
     grant_type: "authorization_code",
     redirect_uri: pending.redirectUri,
-    resource: pending.resource,
+    ...(pending.authorizationResource ? { resource: pending.authorizationResource } : {}),
     ...(secrets.clientSecret ? { client_secret: secrets.clientSecret } : {}),
   });
   const response = await dependencies.fetch("https://oauth2.googleapis.com/token", {
@@ -463,6 +470,10 @@ async function verifyGoogleWorkspaceAccess(
   accessToken: string,
   signal: AbortSignal,
 ): Promise<void> {
+  if (account === "gmail") {
+    await verifyGmailApiAccess(accessToken, signal);
+    return;
+  }
   const binding = GOOGLE_WORKSPACE_BINDINGS[account];
   const connection = connectMcp({
     transport: "http",
@@ -928,7 +939,7 @@ async function refreshAccessToken(
     client_id: metadata.clientId,
     refresh_token: refreshToken,
     grant_type: "refresh_token",
-    resource: binding.resource,
+    ...(binding.authorizationResource ? { resource: binding.authorizationResource } : {}),
     ...(secrets.clientSecret ? { client_secret: secrets.clientSecret } : {}),
   });
   const response = await dependencies.fetch("https://oauth2.googleapis.com/token", {
@@ -959,7 +970,7 @@ export function googleAuthorizationHeaders(
         return { Authorization: `Bearer ${cached.value}` };
       }
       const metadata = yield* metadataEffect();
-      if (!metadata?.connections[account]) {
+      if (metadata?.connections[account]?.resource !== GOOGLE_WORKSPACE_BINDINGS[account].resource) {
         return yield* Effect.fail(new GoogleAccountError(401, "Google account is not connected"));
       }
       const secrets =

--- a/services/agent-runtime/src/google-account.ts
+++ b/services/agent-runtime/src/google-account.ts
@@ -281,6 +281,9 @@ export function saveGoogleClient(
           (yield* readVaultJson(vault, secretsKey, Schema.decodeUnknownSync(SecretsSchema))) ??
           emptySecrets();
         const sameClient = current?.clientId === clientId;
+        const clientSecret = incomingSecret ?? (sameClient ? currentSecrets.clientSecret : undefined);
+        if (!clientSecret)
+          return yield* Effect.fail(new GoogleAccountError(400, "Client secret is required"));
         const revokeToken = GOOGLE_WORKSPACE_PLUGIN_IDS.flatMap((id) =>
           currentSecrets.refreshTokens[id] ? [currentSecrets.refreshTokens[id]] : [],
         )[0];
@@ -292,11 +295,7 @@ export function saveGoogleClient(
           if (current) yield* writeMetadataEffect({ ...current, connections: {} });
         }
         const secrets: Secrets = {
-          ...(incomingSecret
-            ? { clientSecret: incomingSecret }
-            : sameClient && currentSecrets.clientSecret
-              ? { clientSecret: currentSecrets.clientSecret }
-              : {}),
+          clientSecret,
           refreshTokens: sameClient ? currentSecrets.refreshTokens : {},
           pendingRevocations: pendingRevocations(currentSecrets),
         };
@@ -348,9 +347,9 @@ export function beginGoogleAuthorization(
         yield* retryPendingGoogleRevocations(vault, dependencies);
         yield* requireGoogleAuthorizationFlow(account, flowId);
         const metadata = yield* metadataEffect();
-        if (!metadata?.clientId) {
+        if (!metadata?.clientId || !metadata.hasClientSecret) {
           return yield* Effect.fail(
-            new GoogleAccountError(409, "Configure a Google OAuth client first"),
+            new GoogleAccountError(409, "Configure a Google OAuth client ID and secret first"),
           );
         }
         const binding = GOOGLE_WORKSPACE_BINDINGS[account];

--- a/services/agent-runtime/src/google-workspace-binding.ts
+++ b/services/agent-runtime/src/google-workspace-binding.ts
@@ -5,7 +5,9 @@ type GoogleWorkspaceBinding = {
   name: string;
   connectorId: string;
   endpoint: string;
+  legacyEndpoints?: readonly string[];
   resource: string;
+  authorizationResource?: string;
   scopes: readonly string[];
   observeTools: readonly string[];
   verifyTool: string;
@@ -15,8 +17,9 @@ export const GOOGLE_WORKSPACE_BINDINGS: Record<GoogleWorkspacePluginId, GoogleWo
   gmail: {
     name: "Gmail",
     connectorId: "account-google-gmail",
-    endpoint: "https://gmailmcp.googleapis.com/mcp/v1",
-    resource: "https://gmailmcp.googleapis.com/mcp",
+    endpoint: "https://gmail.googleapis.com/gmail/v1/users/me",
+    legacyEndpoints: ["https://gmailmcp.googleapis.com/mcp/v1"],
+    resource: "https://gmail.googleapis.com/",
     scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
     observeTools: ["list_drafts", "get_thread", "get_message", "search_threads", "list_labels"],
     verifyTool: "list_labels",
@@ -26,6 +29,7 @@ export const GOOGLE_WORKSPACE_BINDINGS: Record<GoogleWorkspacePluginId, GoogleWo
     connectorId: "account-google-calendar",
     endpoint: "https://calendarmcp.googleapis.com/mcp/v1",
     resource: "https://calendarmcp.googleapis.com/mcp/v1",
+    authorizationResource: "https://calendarmcp.googleapis.com/mcp/v1",
     scopes: [
       "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
       "https://www.googleapis.com/auth/calendar.events.freebusy",

--- a/services/agent-runtime/test/gmail-api-mcp.test.ts
+++ b/services/agent-runtime/test/gmail-api-mcp.test.ts
@@ -149,7 +149,7 @@ describe("gmail api connector", () => {
     })) as { structuredContent: { plaintextBody: string } };
 
     expect(result.structuredContent.plaintextBody).toBe(
-      "Hello there\nignored()&lt;script&gt;encoded()&lt;/script&gt;&amp;lt;script&amp;gt;double()",
+      "Hello there\nignored()&amp;lt;script&amp;gt;encoded()&amp;lt;/script&amp;gt;&amp;amp;lt;script&amp;amp;gt;double()",
     );
   });
 

--- a/services/agent-runtime/test/gmail-api-mcp.test.ts
+++ b/services/agent-runtime/test/gmail-api-mcp.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test";
+import { connectGmailApi, verifyGmailApiAccess } from "../src/gmail-api-mcp";
+
+const jsonResponse = (value: unknown, status = 200): Response =>
+  new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+describe("gmail api connector", () => {
+  test("declares only the read-only Gmail tools", async () => {
+    const connection = connectGmailApi(async () => ({ Authorization: "Bearer token" }));
+    const tools = await connection.listTools();
+
+    expect(tools.map((tool) => tool.name)).toEqual([
+      "list_drafts",
+      "get_thread",
+      "get_message",
+      "search_threads",
+      "list_labels",
+    ]);
+    expect(tools.every((tool) => tool.annotations?.readOnlyHint === true)).toBe(true);
+  });
+
+  test("maps Gmail labels into the plugin tool result", async () => {
+    const connection = connectGmailApi(
+      async () => ({ Authorization: "Bearer token" }),
+      undefined,
+      async () =>
+        jsonResponse({
+          labels: [
+            {
+              id: "INBOX",
+              name: "INBOX",
+              messagesTotal: 12,
+              messagesUnread: 3,
+              threadsTotal: 8,
+              threadsUnread: 2,
+            },
+          ],
+        }),
+    );
+
+    const result = (await connection.callTool("list_labels", {})) as {
+      structuredContent: { labels: Array<Record<string, unknown>> };
+    };
+
+    expect(result.structuredContent.labels).toEqual([
+      {
+        labelId: "INBOX",
+        name: "INBOX",
+        messagesTotal: 12,
+        messagesUnread: 3,
+        threadsTotal: 8,
+        threadsUnread: 2,
+      },
+    ]);
+  });
+
+  test("refreshes authorization once after a 401", async () => {
+    const refreshes: boolean[] = [];
+    let requests = 0;
+    const connection = connectGmailApi(
+      async (forceRefresh) => {
+        refreshes.push(forceRefresh);
+        return { Authorization: forceRefresh ? "Bearer fresh" : "Bearer stale" };
+      },
+      undefined,
+      async (_input, init) => {
+        requests += 1;
+        const authorization = new Headers(init?.headers).get("authorization");
+        return authorization === "Bearer fresh"
+          ? jsonResponse({ labels: [] })
+          : jsonResponse({ error: "expired" }, 401);
+      },
+    );
+
+    await connection.callTool("list_labels", {});
+
+    expect(requests).toBe(2);
+    expect(refreshes).toEqual([false, true]);
+  });
+
+  test("decodes message text and metadata", async () => {
+    const connection = connectGmailApi(
+      async () => ({ Authorization: "Bearer token" }),
+      undefined,
+      async () =>
+        jsonResponse({
+          id: "message-1",
+          threadId: "thread-1",
+          internalDate: "1786480000000",
+          labelIds: ["INBOX", "UNREAD"],
+          snippet: "Hello",
+          payload: {
+            mimeType: "multipart/alternative",
+            headers: [
+              { name: "From", value: "Alice <alice@example.com>" },
+              { name: "To", value: "Sero <sherifcherfa@gmail.com>" },
+              { name: "Subject", value: "Status" },
+              { name: "Date", value: "Tue, 11 Aug 2026 12:00:00 +0000" },
+            ],
+            parts: [
+              {
+                mimeType: "text/plain",
+                body: { data: Buffer.from("Hello from Gmail").toString("base64url") },
+              },
+            ],
+          },
+        }),
+    );
+
+    const result = (await connection.callTool("get_message", {
+      messageId: "message-1",
+      messageFormat: "PLAIN_TEXT",
+    })) as { structuredContent: Record<string, unknown> };
+
+    expect(result.structuredContent).toMatchObject({
+      id: "message-1",
+      threadId: "thread-1",
+      subject: "Status",
+      sender: "Alice <alice@example.com>",
+      plaintextBody: "Hello from Gmail",
+      date: "2026-08-11",
+    });
+  });
+
+  test("verifies the same stable Gmail API used by the connector", async () => {
+    let authorization = "";
+
+    await verifyGmailApiAccess("access-token", AbortSignal.timeout(1_000), async (_input, init) => {
+      authorization = new Headers(init?.headers).get("authorization") ?? "";
+      return jsonResponse({ labels: [] });
+    });
+
+    expect(authorization).toBe("Bearer access-token");
+  });
+});

--- a/services/agent-runtime/test/gmail-api-mcp.test.ts
+++ b/services/agent-runtime/test/gmail-api-mcp.test.ts
@@ -125,6 +125,34 @@ describe("gmail api connector", () => {
     });
   });
 
+  test("does not reconstruct markup from encoded HTML", async () => {
+    const connection = connectGmailApi(
+      async () => ({ Authorization: "Bearer token" }),
+      undefined,
+      async () =>
+        jsonResponse({
+          id: "message-1",
+          payload: {
+            mimeType: "text/html",
+            body: {
+              data: Buffer.from(
+                "<p>Hello&nbsp;there</p><script>ignored()</script>&lt;script&gt;encoded()&lt;/script&gt;&amp;lt;script&amp;gt;double()",
+              ).toString("base64url"),
+            },
+          },
+        }),
+    );
+
+    const result = (await connection.callTool("get_message", {
+      messageId: "message-1",
+      messageFormat: "PLAIN_TEXT",
+    })) as { structuredContent: { plaintextBody: string } };
+
+    expect(result.structuredContent.plaintextBody).toBe(
+      "Hello there\nignored()&lt;script&gt;encoded()&lt;/script&gt;&amp;lt;script&amp;gt;double()",
+    );
+  });
+
   test("verifies the same stable Gmail API used by the connector", async () => {
     let authorization = "";
 


### PR DESCRIPTION
## Summary
- replace the developer-preview Gmail MCP dependency with a stable Gmail API-backed connector
- preserve the existing five read-only Gmail plugin tools and migrate managed connector configuration
- require the Google Desktop OAuth client secret before starting consent

## Validation
- `npm run check`
- `npm run test:integration`
- installed `/Applications/Local Studio Dev.app` OAuth callback completed for the configured consumer Gmail account
- live `list_labels` connector call passed through Local Studio (30 labels, Inbox present)