### PR TITLE
Expose external provider models through GET /v1/models

### DIFF
--- a/controller/src/modules/models/routes.ts
+++ b/controller/src/modules/models/routes.ts
@@ -44,6 +44,7 @@ import { notFound } from "../../core/errors";
 import { findObservedInferenceProcess } from "../../core/function-observability";
 import { parseBooleanFlag } from "../../core/validation";
 import { fetchInference } from "../../http/local-fetch";
+import { discoverProviderModels, enabledProvidersWithApiKey } from "../../services/provider-routing";
 
 function isMockInferenceEnabled(): boolean {
   return parseBooleanFlag(process.env["LOCAL_STUDIO_MOCK_INFERENCE"]);
@@ -133,6 +134,28 @@ export const registerModelsRoutes = defineRoutes((app, context) => {
                 vision: resolveModelVision({ identifiers: [inferredId] }),
               },
             });
+          }
+
+          const providerResults = yield* Effect.forEach(
+            enabledProvidersWithApiKey(context.config.providers),
+            (provider) => discoverProviderModels(provider).pipe(Effect.option),
+            { concurrency: "unbounded" },
+          );
+          for (const result of providerResults) {
+            if (result._tag !== "Some") continue;
+            for (const model of result.value.models) {
+              const modelId = `${result.value.provider}/${model.id}`;
+              models.push({
+                id: modelId,
+                object: "model",
+                created: now,
+                owned_by: result.value.provider,
+                active: false,
+                metadata: {
+                  vision: resolveModelVision({ identifiers: [modelId, model.id] }),
+                },
+              });
+            }
           }
 
           const payload: OpenAIModelList = { object: "list", data: models };

--- a/controller/src/modules/studio/provider-routes.ts
+++ b/controller/src/modules/studio/provider-routes.ts
@@ -4,6 +4,7 @@ import { decodeJsonBody } from "../../core/validation";
 import { effectHandler } from "../../http/effect-handler";
 import { documentRoute, defineRoutes, mergeRoutes } from "../../http/route-registrar";
 import { savePersistedConfig, type ProviderConfig } from "../../config/persisted-config";
+import { discoverProviderModels, enabledProvidersWithApiKey } from "../../services/provider-routing";
 
 type ProviderView = {
   id: string;
@@ -26,10 +27,6 @@ const ProviderUpdateSchema = Schema.Struct({
   base_url: Schema.optional(Schema.String),
   api_key: Schema.optional(Schema.String),
   enabled: Schema.optional(Schema.Boolean),
-});
-
-const ProviderModelsSchema = Schema.Struct({
-  data: Schema.optional(Schema.Array(Schema.Struct({ id: Schema.optional(Schema.String) }))),
 });
 
 class ProviderPersistenceError extends Schema.TaggedErrorClass<ProviderPersistenceError>()(
@@ -65,32 +62,6 @@ const required = (
   const trimmed = value.trim();
   return trimmed ? Effect.succeed(trimmed) : Effect.fail(badRequest(`${label} is required`));
 };
-
-const providerModels = (
-  provider: ProviderConfig,
-): Effect.Effect<{ provider: string; models: Array<{ id: string }> }, unknown> =>
-  Effect.gen(function* () {
-    const url = `${provider.base_url.replace(/\/+$/, "")}/v1/models`;
-    const response = yield* Effect.tryPromise({
-      try: () =>
-        fetch(url, {
-          headers: { Authorization: `Bearer ${provider.api_key}` },
-          signal: AbortSignal.timeout(10_000),
-        }),
-      catch: (source) => source,
-    });
-    if (!response.ok) return yield* Effect.fail(response.status);
-    const payload = yield* Effect.tryPromise({
-      try: () => response.json(),
-      catch: (source) => source,
-    });
-    const decoded = yield* Schema.decodeUnknownEffect(ProviderModelsSchema)(payload);
-    const models = (decoded.data ?? []).flatMap((model) => {
-      const id = model.id?.trim();
-      return id ? [{ id }] : [];
-    });
-    return { provider: provider.id, models };
-  });
 
 export const registerStudioProviderRoutes = defineRoutes((app, context) => {
   return mergeRoutes(
@@ -182,8 +153,8 @@ export const registerStudioProviderRoutes = defineRoutes((app, context) => {
       documentRoute,
       effectHandler((ctx) =>
         Effect.forEach(
-          context.config.providers.filter((provider) => provider.enabled && provider.api_key),
-          (provider) => providerModels(provider).pipe(Effect.option),
+          enabledProvidersWithApiKey(context.config.providers),
+          (provider) => discoverProviderModels(provider).pipe(Effect.option),
           { concurrency: "unbounded" },
         ).pipe(
           Effect.map((results) =>

--- a/controller/src/services/provider-routing.ts
+++ b/controller/src/services/provider-routing.ts
@@ -1,3 +1,4 @@
+import { Effect, Schema } from "effect";
 import type { ProviderConfig } from "../config/persisted-config";
 
 export const DEFAULT_CHAT_PROVIDER = "openai";
@@ -49,3 +50,41 @@ export const resolveProviderConfig = (
 ): ProviderRouteConfig | null => {
   return resolveConfiguredProviderConfig(provider, config.providers);
 };
+
+export interface DiscoveredProviderModels {
+  provider: string;
+  models: Array<{ id: string }>;
+}
+
+const ProviderModelsSchema = Schema.Struct({
+  data: Schema.optional(Schema.Array(Schema.Struct({ id: Schema.optional(Schema.String) }))),
+});
+
+export const discoverProviderModels = (
+  provider: ProviderConfig,
+): Effect.Effect<DiscoveredProviderModels, unknown> =>
+  Effect.gen(function* () {
+    const url = `${provider.base_url.replace(/\/+$/, "")}/v1/models`;
+    const response = yield* Effect.tryPromise({
+      try: () =>
+        fetch(url, {
+          headers: { Authorization: `Bearer ${provider.api_key}` },
+          signal: AbortSignal.timeout(10_000),
+        }),
+      catch: (source) => source,
+    });
+    if (!response.ok) return yield* Effect.fail(response.status);
+    const payload = yield* Effect.tryPromise({
+      try: () => response.json(),
+      catch: (source) => source,
+    });
+    const decoded = yield* Schema.decodeUnknownEffect(ProviderModelsSchema)(payload);
+    const models = (decoded.data ?? []).flatMap((model) => {
+      const id = model.id?.trim();
+      return id ? [{ id }] : [];
+    });
+    return { provider: provider.id, models };
+  });
+
+export const enabledProvidersWithApiKey = (providers: ProviderConfig[] = []): ProviderConfig[] =>
+  providers.filter((provider) => provider.enabled && provider.api_key);


### PR DESCRIPTION
## Summary

Controllers with configured external OpenAI-compatible providers only surfaced those providers' models via `GET /studio/provider-models`. Since models are discovered through `GET /v1/models`, external provider models were invisible in the model picker even when the provider was configured and reachable.

## Changes

- **Shared discovery helper**: extracted `discoverProviderModels` and `enabledProvidersWithApiKey` into `controller/src/services/provider-routing.ts`, replacing the inline `providerModels` function previously duplicated in `provider-routes.ts`.
- **`/studio/provider-models`**: now consumes the shared helper; behavior unchanged.
- **`GET /v1/models`**: now also queries enabled, API-key-configured providers and appends their models as qualified IDs (`<provider-id>/<upstream-model-id>`), alongside existing recipe/active-inference entries. Per-provider discovery failures are swallowed (`Effect.option`) so one unreachable provider never fails the whole endpoint, matching `/studio/provider-models` semantics.
- No changes needed in the proxy (`openai-routes.ts`) — it already parses the qualified ID and rewrites the upstream request model correctly.

Example: with provider `my-provider` (base_url `http://<host>:8000`) enabled and reporting `example-model-1`, `GET /v1/models` now includes:

```json
{
  "id": "my-provider/example-model-1",
  "object": "model",
  "owned_by": "my-provider",
  "active": false,
  "metadata": { "vision": false }
}
```

## Validation

```bash
cd controller && bun run typecheck
cd controller && bun run lint
cd controller && bun run check
node scripts/project.mjs validate-contracts
node scripts/project.mjs validate-structure
node scripts/project.mjs audit-layout
```

Manually verified end-to-end against a live controller and a mock upstream provider server: `GET /v1/models` returned the qualified model ID, and a chat completion request using that ID was routed upstream with the model field rewritten back to the original provider model ID.

## UI changes

None — controller-only change. Effect is a discoverability fix for the existing model picker.

## Risks / rollout notes

- Purely additive to `/v1/models` response; existing consumers unaffected.
- Provider discovery adds one upstream HTTP call per enabled/configured provider per `/v1/models` request (10s timeout, best-effort, run concurrently) — negligible latency impact for typical provider counts.

Closes #410
