### PR TITLE
fix(agent): require strict goal outcome sentinels

### DIFF
--- a/services/agent-runtime/bun.lock
+++ b/services/agent-runtime/bun.lock
@@ -19,6 +19,7 @@
       "devDependencies": {
         "@types/node": "24.6.0",
         "@types/proper-lockfile": "4.1.4",
+        "typescript": "5.9.3",
       },
     },
   },
@@ -491,6 +492,8 @@
     "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typebox": ["typebox@1.3.7", "", {}, "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
 

--- a/services/agent-runtime/package.json
+++ b/services/agent-runtime/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "bundle": "node ../../scripts/project.mjs bundle-agent-runtime",
     "build": "node ../../scripts/project.mjs prepare-agent-runtime && tsc -p tsconfig.build.json && node ../../scripts/project.mjs postbuild-agent-runtime",
-    "check": "bun run build",
+    "check": "bun run build && bun test",
     "dev": "bun --watch src/server.ts",
     "start": "node dist/server.js"
   },
@@ -29,7 +29,8 @@
   },
   "devDependencies": {
     "@types/node": "24.6.0",
-    "@types/proper-lockfile": "4.1.4"
+    "@types/proper-lockfile": "4.1.4",
+    "typescript": "5.9.3"
   },
   "overrides": {
     "brace-expansion": "5.0.9"

--- a/shared/agent/goal-protocol.ts
+++ b/shared/agent/goal-protocol.ts
@@ -42,18 +42,17 @@ export function isGoalContinuationPrompt(text: string): boolean {
 
 export type GoalOutcome = { kind: "complete" } | { kind: "blocked"; reason: string };
 
-// A sentinel owns the rest of its line: GOAL_BLOCKED carries its reason there,
-// and a GOAL_COMPLETE is normally alone on the last line anyway.
-const SENTINEL_RE = /[ \t]*\b(?:GOAL_COMPLETE|GOAL_BLOCKED)\b[ \t]*[:\-–—]?[ \t]*[^\n]*/g;
-const COMPLETE_RE = /\bGOAL_COMPLETE\b/;
-const BLOCKED_RE = /\bGOAL_BLOCKED\b[ \t]*[:\-–—]?[ \t]*([^\n]*)/;
+const COMPLETE_SENTINEL_LINE_RE = /(?:^|\n)[ \t]*GOAL_COMPLETE[ \t]*$/;
+const BLOCKED_SENTINEL_LINE_RE =
+  /(?:^|\n)[ \t]*GOAL_BLOCKED(?:[ \t]*[:\-–—]?[ \t]*([^\n]*))?[ \t]*$/;
+const SENTINEL_LINE_RE =
+  /(?:^|\n)[ \t]*(?:GOAL_COMPLETE|GOAL_BLOCKED(?:[ \t]*[:\-–—]?[ \t]*[^\n]*)?)[ \t]*$/;
 
-/** The outcome a settled turn declared, or null when it declared none.
- *  Completion wins over a blocked marker in the pathological both-present case:
- *  a turn that reached the objective has nothing left to be blocked on. */
+/** The outcome a settled turn declared, or null when it declared none. */
 export function goalOutcomeFromText(text: string): GoalOutcome | null {
-  if (COMPLETE_RE.test(text)) return { kind: "complete" };
-  const blocked = BLOCKED_RE.exec(text);
+  const finalText = text.trimEnd();
+  if (COMPLETE_SENTINEL_LINE_RE.test(finalText)) return { kind: "complete" };
+  const blocked = BLOCKED_SENTINEL_LINE_RE.exec(finalText);
   return blocked ? { kind: "blocked", reason: (blocked[1] ?? "").trim() } : null;
 }
 
@@ -63,7 +62,7 @@ export function goalOutcomeFromText(text: string): GoalOutcome | null {
 // at a time. Six characters is the shortest prefix that commits to a sentinel
 // ("GOAL_C" / "GOAL_B"), which leaves the ordinary words "goal" and "GOAL_"
 // alone.
-const PARTIAL_TAIL_RE = /(?:^|\s)(GOAL_[A-Z]*)$/;
+const PARTIAL_TAIL_RE = /(?:^|\n)[ \t]*(GOAL_[A-Z]*)$/;
 
 function stripPartialSentinelTail(text: string): string {
   const match = PARTIAL_TAIL_RE.exec(text);
@@ -82,6 +81,6 @@ function stripPartialSentinelTail(text: string): string {
  *  Returns the input unchanged (same value) when there was nothing to strip, so
  *  callers can use the result to decide whether anything moved. */
 export function stripGoalSentinels(text: string): string {
-  const stripped = stripPartialSentinelTail(text.replace(SENTINEL_RE, ""));
+  const stripped = stripPartialSentinelTail(text.replace(SENTINEL_LINE_RE, ""));
   return stripped === text ? text : stripped.trimEnd();
 }


### PR DESCRIPTION
## Summary
- require goal outcome sentinels to be final protocol lines before settling a goal
- keep prose and quoted marker mentions visible instead of stripping them from rendered assistant text
- run the existing agent-runtime Bun test suite from `bun run check` and declare TypeScript in the isolated runtime package

## Verification
- `node --experimental-strip-types --input-type=module ...` direct parser probe: prose/quoted `GOAL_COMPLETE` returned null; final `GOAL_COMPLETE` and `GOAL_BLOCKED` still settled correctly
- `bun run check` from `services/agent-runtime`: build passed and 64 tests passed across 10 files
- `npm run check` from repo root: passed locally using temporary PATH entries for Bun 1.3.14 and uv-managed Python 3.12.13

## Notes
- The upstream fork PR workflow is in GitHub `action_required`; approving/running it requires admin rights on `sybil-solutions/local-studio`, which this account does not have.