### PR TITLE
fix(installer): delimit port expansion before ellipsis

### DIFF
--- a/scripts/install-controller.sh
+++ b/scripts/install-controller.sh
@@ -204,7 +204,7 @@ else
 fi
 
 # --- health ------------------------------------------------------------------
-log "waiting for controller on :$PORT…"
+log "waiting for controller on :${PORT}…"
 HEALTH_HOST="$HOST"
 case "$HEALTH_HOST" in
   ""|"0.0.0.0"|"::") HEALTH_HOST="127.0.0.1" ;;


### PR DESCRIPTION
## Summary

Delimit the controller port expansion before the adjacent Unicode ellipsis. Under Bash strict unset-variable handling, the undelimited form is parsed as a different variable name, causing the installer to exit before its health check and registration marker.

## Validation

```bash
bash -n scripts/install-controller.sh
bash -uc 'PORT=8080; printf "%s\n" "waiting for controller on :${PORT}…"'
npm run check
```

## UI changes

None.

## Risks / rollout notes

Minimal shell-only change. Controller startup, health-check behavior, and configuration remain unchanged.