### PR TITLE
fix(status): survive a controller that answers /compat with {}

### DIFF
--- a/frontend/src/hooks/realtime-status-equality.ts
+++ b/frontend/src/hooks/realtime-status-equality.ts
@@ -99,9 +99,11 @@ export function areRuntimeSummariesEqual(
 ) {
   if (a === b) return true;
   if (!a || !b) return false;
-  if (a.platform.kind !== b.platform.kind) return false;
-  if (a.gpu_monitoring.available !== b.gpu_monitoring.available) return false;
-  if (a.gpu_monitoring.tool !== b.gpu_monitoring.tool) return false;
+  // Optional chaining throughout: these summaries can be built from a partial
+  // controller payload, and an equality check is never worth throwing over.
+  if (a.platform?.kind !== b.platform?.kind) return false;
+  if (a.gpu_monitoring?.available !== b.gpu_monitoring?.available) return false;
+  if (a.gpu_monitoring?.tool !== b.gpu_monitoring?.tool) return false;
   for (const key of ["vllm", "sglang", "llamacpp", "mlx"] as const) {
     if (!a.backends[key] && !b.backends[key]) continue;
     if (!a.backends[key] || !b.backends[key]) return false;

--- a/frontend/src/hooks/realtime-status-store.ts
+++ b/frontend/src/hooks/realtime-status-store.ts
@@ -232,10 +232,15 @@ function runtimeSummaryFromCompatibility(
   compatibility: PolledCompatibility | null,
 ): RuntimeSummaryData | null {
   if (current || !compatibility) return current;
-  const kind = compatibility.platform.kind;
+  // A controller can answer /compat with a degraded payload — an older build
+  // returns a bare `{}` — and reading through it threw inside the poll promise,
+  // which killed the polling chain and froze the whole status surface. Without
+  // a platform there is no summary worth synthesizing, so keep what we had.
+  const kind = compatibility.platform?.kind;
+  if (!kind) return current;
   return {
     platform: { kind, vendor: fallbackRuntimeVendor(kind) },
-    gpu_monitoring: compatibility.gpu_monitoring,
+    gpu_monitoring: compatibility.gpu_monitoring ?? { available: false, tool: null },
     backends: normalizeRuntimeBackends(compatibility.backends),
   };
 }


### PR DESCRIPTION
## What was happening

The desktop app looked like it was crashing. It wasn't — the status surface was freezing on stale data.

Chain:

1. The configured controller (`omarchy.tailadb2c1.ts.net:8080`) answers `GET /compat` with `200 {}` — an older build, so the payload has no `platform`.
2. `runtimeSummaryFromCompatibility` read `compatibility.platform.kind` straight through it.
3. `TypeError: Cannot read properties of undefined (reading 'kind')`, thrown **inside the polling promise** — uncaught, no error boundary, no crash dialog.
4. The poll chain died. Status froze on its last good render while `/status` requests piled up and aborted at 5 s.

## Fix

Without a platform there is no summary worth synthesizing, so keep the current one rather than building a broken one. `areRuntimeSummariesEqual` gets the same treatment — an equality check is never worth throwing over. `normalizeRuntimeBackends` already tolerated a missing payload; `platform` and `gpu_monitoring` now do too.

## Verified

Ran the dev server against that exact controller. Before: the TypeError on every load. After: no exception, and Status renders live (Qwen3.8-27B on sglang, 4× RTX 3090).

The controller on that box should still be redeployed — `/compat` returning `{}` is its own bug. This just stops one degraded endpoint from taking the whole status surface down with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)