### PR TITLE
fix(agent): expose Inkling reasoning levels

### DIFF
--- a/services/agent-runtime/src/pi-runtime-models.ts
+++ b/services/agent-runtime/src/pi-runtime-models.ts
@@ -134,7 +134,17 @@ function supportedPiThinkingLevels(
   });
 }
 
-export function controllerModelThinkingLevels(reasoning: boolean): AgentThinkingLevel[] {
+function isInklingModelId(modelId: string): boolean {
+  return modelId.toLowerCase().includes("inkling");
+}
+
+export function controllerModelThinkingLevels(
+  reasoning: boolean,
+  modelId = "",
+): AgentThinkingLevel[] {
+  if (reasoning && isInklingModelId(modelId)) {
+    return ["off", "minimal", "low", "medium", "high", "max"];
+  }
   return AGENT_THINKING_LEVELS.filter((level) =>
     reasoning ? level === "high" || level === "max" : level === "off",
   );
@@ -280,7 +290,7 @@ async function fetchModelsFromController(
       providerId,
       controllerUrl: backendUrl,
       controllerName: label,
-      thinkingLevels: controllerModelThinkingLevels(model.reasoning),
+      thinkingLevels: controllerModelThinkingLevels(model.reasoning, model.rawId ?? model.id),
       name: multipleControllers ? `${model.name} · ${label}` : model.name,
     }),
   );
@@ -432,6 +442,11 @@ function isDeepSeekReasoningModel(model: AgentModel): boolean {
   return model.reasoning && id.includes("deepseek");
 }
 
+function isInklingReasoningModel(model: AgentModel): boolean {
+  const id = `${model.id} ${model.rawId ?? ""} ${model.name}`.toLowerCase();
+  return model.reasoning && id.includes("inkling");
+}
+
 const VLLM_OPENAI_COMPAT: OpenAICompletionsCompat = {
   supportsStore: false,
   supportsDeveloperRole: false,
@@ -444,6 +459,7 @@ const VLLM_OPENAI_COMPAT: OpenAICompletionsCompat = {
 export function modelsToPiModels(models: AgentModel[]) {
   return models.map((model) => {
     const deepSeekReasoning = isDeepSeekReasoningModel(model);
+    const inklingReasoning = isInklingReasoningModel(model);
     return {
       id: model.rawId ?? model.id,
       name: model.name,
@@ -465,7 +481,19 @@ export function modelsToPiModels(models: AgentModel[]) {
               max: "max",
             },
           }
-        : {}),
+        : inklingReasoning
+          ? {
+              thinkingLevelMap: {
+                off: "none",
+                minimal: "minimal",
+                low: "low",
+                medium: "medium",
+                high: "high",
+                xhigh: null,
+                max: "max",
+              },
+            }
+          : {}),
       compat: {
         ...VLLM_OPENAI_COMPAT,
         ...(deepSeekReasoning

--- a/services/agent-runtime/test/inkling-thinking-levels.test.ts
+++ b/services/agent-runtime/test/inkling-thinking-levels.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { inferReasoningSupport, normalizeOpenAIModel } from "../../../shared/agent/models";
+import { controllerModelThinkingLevels, modelsToPiModels } from "../src/pi-runtime-models";
+
+describe("Inkling thinking levels", () => {
+  test("detects Inkling as a reasoning model", () => {
+    expect(inferReasoningSupport("inkling-small")).toBe(true);
+    expect(normalizeOpenAIModel({ id: "inkling-small" }).reasoning).toBe(true);
+  });
+
+  test("exposes only effort names accepted by the checkpoint template", () => {
+    expect(controllerModelThinkingLevels(true, "inkling-small")).toEqual([
+      "off",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "max",
+    ]);
+  });
+
+  test("maps Local Studio levels to Inkling reasoning_effort values", () => {
+    const [model] = modelsToPiModels([
+      {
+        id: "inkling-small",
+        name: "Inkling Small",
+        provider: "local-studio",
+        contextWindow: 262_144,
+        maxTokens: 65_536,
+        reasoning: true,
+        vision: true,
+        active: true,
+      },
+    ]);
+
+    expect(model?.thinkingLevelMap).toEqual({
+      off: "none",
+      minimal: "minimal",
+      low: "low",
+      medium: "medium",
+      high: "high",
+      xhigh: null,
+      max: "max",
+    });
+    expect(model?.compat.supportsReasoningEffort).toBe(true);
+  });
+});

--- a/shared/agent/models.ts
+++ b/shared/agent/models.ts
@@ -49,6 +49,7 @@ export function inferReasoningSupport(modelId: string): boolean {
     normalized.includes("thinking") ||
     normalized.includes("r1") ||
     normalized.includes("deepseek") ||
+    normalized.includes("inkling") ||
     normalized.includes("qwen3") ||
     normalized.includes("glm-5") ||
     normalized.includes("mimo")


### PR DESCRIPTION
## Summary
- recognize Inkling controller models as reasoning capable
- expose the checkpoint-supported none/minimal/low/medium/high/max effort levels
- map Local Studio levels to Inkling reasoning_effort values and omit unsupported xhigh

## Validation
- bun test services/agent-runtime/test/inkling-thinking-levels.test.ts
- npm run check:agent-runtime
- npm run check:frontend