### PR TITLE
fix(usage): restore the profile header and stat grid above the tabs

### DIFF
--- a/frontend/src/features/usage/usage-activity-tab.tsx
+++ b/frontend/src/features/usage/usage-activity-tab.tsx
@@ -15,7 +15,6 @@ import {
   TableNotice,
   type Stat,
 } from "@/features/recipes/recipes-content/catalog-table-shell";
-import { TokenActivityHeatmap } from "./token-activity-heatmap";
 import { UsageBarRow, type UsageBar } from "./usage-bars";
 import { useSortedRows } from "./usage-sort";
 
@@ -237,16 +236,6 @@ export function UsageActivityTab({ stats }: { stats: UsageStats }) {
           ) : null}
         </TableFrame>
       )}
-
-      <section>
-        <div className="flex items-baseline justify-between gap-4">
-          <h3 className="text-[length:var(--fs-md)] font-medium text-(--ui-fg)">Past year</h3>
-          <span className="text-[length:var(--fs-xs)] text-(--dim)/70">tokens per day</span>
-        </div>
-        <div className="mt-3">
-          <TokenActivityHeatmap daily={stats.daily} />
-        </div>
-      </section>
     </div>
   );
 }

--- a/frontend/src/features/usage/usage-models-tab.tsx
+++ b/frontend/src/features/usage/usage-models-tab.tsx
@@ -21,15 +21,7 @@ import { UsageModelDrawer, modelIdentity, type UsageModel } from "./usage-model-
 import { useSortedRows } from "./usage-sort";
 
 type SortKey =
-  | "model"
-  | "requests"
-  | "tokens"
-  | "avg"
-  | "prefill"
-  | "decode"
-  | "ttft"
-  | "latency"
-  | "success";
+  "model" | "requests" | "tokens" | "avg" | "prefill" | "decode" | "ttft" | "latency" | "success";
 
 const sortValue = (row: UsageModel, key: SortKey): number | string | null => {
   switch (key) {
@@ -83,28 +75,17 @@ export function UsageModelsTab({ stats }: { stats: UsageStats }) {
   const peak = sorted.reduce((max, row) => Math.max(max, row.total_tokens), 0);
   const decode = weightedDecodeTps(stats.by_model);
 
+  // Deliberately NOT a second copy of the page's headline grid. Requests,
+  // sessions, success rate and p95 already sit above the tab strip and are true
+  // of the whole window; repeating them here made two near-identical stat rows
+  // stack. What is left is what only this tab can say.
   const summary: Stat[] = [
     {
-      label: "Tokens",
-      value: formatNumber(stats.totals.total_tokens),
-      sub: `${formatCompactTokens(stats.totals.prompt_tokens)} in · ${formatCompactTokens(stats.totals.completion_tokens)} out`,
+      label: "Token mix",
+      value: `${formatCompactTokens(stats.totals.prompt_tokens)} in · ${formatCompactTokens(stats.totals.completion_tokens)} out`,
+      sub: `${formatNumber(stats.totals.total_tokens)} total`,
       title:
-        "Every token this controller proxied, prompt and completion together, across the whole retention window.",
-    },
-    {
-      label: "Requests",
-      value: formatNumber(stats.totals.total_requests),
-      sub: `${stats.totals.success_rate.toFixed(1)}% succeeded`,
-      title: "Completions requested through the proxy, successful and failed.",
-    },
-    {
-      label: "Sessions",
-      value: formatNumber(stats.totals.unique_sessions),
-      sub:
-        stats.totals.unique_users > 0
-          ? `${formatNumber(stats.totals.unique_users)} users`
-          : undefined,
-      title: "Distinct conversation ids seen. One chat that runs all day counts once.",
+        "How the proxied tokens split between prompt and completion. Prefill-heavy traffic is why cache hit rate matters more here than raw throughput.",
     },
     {
       label: "Cache hit rate",
@@ -120,13 +101,6 @@ export function UsageModelsTab({ stats }: { stats: UsageStats }) {
       sub: "weighted by output",
       title:
         "Generation throughput averaged across models, weighted by completion tokens so a rarely-used model cannot skew it. This is the speed a chat actually feels.",
-    },
-    {
-      label: "Latency p95",
-      value: formatMs(stats.latency.p95_ms),
-      sub: `p50 ${formatMs(stats.latency.p50_ms)}`,
-      title:
-        "Wall-clock request duration. p95 is the slow tail you notice; p50 is the request you usually get.",
     },
   ];
 

--- a/frontend/src/features/usage/usage-page.tsx
+++ b/frontend/src/features/usage/usage-page.tsx
@@ -16,6 +16,7 @@ import { UsageModelsTab } from "./usage-models-tab";
 import { UsageActivityTab } from "./usage-activity-tab";
 import { UsageControllerTab } from "./usage-controller-tab";
 import { UsageErrorsTab } from "./usage-errors-tab";
+import { TokenActivityHeatmap } from "./token-activity-heatmap";
 
 type UsageTab = "models" | "activity" | "routes" | "errors";
 
@@ -179,6 +180,19 @@ export default function UsagePage() {
           <Stat label="Success rate" value={`${Math.round(stats.totals.success_rate)}%`} />
           <Stat label="P95 latency" value={milliseconds(stats.latency.p95_ms)} />
         </StatGrid>
+
+        {/* The year at a glance, above the tabs rather than inside one: it is
+            true of the whole window like the grid above it, and it is the thing
+            people come to this page to look at. */}
+        <section className="mt-8">
+          <div className="flex items-baseline justify-between gap-4">
+            <h2 className="text-[length:var(--fs-md)] font-medium text-(--ui-fg)">Past year</h2>
+            <span className="text-[length:var(--fs-xs)] text-(--ui-muted)">tokens per day</span>
+          </div>
+          <div className="mt-3">
+            <TokenActivityHeatmap daily={stats.daily} />
+          </div>
+        </section>
 
         <div className="mt-8 border-b border-(--ui-separator)">
           <Tabs items={USAGE_TABS} activeTab={tab} onSelectTab={setTab} className="-mb-px" />

--- a/frontend/src/features/usage/usage-page.tsx
+++ b/frontend/src/features/usage/usage-page.tsx
@@ -1,10 +1,15 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
-import { AppPage, Button, ErrorBox, RefreshButton, TabbedPage } from "@/ui";
-import { Activity, AlertTriangle, Server, Sparkles } from "@/ui/icon-registry";
+import { useRef, useState, type ReactNode } from "react";
+import { AppPage, Button, ErrorBox, PageContainer, RefreshButton, Tabs } from "@/ui";
+import { Activity, AlertTriangle, Server, Sparkles, Upload } from "@/ui/icon-registry";
 import { formatNumber } from "@/lib/formatters";
 import type { UsageStats } from "@/lib/types";
+import {
+  ProfileAvatar,
+  profileImageFromFile,
+  useLocalProfile,
+} from "@/features/shell/local-profile";
 import { useUsage } from "./use-usage";
 import { UsageSkeleton } from "./usage-skeleton";
 import { UsageModelsTab } from "./usage-models-tab";
@@ -44,55 +49,53 @@ const TAB_HEADINGS: Record<UsageTab, { title: string; description: string }> = {
   },
 };
 
-/** The left half of the context strip: what window the tab's numbers cover. */
-const tabScope = (tab: UsageTab, stats: UsageStats): { scale: string; detail: string } => {
-  if (tab === "models") {
-    return {
-      scale: `${stats.by_model.length} ${stats.by_model.length === 1 ? "model" : "models"}`,
-      detail: `${formatNumber(stats.totals.total_requests)} requests · ${formatNumber(stats.totals.total_tokens)} tokens proxied`,
-    };
+const activeDays = (stats: UsageStats): number =>
+  stats.daily.filter((day) => day.total_tokens > 0).length;
+
+const currentStreak = (stats: UsageStats): number => {
+  const active = new Set(stats.daily.filter((day) => day.total_tokens > 0).map((day) => day.date));
+  const cursor = new Date();
+  cursor.setUTCHours(0, 0, 0, 0);
+  if (!active.has(cursor.toISOString().slice(0, 10))) cursor.setUTCDate(cursor.getUTCDate() - 1);
+  let streak = 0;
+  while (active.has(cursor.toISOString().slice(0, 10))) {
+    streak += 1;
+    cursor.setUTCDate(cursor.getUTCDate() - 1);
   }
-  if (tab === "activity") {
-    return {
-      scale: `${stats.daily.length} days recorded`,
-      detail: `${formatNumber(stats.recent_activity.last_24h_requests)} requests in the last 24 hours`,
-    };
-  }
-  if (tab === "routes") {
-    const controller = stats.controller;
-    return {
-      scale: controller ? `${controller.by_path.length} routes` : "No controller telemetry",
-      detail: controller
-        ? `${formatNumber(controller.totals.total_requests)} controller requests · ${controller.totals.success_rate.toFixed(1)}% served`
-        : "This controller build does not report request stats.",
-    };
-  }
-  const requests = stats.controller?.recent_errors.length ?? 0;
-  const tools = stats.controller?.function_calls?.recent_errors.length ?? 0;
-  return {
-    scale: `${requests + tools} recorded`,
-    detail: `${requests} request errors · ${tools} tool-call errors`,
-  };
+  return streak;
 };
 
+const milliseconds = (value: number | null): string =>
+  value === null ? "—" : `${Math.round(value)} ms`;
+
 /**
- * Usage as four tables.
+ * Usage: the profile summary it always had, with the four tabs underneath.
  *
- * The page used to open on one number at display size and then show three
- * proportional-bar cards, while roughly seventy percent of the payload it
- * already fetched — every throughput field, the whole controller block, the
- * hour-of-day pattern — was normalised and dropped. It is now the Models page's
- * sibling: the same tabbed shell, the same table language, and each tab's stat
- * strip summarising the rows directly beneath it rather than floating free.
+ * The tabs earn their place — they surface throughput, the controller block and
+ * the hour-of-day pattern that the page used to fetch and drop — but the page
+ * still opens the way it did: who this machine is, one headline number, and the
+ * six-cell grid. Those six are true of the whole retention window, so they sit
+ * above the tab strip rather than inside any one tab.
  */
 export default function UsagePage() {
   const { stats, loading, error, loadStats } = useUsage();
   const [tab, setTab] = useState<UsageTab>("models");
+  const [profile, updateProfile] = useLocalProfile();
+  const [imageError, setImageError] = useState("");
+  const imageInputRef = useRef<HTMLInputElement>(null);
+
+  const updateImage = async (file: File | undefined) => {
+    if (!file) return;
+    try {
+      updateProfile({ imageUrl: await profileImageFromFile(file) });
+      setImageError("");
+    } catch (nextError) {
+      setImageError(nextError instanceof Error ? nextError.message : "Image failed to load");
+    }
+  };
 
   if (loading && !stats) return <UsageSkeleton />;
 
-  // The skeleton above already owns the first-load case, so the only state left
-  // to draw here is "the fetch failed and we have nothing cached".
   if (error && !stats) {
     return (
       <AppPage>
@@ -108,54 +111,119 @@ export default function UsagePage() {
   if (!stats) return null;
 
   const heading = TAB_HEADINGS[tab];
-  const scope = tabScope(tab, stats);
 
   return (
-    <TabbedPage
-      title="Usage"
-      description="Everything this controller has proxied — per model, over time, and where it failed."
-      width="sm"
-      tabs={USAGE_TABS}
-      activeTab={tab}
-      onSelectTab={setTab}
-      actions={
-        <RefreshButton
-          onRefresh={loadStats}
-          loading={loading}
-          label="Refresh usage"
-          className="h-8 w-8"
-        />
-      }
-    >
-      <section>
-        <h2 className="text-[length:var(--fs-2xl)] font-medium tracking-[-0.015em] text-(--ui-fg)">
-          {heading.title}
-        </h2>
-        <p className="mt-1 text-[length:var(--fs-sm)] text-(--ui-muted)">{heading.description}</p>
-
-        {/* One quiet line of context, matching the Models page: the window
-            these numbers cover, and how much of it there is. */}
-        <div className="mt-6 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 border-b border-(--ui-separator) pb-3">
-          <div className="flex min-w-0 items-baseline gap-2">
-            <span className="text-[length:var(--fs-md)] text-(--ui-fg)">{scope.scale}</span>
-            <span className="truncate text-[length:var(--fs-sm)] text-(--ui-muted)">
-              {scope.detail}
-            </span>
+    <AppPage>
+      <PageContainer width="sm" className="pt-5 sm:pt-7">
+        <header className="flex items-start justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-3">
+            <button
+              type="button"
+              onClick={() => imageInputRef.current?.click()}
+              className="group relative shrink-0 rounded-full"
+              title="Update profile image"
+              aria-label="Update profile image"
+            >
+              <ProfileAvatar profile={profile} size={38} />
+              <span className="absolute inset-0 flex items-center justify-center rounded-full bg-black/55 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+                <Upload className="h-4 w-4 text-white" />
+              </span>
+            </button>
+            <input
+              ref={imageInputRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={(event) => void updateImage(event.currentTarget.files?.[0])}
+            />
+            <div className="min-w-0">
+              <h1 className="text-[length:var(--fs-sm)] text-(--ui-muted)">Usage</h1>
+              <input
+                value={profile.name}
+                onChange={(event) => updateProfile({ name: event.target.value })}
+                onBlur={() => {
+                  if (!profile.name.trim()) updateProfile({ name: "Studio" });
+                }}
+                aria-label="Profile display name"
+                className="mt-0.5 block h-7 max-w-56 bg-transparent text-[length:var(--fs-lg)] font-medium text-(--ui-fg) outline-none placeholder:text-(--ui-muted)"
+                placeholder="Studio"
+              />
+              {imageError ? (
+                <p className="mt-1 text-[length:var(--fs-xs)] text-(--err)">{imageError}</p>
+              ) : null}
+            </div>
           </div>
+          <RefreshButton onRefresh={loadStats} loading={loading} className="h-7 w-7" />
+        </header>
+
+        <section className="mt-8">
+          <p className="text-[length:var(--fs-sm)] text-(--ui-muted)">Proxied tokens</p>
+          <div className="mt-1 text-[length:var(--fs-display)] font-medium leading-none tracking-[-0.03em] tabular-nums text-(--ui-fg)">
+            {formatNumber(stats.totals.total_tokens)}
+          </div>
+          <p className="mt-2 text-[length:var(--fs-sm)] text-(--ui-muted)">
+            Requests proxied through this controller
+          </p>
+        </section>
+
+        {/* gap-px over a border-coloured ground, rather than divide-x: a divided
+            grid draws a stray left edge on the first cell of every wrapped row,
+            so the rule only looked right at the one breakpoint where all six
+            cells fit on a single line. This way the hairlines are exact at 2, 3
+            and 6 columns, and the rounded corners clip cleanly. */}
+        <StatGrid>
+          <Stat label="Requests" value={formatNumber(stats.totals.total_requests)} />
+          <Stat label="Sessions" value={formatNumber(stats.totals.unique_sessions)} />
+          <Stat label="Active days" value={formatNumber(activeDays(stats))} />
+          <Stat label="Active streak" value={`${currentStreak(stats)} days`} />
+          <Stat label="Success rate" value={`${Math.round(stats.totals.success_rate)}%`} />
+          <Stat label="P95 latency" value={milliseconds(stats.latency.p95_ms)} />
+        </StatGrid>
+
+        <div className="mt-8 border-b border-(--ui-separator)">
+          <Tabs items={USAGE_TABS} activeTab={tab} onSelectTab={setTab} className="-mb-px" />
         </div>
 
-        <div className="mt-6">
-          {tab === "models" ? (
-            <UsageModelsTab stats={stats} />
-          ) : tab === "activity" ? (
-            <UsageActivityTab stats={stats} />
-          ) : tab === "routes" ? (
-            <UsageControllerTab stats={stats} />
-          ) : (
-            <UsageErrorsTab stats={stats} />
-          )}
-        </div>
-      </section>
-    </TabbedPage>
+        <section className="mt-8">
+          <h2 className="text-[length:var(--fs-2xl)] font-medium tracking-[-0.015em] text-(--ui-fg)">
+            {heading.title}
+          </h2>
+          <p className="mt-1 text-[length:var(--fs-sm)] text-(--ui-muted)">{heading.description}</p>
+
+          <div className="mt-6">
+            {tab === "models" ? (
+              <UsageModelsTab stats={stats} />
+            ) : tab === "activity" ? (
+              <UsageActivityTab stats={stats} />
+            ) : tab === "routes" ? (
+              <UsageControllerTab stats={stats} />
+            ) : (
+              <UsageErrorsTab stats={stats} />
+            )}
+          </div>
+        </section>
+      </PageContainer>
+    </AppPage>
+  );
+}
+
+function StatGrid({ children }: { children: ReactNode }) {
+  return (
+    <dl className="mt-6 grid grid-cols-2 gap-px overflow-hidden rounded-[var(--rad-xl)] bg-(--ui-border) sm:grid-cols-3 lg:grid-cols-6">
+      {children}
+    </dl>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0 bg-(--ui-surface) px-3 py-2.5 sm:px-4">
+      {/* truncate, because "Active streak" and a five-digit millisecond value
+          both have to survive a six-column row on a narrow window. */}
+      <dd className="truncate text-[length:var(--fs-lg)] font-medium tabular-nums text-(--ui-fg)">
+        {value}
+      </dd>
+      <dt className="mt-0.5 truncate text-[length:var(--fs-sm)] text-(--ui-muted)">{label}</dt>
+    </div>
   );
 }

--- a/frontend/src/features/usage/usage-skeleton.tsx
+++ b/frontend/src/features/usage/usage-skeleton.tsx
@@ -18,24 +18,42 @@ const MODEL_COLUMNS = [
 /**
  * The loading state is the loaded page with the ink removed.
  *
- * Header, tab bar, tab heading, context strip, six-up stat strip, then the
- * Models table with its nine real column labels — every band lands at the
- * height it will occupy once the data arrives, so nothing on the page moves
+ * Profile header, headline number, the six-cell grid, tab bar, tab heading,
+ * then the Models table with its nine real column labels — every band lands at
+ * the height it will occupy once the data arrives, so nothing on the page moves
  * when it does.
  */
 export function UsageSkeleton() {
   return (
     <AppPage>
-      <PageContainer width="sm" className="pt-6 sm:pt-8">
-        <div className="mb-4 flex min-h-8 items-center justify-between gap-3">
-          <div>
-            <div className={`${pulse} h-7 w-28`} />
-            <div className={`${pulse} mt-2 h-3.5 w-96 max-w-full`} />
+      <PageContainer width="sm" className="pt-5 sm:pt-7">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <div className={`${pulse} h-[38px] w-[38px] shrink-0 rounded-full`} />
+            <div>
+              <div className={`${pulse} h-3.5 w-14`} />
+              <div className={`${pulse} mt-1.5 h-5 w-32`} />
+            </div>
           </div>
-          <div className={`${pulse} h-8 w-8 rounded-md`} />
+          <div className={`${pulse} h-7 w-7 rounded-md`} />
         </div>
 
-        <div className="mt-7 flex gap-1 border-b border-(--ui-separator)">
+        <div className="mt-8">
+          <div className={`${pulse} h-3.5 w-28`} />
+          <div className={`${pulse} mt-2 h-12 w-56`} />
+          <div className={`${pulse} mt-3 h-3.5 w-72 max-w-full`} />
+        </div>
+
+        <div className="mt-6 grid grid-cols-2 gap-px overflow-hidden rounded-[var(--rad-xl)] bg-(--ui-border) sm:grid-cols-3 lg:grid-cols-6">
+          {Array.from({ length: 6 }, (_, index) => (
+            <div key={index} className="bg-(--ui-surface) px-3 py-2.5 sm:px-4">
+              <div className={`${pulse} h-5 w-16`} />
+              <div className={`${pulse} mt-1.5 h-3.5 w-20`} />
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-8 flex gap-1 border-b border-(--ui-separator)">
           {[64, 68, 84, 60].map((width) => (
             <div key={width} className="px-4 py-2">
               <div className={`${pulse} h-4`} style={{ width }} />
@@ -46,21 +64,6 @@ export function UsageSkeleton() {
         <div className="mt-8">
           <div className={`${pulse} h-6 w-40`} />
           <div className={`${pulse} mt-2 h-3.5 w-[36rem] max-w-full`} />
-
-          <div className="mt-6 flex items-baseline gap-2 border-b border-(--ui-separator) pb-3">
-            <div className={`${pulse} h-4 w-24`} />
-            <div className={`${pulse} h-3.5 w-64 max-w-full`} />
-          </div>
-
-          <div className="mt-6 grid grid-cols-2 divide-x divide-(--ui-separator) border-b border-(--ui-separator) pb-3 sm:grid-cols-3 lg:grid-cols-6">
-            {Array.from({ length: 6 }, (_, index) => (
-              <div key={index} className="px-3 py-2 first:pl-0">
-                <div className={`${pulse} h-3 w-16`} />
-                <div className={`${pulse} mt-1.5 h-4 w-20`} />
-                <div className={`${pulse} mt-1.5 h-3 w-14`} />
-              </div>
-            ))}
-          </div>
 
           <div className="mt-6">
             <TableSkeleton columns={MODEL_COLUMNS} rows={7} minWidthClass="min-w-[64rem]" />


### PR DESCRIPTION
The overnight rebuild kept the data and threw away the page: the profile avatar and its editable name, the headline token count, and the six-cell stat grid were all replaced by a generic tabbed header — and the per-tab strip then repeated four of the six numbers it had just removed.

Header and grid are back above the tab strip, where they belong (those six are true of the whole retention window, not of any one tab). The tabs stay. The Models strip is trimmed to what only that tab can say: token mix, cache hit rate, decode.

The grid uses `gap-px` over a border-coloured ground instead of `divide-x` — a divided grid draws a stray left edge on the first cell of every wrapped row, so it only looked right at the single breakpoint where all six cells fit on one line. Verified at 6-up and wrapped 3×2. Skeleton reshaped to match, so nothing moves when data lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)