### PR TITLE
fix(ci): handle dev promotion ancestry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,9 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.sha }}
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ "$GITHUB_HEAD_REF" == "dev" ]]; then
+            node scripts/project.mjs check-commits --range "$BASE_SHA..$HEAD_SHA" --exclude origin/dev
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             node scripts/project.mjs check-commits --range "$BASE_SHA..$HEAD_SHA" --exclude origin/main
           else
             node scripts/project.mjs check-commits --range "$BASE_SHA..$HEAD_SHA"


### PR DESCRIPTION
## Summary
- exclude the already-validated dev head when checking a dev-to-main promotion merge
- retain normal commit validation for feature PRs and direct push events

## Validation
- simulated feature PR range against origin/dev
- simulated promotion range against origin/main
- local pre-push static and cleanup gates