### PR TITLE
feat(chat): render referenced media inline

### DIFF
--- a/frontend/src/app/api/agent/fs/raw/byte-range.ts
+++ b/frontend/src/app/api/agent/fs/raw/byte-range.ts
@@ -1,0 +1,27 @@
+export type ByteRange = { start: number; end: number };
+
+export function parseByteRange(value: string | null, size: number): ByteRange | undefined | null {
+  if (!value) return undefined;
+  const match = /^bytes=(\d*)-(\d*)$/.exec(value.trim());
+  if (!match || size <= 0) return null;
+  const startText = match[1] ?? "";
+  const endText = match[2] ?? "";
+  if (!startText && !endText) return null;
+  if (!startText) {
+    const suffix = Number(endText);
+    if (!Number.isSafeInteger(suffix) || suffix <= 0) return null;
+    return { start: Math.max(0, size - suffix), end: size - 1 };
+  }
+  const start = Number(startText);
+  const end = endText ? Number(endText) : size - 1;
+  if (
+    !Number.isSafeInteger(start) ||
+    !Number.isSafeInteger(end) ||
+    start < 0 ||
+    start >= size ||
+    end < start
+  ) {
+    return null;
+  }
+  return { start, end: Math.min(end, size - 1) };
+}

--- a/frontend/src/app/api/agent/fs/raw/route.test.ts
+++ b/frontend/src/app/api/agent/fs/raw/route.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, test } from "node:test";
+import { NextRequest } from "next/server";
+import { parseByteRange } from "./byte-range";
+import { GET } from "./route";
+
+describe("raw file byte ranges", () => {
+  test("parses bounded, open-ended, and suffix ranges", () => {
+    assert.deepEqual(parseByteRange("bytes=10-19", 100), { start: 10, end: 19 });
+    assert.deepEqual(parseByteRange("bytes=90-", 100), { start: 90, end: 99 });
+    assert.deepEqual(parseByteRange("bytes=-12", 100), { start: 88, end: 99 });
+    assert.deepEqual(parseByteRange("bytes=90-120", 100), { start: 90, end: 99 });
+  });
+
+  test("distinguishes absent and invalid ranges", () => {
+    assert.equal(parseByteRange(null, 100), undefined);
+    assert.equal(parseByteRange("bytes=100-101", 100), null);
+    assert.equal(parseByteRange("bytes=20-10", 100), null);
+    assert.equal(parseByteRange("bytes=0-1,4-5", 100), null);
+  });
+});
+
+describe("raw response media", () => {
+  test("streams seekable video with the correct range headers", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "local-studio-media-"));
+    try {
+      await writeFile(path.join(cwd, "clip.mp4"), Buffer.from([0, 1, 2, 3, 4, 5, 6, 7]));
+      const request = new NextRequest(
+        `http://localhost/api/agent/fs/raw?cwd=${encodeURIComponent(cwd)}&path=clip.mp4`,
+        { headers: { range: "bytes=2-5" } },
+      );
+      const response = await GET(request);
+      assert.equal(response.status, 206);
+      assert.equal(response.headers.get("content-type"), "video/mp4");
+      assert.equal(response.headers.get("content-range"), "bytes 2-5/8");
+      assert.equal(response.headers.get("accept-ranges"), "bytes");
+      assert.deepEqual([...new Uint8Array(await response.arrayBuffer())], [2, 3, 4, 5]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("serves SVG as an inline image with a restrictive document policy", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "local-studio-media-"));
+    try {
+      await writeFile(
+        path.join(cwd, "diagram.svg"),
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>',
+      );
+      const request = new NextRequest(
+        `http://localhost/api/agent/fs/raw?cwd=${encodeURIComponent(cwd)}&path=diagram.svg`,
+      );
+      const response = await GET(request);
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get("content-type"), "image/svg+xml");
+      assert.match(response.headers.get("content-disposition") ?? "", /^inline;/);
+      assert.match(response.headers.get("content-security-policy") ?? "", /default-src 'none'/);
+      assert.match(await response.text(), /^<svg/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/frontend/src/app/api/agent/fs/raw/route.ts
+++ b/frontend/src/app/api/agent/fs/raw/route.ts
@@ -1,15 +1,15 @@
 import { NextRequest } from "next/server";
 import path from "node:path";
-import { readFileBytes } from "@/features/agent/fs-store";
+import { createReadStream } from "node:fs";
+import { Readable } from "node:stream";
+import { resolveReadableFile } from "@/features/agent/fs-store";
 import { requireApiAccess } from "@/lib/auth/guard";
 import { errorMessage, jsonError, requireAbsoluteCwd } from "@/app/api/_lib/route-helpers";
+import { parseByteRange } from "./byte-range";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-// Only formats the Files panel renders inline get their real media type. Every
-// other file is served as an opaque download, so a repo's own .html/.svg can
-// never execute as a same-origin document.
 const INLINE_TYPES: Record<string, string> = {
   ".apng": "image/apng",
   ".avif": "image/avif",
@@ -20,7 +20,24 @@ const INLINE_TYPES: Record<string, string> = {
   ".jpg": "image/jpeg",
   ".pdf": "application/pdf",
   ".png": "image/png",
+  ".svg": "image/svg+xml",
   ".webp": "image/webp",
+  ".m4v": "video/mp4",
+  ".mov": "video/quicktime",
+  ".mp4": "video/mp4",
+  ".mpeg": "video/mpeg",
+  ".mpg": "video/mpeg",
+  ".ogv": "video/ogg",
+  ".webm": "video/webm",
+  ".aac": "audio/aac",
+  ".flac": "audio/flac",
+  ".m4a": "audio/mp4",
+  ".mp3": "audio/mpeg",
+  ".oga": "audio/ogg",
+  ".ogg": "audio/ogg",
+  ".opus": "audio/ogg",
+  ".wav": "audio/wav",
+  ".wave": "audio/wav",
 };
 
 export async function GET(request: NextRequest) {
@@ -31,19 +48,40 @@ export async function GET(request: NextRequest) {
   const relPath = request.nextUrl.searchParams.get("path")?.trim() ?? "";
   if (!relPath) return jsonError("path is required");
   try {
-    const { bytes, size, modifiedAt } = await readFileBytes(result.cwd, relPath);
+    const { filePath, size, modifiedAt } = await resolveReadableFile(result.cwd, relPath);
     const name = path.basename(relPath);
     const inlineType = INLINE_TYPES[path.extname(relPath).toLowerCase()];
-    return new Response(new Uint8Array(bytes), {
+    const range = parseByteRange(request.headers.get("range"), size);
+    if (range === null) {
+      return new Response(null, {
+        status: 416,
+        headers: { "content-range": `bytes */${size}`, "accept-ranges": "bytes" },
+      });
+    }
+    const start = range?.start ?? 0;
+    const end = range?.end ?? Math.max(0, size - 1);
+    const stream = size > 0 ? Readable.toWeb(createReadStream(filePath, { start, end })) : null;
+    const headers: Record<string, string> = {
+      "content-type": inlineType ?? "application/octet-stream",
+      "content-length": String(size === 0 ? 0 : end - start + 1),
+      "content-disposition": inlineType
+        ? `inline; filename="${encodeURIComponent(name)}"`
+        : `attachment; filename="${encodeURIComponent(name)}"`,
+      "last-modified": modifiedAt.toUTCString(),
+      "x-content-type-options": "nosniff",
+      "cache-control": "no-store",
+      "accept-ranges": "bytes",
+      "cross-origin-resource-policy": "same-origin",
+    };
+    if (range) headers["content-range"] = `bytes ${start}-${end}/${size}`;
+    if (inlineType === "image/svg+xml") {
+      headers["content-security-policy"] =
+        "default-src 'none'; img-src data:; style-src 'unsafe-inline'; sandbox";
+    }
+    return new Response(stream as ReadableStream<Uint8Array> | null, {
+      status: range ? 206 : 200,
       headers: {
-        "content-type": inlineType ?? "application/octet-stream",
-        "content-length": String(size),
-        "content-disposition": inlineType
-          ? `inline; filename="${encodeURIComponent(name)}"`
-          : `attachment; filename="${encodeURIComponent(name)}"`,
-        "last-modified": modifiedAt.toUTCString(),
-        "x-content-type-options": "nosniff",
-        "cache-control": "no-store",
+        ...headers,
       },
     });
   } catch (error) {

--- a/frontend/src/app/styles/globals/chat.css
+++ b/frontend/src/app/styles/globals/chat.css
@@ -249,6 +249,39 @@
   margin: 0.75rem 0;
 }
 
+.chat-markdown .chat-response-media {
+  display: flex;
+  width: min(100%, 44rem);
+  flex-direction: column;
+  gap: 0.4rem;
+  margin: 0.75rem 0;
+}
+
+.chat-markdown .chat-response-media img,
+.chat-markdown .chat-response-media video {
+  display: block;
+  width: 100%;
+  max-height: min(32rem, 70vh);
+  margin: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--rad-md);
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  object-fit: contain;
+}
+
+.chat-markdown .chat-response-media audio {
+  display: block;
+  width: min(100%, 36rem);
+}
+
+.chat-markdown .chat-response-media-caption {
+  display: block;
+  min-width: 0;
+  font-size: var(--fs-xs);
+  line-height: 1.35;
+  color: var(--dim);
+}
+
 /* Inline code: quiet — a whisper of background, tight padding, no chunky pill. */
 .chat-markdown :not(pre) > code {
   padding: 0.5px 4px;

--- a/frontend/src/features/agent/fs-store.ts
+++ b/frontend/src/features/agent/fs-store.ts
@@ -174,26 +174,18 @@ export async function readFileSnippet(
   return { content: buf.toString("utf-8"), truncated: false, size: stats.size };
 }
 
-// Raw bytes for files the text reader refuses (images, PDFs). Same trust
-// boundary as readFileSnippet — resolved inside an allowed workspace root — but
-// returns the buffer unchanged so the caller can serve it with a real content
-// type instead of a "binary, cannot render" dead end.
-export async function readFileBytes(
+export async function resolveReadableFile(
   rootCwd: string,
   relPath: string,
-  maxBytes = 64 * 1024 * 1024,
-): Promise<{ bytes: Buffer; size: number; modifiedAt: Date }> {
+): Promise<{ filePath: string; size: number; modifiedAt: Date }> {
   const root = resolveWorkspaceRoot(rootCwd);
   const target = ensureInside(root, path.resolve(root, relPath));
-  // Redundant with ensureInside, but stated in a form static analysis can
-  // verify: the realpath'd target sits under the realpath'd root.
   if (target !== root && !target.startsWith(root + path.sep)) {
     throw new Error("Path escapes project root");
   }
   const stats = await fs.stat(target);
   if (!stats.isFile()) throw new Error("Not a file");
-  if (stats.size > maxBytes) throw new Error("File is too large to serve");
-  return { bytes: await fs.readFile(target), size: stats.size, modifiedAt: stats.mtime };
+  return { filePath: target, size: stats.size, modifiedAt: stats.mtime };
 }
 
 export async function writeFileContent(

--- a/frontend/src/features/agent/ui/assistant-markdown.tsx
+++ b/frontend/src/features/agent/ui/assistant-markdown.tsx
@@ -1,13 +1,29 @@
 "use client";
 
-import React, { Children, isValidElement, memo, useCallback, useMemo, type ReactNode } from "react";
+import React, {
+  Children,
+  isValidElement,
+  memo,
+  useCallback,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import { useCopiedFlag } from "@/features/agent/ui/use-copied-flag";
-import ReactMarkdown, { type Components } from "react-markdown";
+import ReactMarkdown, { defaultUrlTransform, type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { normalizeBrowserInput } from "@/features/agent/tools/browser-url";
 import { useToolsActions } from "@/features/agent/tools/context";
 import type { ComputerTab } from "@/features/agent/tools/types";
 import { writeClipboardText } from "@/lib/clipboard";
+import {
+  assistantMediaKind,
+  assistantMediaName,
+  assistantMediaSource,
+  cleanFileReference,
+  remarkLocalMediaReferences,
+  type AssistantMediaKind,
+} from "@/features/agent/ui/assistant-media";
 
 const FILE_REF_PATTERN =
   /^(?:file:\/\/|~\/|\.{1,2}\/|\/|[\w.-]+\/)[^\s`'")]+(?:\.[A-Za-z0-9][A-Za-z0-9_-]*)(?::\d+(?::\d+)?)?$/;
@@ -141,7 +157,11 @@ function safeExternalHref(value: string | undefined): boolean {
 
 // The remark/rehype plugin lists are constant. Hoisted out of render so the
 // `ReactMarkdown` reconciler sees the same array identity each commit.
-const REMARK_PLUGINS = [remarkGfm];
+const REMARK_PLUGINS = [remarkGfm, remarkLocalMediaReferences];
+
+function appUrlTransform(value: string): string {
+  return isFileReference(value) || assistantMediaKind(value) ? value : defaultUrlTransform(value);
+}
 
 // Repair a single emphasis run whose closing delimiter has a stray leading
 // space (`**text **`), which CommonMark won't parse as bold. Two guards keep us
@@ -167,14 +187,7 @@ type ToolHandlers = {
   requestFileOpen: (path: string) => void;
 };
 
-function buildComponentsWithAppLinks(tools: ToolHandlers): Components {
-  const stripPath = (raw: string) =>
-    raw
-      .trim()
-      .replace(/^`+|`+$/g, "")
-      .replace(/^file:\/\//, "")
-      .replace(/:\d+(?::\d+)?$/, "");
-
+function buildComponentsWithAppLinks(tools: ToolHandlers, cwd: string | null): Components {
   // Clicking a file reference opens it in the right panel's Files view with the
   // file selected — on both web and desktop. `requestFileOpen` opens the panel,
   // switches to the files tab, and the filesystem effect resolves the path
@@ -186,7 +199,7 @@ function buildComponentsWithAppLinks(tools: ToolHandlers): Components {
   // in-app Files view when reveal is unavailable or fails; on web there is no OS
   // file manager, so it just opens the Files view like a plain click.
   const openFileReference = (raw: string, revealInOs: boolean) => {
-    const cleaned = stripPath(raw);
+    const cleaned = cleanFileReference(raw);
     if (!cleaned) return;
     const reveal = revealInOs ? window.localStudioDesktop?.revealPath : undefined;
     if (reveal) {
@@ -212,10 +225,28 @@ function buildComponentsWithAppLinks(tools: ToolHandlers): Components {
         );
       }
       const value = nodeToPlainText(children).trim();
+      const mediaKind = assistantMediaKind(value);
+      if (mediaKind) {
+        return (
+          <AssistantMedia cwd={cwd} kind={mediaKind} onOpen={openFileReference} reference={value} />
+        );
+      }
       if (isFileReference(value)) return <FileLink onOpen={openFileReference} value={value} />;
       return <code {...props}>{children}</code>;
     },
     a: ({ node: _n, href, children, ...props }) => {
+      const mediaKind = assistantMediaKind(href);
+      if (typeof href === "string" && mediaKind) {
+        return (
+          <AssistantMedia
+            cwd={cwd}
+            kind={mediaKind}
+            label={nodeToPlainText(children)}
+            onOpen={openFileReference}
+            reference={href}
+          />
+        );
+      }
       if (typeof href === "string" && isFileReference(href)) {
         return (
           <FileLink onOpen={openFileReference} value={href}>
@@ -245,7 +276,88 @@ function buildComponentsWithAppLinks(tools: ToolHandlers): Components {
         </a>
       );
     },
+    img: ({ src, alt }) => {
+      const reference = typeof src === "string" ? src : "";
+      const mediaKind = assistantMediaKind(reference);
+      return mediaKind ? (
+        <AssistantMedia
+          cwd={cwd}
+          kind={mediaKind}
+          label={alt ?? undefined}
+          onOpen={openFileReference}
+          reference={reference}
+        />
+      ) : (
+        <span>{alt ? `[Image: ${alt}]` : "[Remote image hidden]"}</span>
+      );
+    },
   };
+}
+
+function AssistantMedia({
+  cwd,
+  kind,
+  label,
+  onOpen,
+  reference,
+}: {
+  cwd: string | null;
+  kind: AssistantMediaKind;
+  label?: string;
+  onOpen: (value: string, revealInOs: boolean) => void;
+  reference: string;
+}) {
+  const source = assistantMediaSource(reference, cwd);
+  if (!source) return <FileLink onOpen={onOpen} value={reference} />;
+  return (
+    <AssistantMediaPlayback
+      key={source}
+      kind={kind}
+      label={label?.trim() || assistantMediaName(reference)}
+      onOpen={onOpen}
+      reference={reference}
+      source={source}
+    />
+  );
+}
+
+function AssistantMediaPlayback({
+  kind,
+  label,
+  onOpen,
+  reference,
+  source,
+}: {
+  kind: AssistantMediaKind;
+  label: string;
+  onOpen: (value: string, revealInOs: boolean) => void;
+  reference: string;
+  source: string;
+}) {
+  const [failed, setFailed] = useState(false);
+  if (failed) return <FileLink onOpen={onOpen} value={reference} />;
+  return (
+    <span className="chat-response-media" data-kind={kind}>
+      {kind === "image" ? (
+        <img src={source} alt={label} loading="lazy" onError={() => setFailed(true)} />
+      ) : kind === "video" ? (
+        <video
+          src={source}
+          controls
+          preload="metadata"
+          playsInline
+          onError={() => setFailed(true)}
+        />
+      ) : (
+        <audio src={source} controls preload="metadata" onError={() => setFailed(true)} />
+      )}
+      <span className="chat-response-media-caption">
+        <FileLink onOpen={onOpen} value={reference}>
+          {label}
+        </FileLink>
+      </span>
+    </span>
+  );
 }
 
 // A file path renders as a plain blue link (monospace, so paths stay legible)
@@ -274,7 +386,7 @@ function FileLink({
   );
 }
 
-function AssistantMarkdownInner({ text }: { text: string }) {
+function AssistantMarkdownInner({ text, cwd = null }: { text: string; cwd?: string | null }) {
   // Actions-only subscription: tools state churn (browser typing, selections)
   // never re-renders frozen markdown blocks.
   const tools = useToolsActions();
@@ -283,13 +395,16 @@ function AssistantMarkdownInner({ text }: { text: string }) {
   // captures changes identity (they're useCallback-stable in ToolsProvider).
   const componentsWithAppLinks = useMemo<Components>(
     () =>
-      buildComponentsWithAppLinks({
-        setComputerOpen: tools.setComputerOpen,
-        setComputerTab: tools.setComputerTab,
-        setBrowserUrl: tools.setBrowserUrl,
-        requestFileOpen: tools.requestFileOpen,
-      }),
-    [tools.setComputerOpen, tools.setComputerTab, tools.setBrowserUrl, tools.requestFileOpen],
+      buildComponentsWithAppLinks(
+        {
+          setComputerOpen: tools.setComputerOpen,
+          setComputerTab: tools.setComputerTab,
+          setBrowserUrl: tools.setBrowserUrl,
+          requestFileOpen: tools.requestFileOpen,
+        },
+        cwd,
+      ),
+    [cwd, tools.setComputerOpen, tools.setComputerTab, tools.setBrowserUrl, tools.requestFileOpen],
   );
   return (
     <div className="chat-markdown min-w-0 max-w-full overflow-x-hidden [overflow-wrap:anywhere]">
@@ -300,7 +415,11 @@ function AssistantMarkdownInner({ text }: { text: string }) {
           </pre>
         }
       >
-        <ReactMarkdown remarkPlugins={REMARK_PLUGINS} components={componentsWithAppLinks}>
+        <ReactMarkdown
+          remarkPlugins={REMARK_PLUGINS}
+          components={componentsWithAppLinks}
+          urlTransform={appUrlTransform}
+        >
           {normalizedText}
         </ReactMarkdown>
       </MarkdownErrorBoundary>

--- a/frontend/src/features/agent/ui/assistant-media.test.ts
+++ b/frontend/src/features/agent/ui/assistant-media.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  assistantMediaKind,
+  assistantMediaSource,
+  cleanFileReference,
+  remarkLocalMediaReferences,
+} from "./assistant-media";
+
+describe("assistant response media", () => {
+  test("classifies local image, video, audio, and SVG references", () => {
+    assert.equal(assistantMediaKind("/tmp/result.png"), "image");
+    assert.equal(assistantMediaKind("./diagram.svg"), "image");
+    assert.equal(assistantMediaKind("outputs/demo.mp4"), "video");
+    assert.equal(assistantMediaKind("~/Music/answer.wav"), "audio");
+    assert.equal(assistantMediaKind("https://example.com/result.png"), null);
+    assert.equal(assistantMediaKind("src/index.ts"), null);
+  });
+
+  test("builds authenticated raw-file URLs for relative and absolute paths", () => {
+    assert.equal(
+      assistantMediaSource("output/result.png", "/Users/me/project"),
+      "/api/agent/fs/raw?cwd=%2FUsers%2Fme%2Fproject&path=output%2Fresult.png",
+    );
+    assert.equal(
+      assistantMediaSource("/Users/me/Desktop/demo.mp4", "/Users/me/project"),
+      "/api/agent/fs/raw?cwd=%2FUsers%2Fme%2FDesktop&path=demo.mp4",
+    );
+  });
+
+  test("decodes file URLs before opening or serving them", () => {
+    assert.equal(
+      cleanFileReference("file:///Users/me/Desktop/a%20demo.svg"),
+      "/Users/me/Desktop/a demo.svg",
+    );
+  });
+
+  test("turns unformatted media paths into markdown links without touching remote URLs", () => {
+    const tree = {
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            {
+              type: "text",
+              value:
+                "Rendered /Users/me/out/image.svg and clips/demo.mp4, not https://example.com/a.png.",
+            },
+          ],
+        },
+      ],
+    };
+    remarkLocalMediaReferences()(tree);
+    const children = (tree.children[0]?.children ?? []) as Array<{ type: string; url?: string }>;
+    assert.deepEqual(
+      children.filter((node) => node.type === "link").map((node) => node.url),
+      ["/Users/me/out/image.svg", "clips/demo.mp4"],
+    );
+  });
+
+  test("does not rewrite media-looking paths inside code", () => {
+    const tree = {
+      type: "root",
+      children: [{ type: "code", value: "ffmpeg -i clips/demo.mp4" }],
+    };
+    remarkLocalMediaReferences()(tree);
+    assert.deepEqual(tree.children, [{ type: "code", value: "ffmpeg -i clips/demo.mp4" }]);
+  });
+});

--- a/frontend/src/features/agent/ui/assistant-media.ts
+++ b/frontend/src/features/agent/ui/assistant-media.ts
@@ -1,0 +1,120 @@
+import { resolveFileOpenTarget } from "@/features/agent/ui/filesystem-panel-effects";
+
+export type AssistantMediaKind = "image" | "video" | "audio";
+
+type MarkdownNode = {
+  type: string;
+  value?: string;
+  url?: string;
+  children?: MarkdownNode[];
+};
+
+const IMAGE_EXTENSIONS = new Set([
+  "apng",
+  "avif",
+  "bmp",
+  "gif",
+  "ico",
+  "jpeg",
+  "jpg",
+  "png",
+  "svg",
+  "webp",
+]);
+const VIDEO_EXTENSIONS = new Set(["m4v", "mov", "mp4", "mpeg", "mpg", "ogv", "webm"]);
+const AUDIO_EXTENSIONS = new Set([
+  "aac",
+  "flac",
+  "m4a",
+  "mp3",
+  "oga",
+  "ogg",
+  "opus",
+  "wav",
+  "wave",
+]);
+const MEDIA_EXTENSIONS = [...IMAGE_EXTENSIONS, ...VIDEO_EXTENSIONS, ...AUDIO_EXTENSIONS].join("|");
+const MEDIA_TOKEN_PATTERN = new RegExp(
+  `(^|[\\s([{\"'])([^\\s\\x60'\")<>]+\\.(?:${MEDIA_EXTENSIONS}))(?=$|[\\s)\\]}\",.!?;:])`,
+  "gi",
+);
+const SKIPPED_MARKDOWN_NODES = new Set(["code", "inlineCode", "link", "image"]);
+
+export function cleanFileReference(value: string): string {
+  let clean = value.trim().replace(/^`+|`+$/g, "");
+  if (/^file:\/\//i.test(clean)) {
+    try {
+      clean = decodeURIComponent(new URL(clean).pathname);
+    } catch {
+      clean = clean.replace(/^file:\/\//i, "");
+    }
+  } else {
+    try {
+      clean = decodeURIComponent(clean);
+    } catch {
+      return clean.replace(/:\d+(?::\d+)?$/, "");
+    }
+  }
+  return clean.replace(/:\d+(?::\d+)?$/, "");
+}
+
+export function assistantMediaKind(value: string | undefined): AssistantMediaKind | null {
+  if (!value || /^(?:https?|data|blob):/i.test(value.trim())) return null;
+  const clean = cleanFileReference(value).split(/[?#]/, 1)[0] ?? "";
+  const extension = /\.([A-Za-z0-9]+)$/.exec(clean)?.[1]?.toLowerCase();
+  if (!extension) return null;
+  if (IMAGE_EXTENSIONS.has(extension)) return "image";
+  if (VIDEO_EXTENSIONS.has(extension)) return "video";
+  if (AUDIO_EXTENSIONS.has(extension)) return "audio";
+  return null;
+}
+
+export function assistantMediaSource(reference: string, cwd: string | null): string | null {
+  if (!assistantMediaKind(reference)) return null;
+  const target = resolveFileOpenTarget(cleanFileReference(reference), cwd);
+  if (!target || target.kind !== "file") return null;
+  return `/api/agent/fs/raw?cwd=${encodeURIComponent(target.root)}&path=${encodeURIComponent(target.rel)}`;
+}
+
+export function assistantMediaName(reference: string): string {
+  const clean = cleanFileReference(reference).replace(/\/+$/, "");
+  return clean.slice(clean.lastIndexOf("/") + 1) || clean;
+}
+
+function splitMediaReferences(value: string): MarkdownNode[] {
+  const nodes: MarkdownNode[] = [];
+  let cursor = 0;
+  MEDIA_TOKEN_PATTERN.lastIndex = 0;
+  for (
+    let match = MEDIA_TOKEN_PATTERN.exec(value);
+    match;
+    match = MEDIA_TOKEN_PATTERN.exec(value)
+  ) {
+    const prefix = match[1] ?? "";
+    const reference = match[2] ?? "";
+    if (!assistantMediaKind(reference)) continue;
+    const start = match.index + prefix.length;
+    if (start > cursor) nodes.push({ type: "text", value: value.slice(cursor, start) });
+    nodes.push({
+      type: "link",
+      url: reference,
+      children: [{ type: "text", value: reference }],
+    });
+    cursor = start + reference.length;
+  }
+  if (cursor === 0) return [{ type: "text", value }];
+  if (cursor < value.length) nodes.push({ type: "text", value: value.slice(cursor) });
+  return nodes;
+}
+
+function transformMarkdownNode(node: MarkdownNode): void {
+  if (!node.children || SKIPPED_MARKDOWN_NODES.has(node.type)) return;
+  node.children = node.children.flatMap((child) =>
+    child.type === "text" && child.value ? splitMediaReferences(child.value) : [child],
+  );
+  for (const child of node.children) transformMarkdownNode(child);
+}
+
+export function remarkLocalMediaReferences() {
+  return (tree: MarkdownNode) => transformMarkdownNode(tree);
+}

--- a/frontend/src/features/agent/ui/chat-pane.tsx
+++ b/frontend/src/features/agent/ui/chat-pane.tsx
@@ -172,6 +172,7 @@ function ChatTranscript({
   stickToBottom,
   setStickToBottom,
   running,
+  cwd,
   onForkSession,
   loadEarlierHistory,
 }: {
@@ -182,6 +183,7 @@ function ChatTranscript({
   stickToBottom: boolean;
   setStickToBottom: (value: boolean) => void;
   running: boolean;
+  cwd: string;
   onForkSession?: () => void;
   loadEarlierHistory: () => Promise<void>;
 }) {
@@ -199,6 +201,7 @@ function ChatTranscript({
           onStickToBottomChange={setStickToBottom}
           messages={activeTab?.messages ?? []}
           running={running}
+          cwd={cwd || null}
           viewKey={viewKey}
           viewAlias={viewAlias}
           onForkSession={onForkSession}
@@ -667,6 +670,7 @@ export function ChatPane({
         stickToBottom={stickToBottom}
         setStickToBottom={setStickToBottom}
         running={Boolean(running)}
+        cwd={cwd}
         onForkSession={onForkSession}
         loadEarlierHistory={loadEarlierHistory}
       />

--- a/frontend/src/features/agent/ui/timeline/session-pane-block-router.tsx
+++ b/frontend/src/features/agent/ui/timeline/session-pane-block-router.tsx
@@ -13,8 +13,14 @@ import {
 // Per-content-block memo. `appendDelta` preserves the reference of every
 // non-trailing text block during streaming, so prior content blocks skip
 // re-rendering entirely once the assistant moves on past them.
-const MemoContentBlock = memo(function MemoContentBlock({ block }: { block: TextBlock }) {
-  return <AssistantMarkdown text={block.text} />;
+const MemoContentBlock = memo(function MemoContentBlock({
+  block,
+  cwd,
+}: {
+  block: TextBlock;
+  cwd: string | null;
+}) {
+  return <AssistantMarkdown text={block.text} cwd={cwd} />;
 });
 
 function EventBlockView({ block }: { block: EventBlock }) {
@@ -42,11 +48,13 @@ const AssistantBlocks = memo(function AssistantBlocks({
   blocks,
   live,
   running,
+  cwd,
   onForkSession,
 }: {
   blocks: AssistantBlock[];
   live: boolean;
   running: boolean;
+  cwd: string | null;
   onForkSession?: () => void;
 }) {
   const routedBlocks = useMemo(() => groupAssistantBlocks(blocks), [blocks]);
@@ -80,7 +88,7 @@ const AssistantBlocks = memo(function AssistantBlocks({
     if (item.kind === "content") {
       nodes.push(
         <div key={item.block.id} className="min-w-0">
-          <MemoContentBlock block={item.block} />
+          <MemoContentBlock block={item.block} cwd={cwd} />
           {showActions && index === lastContentIndex ? (
             <AssistantMessageActions copyText={copyText} onForkSession={onForkSession} />
           ) : null}
@@ -101,11 +109,13 @@ function SessionPaneBlockRouterInner({
   message,
   live,
   running,
+  cwd,
   onForkSession,
 }: {
   message: ChatMessage;
   live: boolean;
   running: boolean;
+  cwd: string | null;
   onForkSession?: () => void;
 }) {
   if (message.role === "user") {
@@ -117,6 +127,7 @@ function SessionPaneBlockRouterInner({
       blocks={message.blocks ?? EMPTY_BLOCKS}
       live={live}
       running={running}
+      cwd={cwd}
       onForkSession={onForkSession}
     />
   );

--- a/frontend/src/features/agent/ui/timeline/timeline.tsx
+++ b/frontend/src/features/agent/ui/timeline/timeline.tsx
@@ -25,6 +25,7 @@ function messageRenders(message: ChatMessage): boolean {
 type TimelineProps = {
   messages: ChatMessage[];
   running: boolean;
+  cwd: string | null;
   onForkSession?: () => void;
   emptyPrompt?: boolean;
   stickToBottom?: boolean;
@@ -41,27 +42,37 @@ const MemoMessage = memo(
     message,
     live,
     running,
+    cwd,
     onForkSession,
   }: {
     message: ChatMessage;
     live: boolean;
     running: boolean;
+    cwd: string | null;
     onForkSession?: () => void;
   }) {
     return (
-      <MessageView message={message} live={live} running={running} onForkSession={onForkSession} />
+      <MessageView
+        message={message}
+        live={live}
+        running={running}
+        cwd={cwd}
+        onForkSession={onForkSession}
+      />
     );
   },
   (prev, next) =>
     prev.message === next.message &&
     prev.live === next.live &&
     prev.running === next.running &&
+    prev.cwd === next.cwd &&
     prev.onForkSession === next.onForkSession,
 );
 
 export function Timeline({
   messages,
   running,
+  cwd,
   onForkSession,
   emptyPrompt = false,
   stickToBottom = true,
@@ -131,6 +142,7 @@ export function Timeline({
                     message={message}
                     live={isLast && running}
                     running={running}
+                    cwd={cwd}
                     onForkSession={onForkSession}
                   />
                 </div>
@@ -670,11 +682,13 @@ function MessageView({
   message,
   live = false,
   running = false,
+  cwd = null,
   onForkSession,
 }: {
   message: ChatMessage;
   live?: boolean;
   running?: boolean;
+  cwd?: string | null;
   onForkSession?: () => void;
 }) {
   return (
@@ -682,6 +696,7 @@ function MessageView({
       message={message}
       live={live}
       running={running}
+      cwd={cwd}
       onForkSession={onForkSession}
     />
   );


### PR DESCRIPTION
## Summary

- render local PNG, JPEG, GIF, WebP, AVIF, BMP, ICO, APNG, and SVG references inline in assistant responses
- render referenced MP4, MOV, WebM, OGV, MP3, WAV, M4A, AAC, FLAC, OGG, and Opus files with native video/audio controls
- recognize Markdown images, Markdown links, inline-code paths, and plain media paths while leaving remote images hidden
- stream authenticated local files with byte-range support and constrain direct SVG documents with a restrictive CSP

## Validation

- `npm run check`
- 139 frontend tests, 90 controller tests, and 97 agent-runtime tests passed
- browser acceptance: PNG and SVG loaded at intrinsic dimensions; MP4 and WAV reached readyState 4 and duration 1s through 206 responses