### PR TITLE
fix(agent): prevent DeepSeek control token leaks

### DIFF
--- a/controller/src/modules/proxy/tool-call-stream.ts
+++ b/controller/src/modules/proxy/tool-call-stream.ts
@@ -23,6 +23,16 @@ export interface ToolCallStreamOptions {
   bufferImplicitReasoningContent?: boolean;
 }
 
+// DeepSeek V4 occasionally emits these control tokens as visible text around
+// long, tool-heavy conversations. They are prompt delimiters, never intended
+// for the client, and replaying them in the next assistant message amplifies
+// the leak. The tokenizer normally hides them, but strip the literal fallback
+// here as well so every controller client gets a clean stream.
+const stripLeakedDeepSeekControlTokens = (text: string): string =>
+  text
+    .replaceAll("<｜begin▁of▁sentence｜>", "")
+    .replaceAll("<｜end▁of▁sentence｜>", "");
+
 export const createToolCallStream = (
   source: ReadableStream<Uint8Array>,
   onUsage?: (usage: StreamUsage) => void,
@@ -41,7 +51,7 @@ export const createToolCallStream = (
   const reasoningHistory = new Map<string, { text: string; snapshot: boolean }>();
   const replayCursors = new Map<string, number>();
   const stripToolXmlDelta = (text: string): string => {
-    return stripToolCallsFromContent(text);
+    return stripToolCallsFromContent(stripLeakedDeepSeekControlTokens(text));
   };
 
   const normalizeTextDelta = (
@@ -142,8 +152,9 @@ export const createToolCallStream = (
     content: string,
   ): void => {
     if (!content) return;
-    visibleContentBuffer += content;
-    const cleaned = stripToolXmlDelta(content);
+    const controlTokensStripped = stripLeakedDeepSeekControlTokens(content);
+    visibleContentBuffer += controlTokensStripped;
+    const cleaned = stripToolXmlDelta(controlTokensStripped);
     const chunk = buildFlushChunk({ content: cleaned });
     if (chunk) enqueueDataEvent(controller, chunk);
   };
@@ -286,10 +297,11 @@ export const createToolCallStream = (
         let reasoningFromContent = "";
         if (content) {
           const rewritten = contentThink.rewrite(content, false);
-          if (rewritten.content) {
-            visibleContentBuffer += rewritten.content;
+          const controlTokensStripped = stripLeakedDeepSeekControlTokens(rewritten.content);
+          if (controlTokensStripped) {
+            visibleContentBuffer += controlTokensStripped;
           }
-          const cleanedContent = stripToolXmlDelta(rewritten.content);
+          const cleanedContent = stripToolXmlDelta(controlTokensStripped);
           if (cleanedContent) {
             delta["content"] = cleanedContent;
           } else if ("content" in delta) {

--- a/services/agent-runtime/src/pi-runtime-models.ts
+++ b/services/agent-runtime/src/pi-runtime-models.ts
@@ -442,6 +442,10 @@ function isDeepSeekReasoningModel(model: AgentModel): boolean {
   return model.reasoning && id.includes("deepseek");
 }
 
+function isControllerBackedModel(model: AgentModel): boolean {
+  return typeof model.controllerUrl === "string" && model.controllerUrl.length > 0;
+}
+
 function isInklingReasoningModel(model: AgentModel): boolean {
   const id = `${model.id} ${model.rawId ?? ""} ${model.name}`.toLowerCase();
   return model.reasoning && id.includes("inkling");
@@ -458,7 +462,13 @@ const VLLM_OPENAI_COMPAT: OpenAICompletionsCompat = {
 
 export function modelsToPiModels(models: AgentModel[]) {
   return models.map((model) => {
-    const deepSeekReasoning = isDeepSeekReasoningModel(model);
+    // The hosted DeepSeek API uses a `thinking` object and requires an empty
+    // `reasoning_content` field on replayed assistant messages. Our vLLM
+    // controller exposes DeepSeek V4 through the standard OpenAI-compatible
+    // surface instead, where that hosted-only dialect corrupts tool-history
+    // turns. Keep the ordinary `reasoning_effort` mapping for controller models.
+    const deepSeekReasoning =
+      isDeepSeekReasoningModel(model) && !isControllerBackedModel(model);
     const inklingReasoning = isInklingReasoningModel(model);
     return {
       id: model.rawId ?? model.id,


### PR DESCRIPTION
Fixes literal DeepSeek begin/end-of-sentence control tokens appearing in Local Studio around tool-call turns.

- Treat controller-backed DeepSeek V4 as a local vLLM model rather than the hosted DeepSeek thinking protocol.
- Strip leaked DeepSeek control markers from the controller tool-call stream and replay buffer.

Validated controller typecheck/lint, agent-runtime build, compatibility classification, and a synthetic streamed tool-call case.