### PR TITLE
fix: quiet the bell, stop composer hydration churn, surface automation threads

### DIFF
--- a/frontend/src/features/agent/automations/automation-editor.tsx
+++ b/frontend/src/features/agent/automations/automation-editor.tsx
@@ -314,10 +314,14 @@ function RunHistory({ automation }: { automation: Automation }) {
       </div>
       <div className="divide-y divide-(--ui-separator) border-y border-(--ui-separator)">
         {automation.runs.map((run, index) => {
-          const transcriptHref =
-            run.piSessionId && run.projectId
-              ? `/agent?project=${encodeURIComponent(run.projectId)}&session=${encodeURIComponent(run.piSessionId)}&replace=1`
-              : null;
+          // The session id is what opens the thread; the project only preselects
+          // the sidebar. Requiring both hid every run of an automation whose cwd
+          // is not a registered project — the scheduler resolves projectId by
+          // matching cwd against the project list, so that is most of them — and
+          // the UI claimed "Transcript unavailable" for threads that existed.
+          const transcriptHref = run.piSessionId
+            ? `/agent?${run.projectId ? `project=${encodeURIComponent(run.projectId)}&` : ""}session=${encodeURIComponent(run.piSessionId)}&replace=1`
+            : null;
           return (
             <div
               key={`${run.at}-${run.piSessionId ?? index}`}

--- a/frontend/src/features/agent/ui/composer-project-drawer.tsx
+++ b/frontend/src/features/agent/ui/composer-project-drawer.tsx
@@ -148,7 +148,22 @@ export function ComposerProjectDrawer({
   }, [piSessionId]);
 
   const activeProject = projects.findByPath(cwd) ?? projects.selectedProject;
-  const label = projectName ?? activeProject?.name ?? "Choose project";
+  // The projects store seeds itself from localStorage synchronously at
+  // creation, so the client's very first render already knows the selected
+  // project while the server's render cannot. Naming it during hydration is a
+  // mismatch, and React responds by throwing away and re-rendering the whole
+  // subtree — the composer. Hold the neutral label until after mount, which is
+  // one frame, and hydrate clean.
+  const [hydrated, setHydrated] = useState(false);
+  useMountSubscription(() => setHydrated(true), []);
+  // Every source of this name is client-only: `projectName` comes from the
+  // pane's restored view state and `activeProject` from the projects store,
+  // which seeds from localStorage synchronously. The server can know none of
+  // it, so the first client render must say what the server said and only then
+  // fill in — otherwise React discards and re-renders the whole composer.
+  const label = hydrated
+    ? (projectName ?? activeProject?.name ?? "Choose project")
+    : "Choose project";
   const hasQueue = queueItems.length > 0;
   const paused = goal?.status === "paused";
   const terminal =

--- a/frontend/src/features/agent/ui/quick-panel/quick-project-picker.tsx
+++ b/frontend/src/features/agent/ui/quick-panel/quick-project-picker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, type MouseEvent, type PointerEvent } from "react";
+import { useMountSubscription } from "@/hooks/use-mount-subscription";
 import { Folder } from "@/ui/icons";
 import type { ProjectsContextValue } from "@/features/agent/projects/context";
 import { POPOVER_SURFACE_CLASS } from "@/ui/popover";
@@ -16,7 +17,13 @@ function stopToolbarEvent(event: MouseEvent | PointerEvent) {
 
 export function QuickProjectPicker({ projects }: Props) {
   const [open, setOpen] = useState(false);
-  const active = projects.selectedProject ?? projects.projects[0] ?? null;
+  // The projects store seeds from localStorage synchronously, so the client
+  // knows the project on its first render and the server does not. Naming it
+  // during hydration mismatches, and React answers a mismatch by discarding
+  // and re-rendering the subtree — here, the whole composer toolbar.
+  const [hydrated, setHydrated] = useState(false);
+  useMountSubscription(() => setHydrated(true), []);
+  const active = hydrated ? (projects.selectedProject ?? projects.projects[0] ?? null) : null;
 
   return (
     <div

--- a/frontend/src/features/shell/left-sidebar-desktop.tsx
+++ b/frontend/src/features/shell/left-sidebar-desktop.tsx
@@ -37,7 +37,8 @@ export function DesktopSidebar({
   onOpenSearch,
   navView,
   onToggleNavView,
-  notificationsIndicator,
+  runningSessions,
+  finishedSessions,
   onNewTask,
 }: {
   pathname: string;
@@ -52,7 +53,8 @@ export function DesktopSidebar({
   onOpenSearch: () => void;
   navView: NavView;
   onToggleNavView: () => void;
-  notificationsIndicator: boolean;
+  runningSessions: number;
+  finishedSessions: number;
   onNewTask: () => void;
 }) {
   return (
@@ -132,27 +134,25 @@ export function DesktopSidebar({
               >
                 <SearchIcon className="h-4 w-4" />
               </button>
+              {/* Session state, stated rather than hinted. The bell used to
+                  carry a bare blue dot that meant "something happened" and
+                  nothing more; a count of what is running — or of what finished
+                  while you were elsewhere — is the thing you actually wanted to
+                  know, and it reads without opening anything. */}
+              <SessionStatus running={runningSessions} finished={finishedSessions} />
               {/* The bell swaps what the nav below lists — notifications when
-                  lit, the project tree otherwise — so it reads as a view toggle
-                  and stays pressed while that view is showing. Unread state is a
-                  ringed badge rather than a bare dot: the ring in sidebar-bg
-                  keeps it legible against the bell's own strokes at this size. */}
+                  lit, the project tree otherwise — so it reads as a view toggle.
+                  Pressed is a foreground shift only, matching the other chrome
+                  buttons: a filled pill here sat lit whenever the notifications
+                  view was open, which read as a stuck hover state. */}
               <button
                 onClick={onToggleNavView}
                 aria-pressed={navView === "notifications"}
-                className="relative flex h-7 w-7 items-center justify-center rounded-md text-(--hl2) transition-colors hover:bg-(--hover) hover:text-(--fg) aria-pressed:bg-(--link)/15 aria-pressed:text-(--link)"
+                className="flex h-7 w-7 items-center justify-center rounded-md text-(--hl2) transition-colors hover:bg-(--hover) hover:text-(--fg) aria-pressed:text-(--fg)"
                 title={navView === "notifications" ? "Show projects" : "Show notifications"}
-                aria-label={
-                  notificationsIndicator ? "Notifications, unseen activity" : "Notifications"
-                }
+                aria-label={navView === "notifications" ? "Show projects" : "Show notifications"}
               >
                 <BellIcon className="h-4 w-4" />
-                {notificationsIndicator ? (
-                  <span
-                    className="absolute right-1 top-1 h-1.5 w-1.5 rounded-full bg-(--link) ring-2 ring-(--sidebar-bg)"
-                    aria-hidden
-                  />
-                ) : null}
               </button>
             </div>
 
@@ -199,4 +199,37 @@ export function DesktopSidebar({
       </div>
     </aside>
   );
+}
+
+/**
+ * What the sessions are doing, in the width of a chip.
+ *
+ * Running wins over finished: a live run is the thing you might want to go
+ * watch, and a finished one will still be there afterwards. Nothing renders
+ * when nothing is happening, so the resting nav stays quiet.
+ */
+function SessionStatus({ running, finished }: { running: number; finished: number }) {
+  if (running > 0) {
+    return (
+      <span
+        className="flex shrink-0 items-center gap-1 rounded-md px-1.5 text-[length:var(--fs-xs)] tabular-nums text-(--hl2)"
+        title={`${running} ${running === 1 ? "session is" : "sessions are"} running`}
+      >
+        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-(--ok)" aria-hidden />
+        {running}
+      </span>
+    );
+  }
+  if (finished > 0) {
+    return (
+      <span
+        className="flex shrink-0 items-center gap-1 rounded-md px-1.5 text-[length:var(--fs-xs)] tabular-nums text-(--hl2)"
+        title={`${finished} ${finished === 1 ? "session" : "sessions"} finished while you were away`}
+      >
+        <span className="h-1.5 w-1.5 rounded-full bg-(--ok)/60" aria-hidden />
+        {finished}
+      </span>
+    );
+  }
+  return null;
 }

--- a/frontend/src/features/shell/left-sidebar.tsx
+++ b/frontend/src/features/shell/left-sidebar.tsx
@@ -74,8 +74,11 @@ export function LeftSidebar({ children }: { children: ReactNode }) {
   // resting view, so the toggle always has somewhere to fall back to.
   const [navView, setNavView] = useState<NavView>("projects");
   const sessionActivity = useSessionActivity();
-  const notificationsIndicator =
-    sessionActivity.active.size > 0 || sessionActivity.unseen.size > 0;
+  // The bell used to carry a bare "something happened" dot, which said nothing
+  // about what. What the nav can usefully show is session state: how many runs
+  // are live right now, and how many finished while you were elsewhere.
+  const runningSessions = sessionActivity.active.size;
+  const finishedSessions = sessionActivity.finished.size;
   const activeSessions = useOpenSessions();
   const [sidebarResizing, setSidebarResizing] = useState(false);
   const [projectsNavReady, setProjectsNavReady] = useState(projectsNavImmediate);
@@ -205,7 +208,8 @@ export function LeftSidebar({ children }: { children: ReactNode }) {
         onToggleNavView={() =>
           setNavView((view) => (view === "notifications" ? "projects" : "notifications"))
         }
-        notificationsIndicator={notificationsIndicator}
+        runningSessions={runningSessions}
+        finishedSessions={finishedSessions}
         onNewTask={openNewTask}
       />
 

--- a/services/agent-runtime/src/automation-scheduler.ts
+++ b/services/agent-runtime/src/automation-scheduler.ts
@@ -10,6 +10,7 @@ import { getGlobalSingleton } from "./instances";
 import { piRuntimeManager } from "./pi-runtime";
 import { lastAssistantResult } from "./session-text";
 import { listProjectsFromStore } from "./projects-store";
+import { refreshPiModels } from "./pi-runtime-models";
 
 const TICK_MS = 30_000;
 
@@ -37,6 +38,30 @@ export function automationRunError(lastError: string | null, summary: string): s
   return summary.trim() ? null : "Automation completed without an assistant response.";
 }
 
+/**
+ * The model an automation should actually run on.
+ *
+ * A schedule outlives the model it was written against: the configured model
+ * gets evicted, a different one is serving, and the run fails at 3am on a
+ * machine nobody is watching. If the configured model is not live, any live
+ * model is a better outcome than no run at all. The configured id is kept when
+ * nothing is live, so the failure still names the model the user chose.
+ */
+async function runnableModelId(configured: string): Promise<string> {
+  try {
+    const { models } = await refreshPiModels();
+    if (models.some((model) => model.id === configured && model.active)) return configured;
+    const live = models.find((model) => model.active);
+    if (!live) return configured;
+    console.warn(
+      `[automation] ${configured} is not live; running on ${live.id} instead`,
+    );
+    return live.id;
+  } catch {
+    return configured;
+  }
+}
+
 export async function runAutomationNow(id: string): Promise<Automation | null> {
   const scheduler = state();
   const automation = await getAutomation(id);
@@ -45,7 +70,8 @@ export async function runAutomationNow(id: string): Promise<Automation | null> {
   const runtimeSessionId = `automation:${id}:${Date.now()}`;
   try {
     const { session } = piRuntimeManager.getSessionForLookup(runtimeSessionId, null);
-    await session.ensureStarted(automation.modelId, automation.cwd || undefined, null, {});
+    const modelId = await runnableModelId(automation.modelId);
+    await session.ensureStarted(modelId, automation.cwd || undefined, null, {});
     await session.prompt(runPrompt(automation), () => {});
     const status = session.status;
     const piSessionId = status.piSessionId;


### PR DESCRIPTION
Four fixes across the shell, composer and automations.

## Nav header
- **The bell looked permanently hovered** — it carried `aria-pressed:bg-(--link)/15`, so it sat filled blue whenever the notifications view was open. Pressed is now a foreground shift only, matching the buttons beside it. Verified: background computes to `rgba(0,0,0,0)` at rest with the view open.
- **The blue dot is gone**, replaced by actual session state: a pulsing count of live runs, or a quieter count of runs that finished while you were away. Nothing renders when nothing is happening, so the resting nav is quieter than before.

## Composer hydration
The project label is built from two client-only sources — the pane's restored view state and the projects store, which seeds from `localStorage` **synchronously at creation**. The server can know neither, so it rendered "Choose project" while the client's first render said the project name. React answers a hydration mismatch by discarding and re-rendering the subtree, and that subtree is the composer, on every single load.

Went from throwing on every page load to **zero hydration errors**, confirmed in the browser.

## Automations
- **Threads were hidden.** Run history linked to a transcript only when a run recorded *both* a session id and a project id. The scheduler derives `projectId` by matching the run's cwd against registered projects, so an automation pointed anywhere else recorded `null` and the UI claimed "Transcript unavailable" for a thread that existed and was perfectly reachable. The session id alone opens it — `workspaceNavigation` already treats the project as optional.
- **Runs no longer die on an evicted model.** A schedule outlives the model it was written against. If the configured model is not live, the run now uses whatever is and logs the substitution; if nothing is live, the configured id is kept so the failure still names the model you picked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)