### PR TITLE
fix(app): first wave of the ruthless pass — sync repairs, measured slowness kills, ui fixes

### DIFF
--- a/controller/src/modules/models/recipes/recipe-matching.ts
+++ b/controller/src/modules/models/recipes/recipe-matching.ts
@@ -15,6 +15,62 @@ const isPathPrefix = (ancestor: string, descendant: string): boolean =>
   descendant === ancestor || descendant.startsWith(`${ancestor}/`);
 
 /**
+ * Rank how well a running process matches a recipe. 0 = no match; higher is
+ * a more specific match:
+ * 4) served_model_name equality (case-insensitive)
+ * 3) normalized exact model path equality
+ * 2) optional contains-style path match (route-specific)
+ * 1) model path basename fallback
+ * Shared by isRecipeRunning (rank > 0) and selectRunningRecipe (best rank
+ * wins) so the boolean and the exclusive selection can never drift apart.
+ */
+const recipeMatchRank = (
+  recipe: Recipe,
+  current: ProcessInfo,
+  options: RecipeMatchOptions = {},
+): number => {
+  const canonicalName = (recipe.served_model_name ?? "").toLowerCase();
+  if (
+    canonicalName &&
+    current.served_model_name &&
+    current.served_model_name.toLowerCase() === canonicalName
+  ) {
+    return 4;
+  }
+
+  if (!current.model_path) {
+    return 0;
+  }
+
+  const recipePath = normalizeModelPath(recipe.model_path);
+  const currentPath = normalizeModelPath(current.model_path);
+
+  if (recipePath === currentPath) {
+    return 3;
+  }
+
+  if (options.allowEitherPathContains) {
+    if (isPathPrefix(currentPath, recipePath) || isPathPrefix(recipePath, currentPath)) {
+      return 2;
+    }
+  } else if (options.allowCurrentContainsRecipePath) {
+    if (isPathPrefix(recipePath, currentPath)) {
+      return 2;
+    }
+  }
+
+  // Basename fallback ONLY when one side lacks directory context (e.g. the
+  // running process reports just a filename). Comparing basenames of two full
+  // paths with different parents would falsely match distinct models that
+  // happen to share a filename (/a/model.gguf vs /b/model.gguf), reporting a
+  // launch as already-running and silently serving the wrong model.
+  if (!recipePath.includes("/") || !currentPath.includes("/")) {
+    return basename(recipePath) === basename(currentPath) ? 1 : 0;
+  }
+  return 0;
+};
+
+/**
  * Determine whether a running process matches a given recipe.
  * Matching order:
  * 1) served_model_name (case-insensitive)
@@ -30,44 +86,31 @@ export const isRecipeRunning = (
   recipe: Recipe,
   current: ProcessInfo,
   options: RecipeMatchOptions = {},
-): boolean => {
-  const canonicalName = (recipe.served_model_name ?? "").toLowerCase();
-  if (
-    canonicalName &&
-    current.served_model_name &&
-    current.served_model_name.toLowerCase() === canonicalName
-  ) {
-    return true;
-  }
+): boolean => recipeMatchRank(recipe, current, options) > 0;
 
-  if (!current.model_path) {
-    return false;
-  }
-
-  const recipePath = normalizeModelPath(recipe.model_path);
-  const currentPath = normalizeModelPath(current.model_path);
-
-  if (recipePath === currentPath) {
-    return true;
-  }
-
-  if (options.allowEitherPathContains) {
-    if (isPathPrefix(currentPath, recipePath) || isPathPrefix(recipePath, currentPath)) {
-      return true;
-    }
-  } else if (options.allowCurrentContainsRecipePath) {
-    if (isPathPrefix(recipePath, currentPath)) {
-      return true;
+/**
+ * Pick the single recipe that best explains the running process. Several
+ * recipes can share a model path (e.g. three glm-5.2 recipes over one weights
+ * directory), and with the contains-style fallback every one of them "runs"
+ * whenever the shared path is loaded — so a boolean per recipe marks them all
+ * active. This ranks the candidates (served_model_name equality, then exact
+ * path equality, then the path-contains fallback, then basename) and returns
+ * only the best; on a rank tie the first recipe in list order wins.
+ * @returns The best-matching recipe, or null when nothing matches.
+ */
+export const selectRunningRecipe = <R extends Recipe>(
+  recipes: readonly R[],
+  current: ProcessInfo,
+  options: RecipeMatchOptions = {},
+): R | null => {
+  let best: R | null = null;
+  let bestRank = 0;
+  for (const recipe of recipes) {
+    const rank = recipeMatchRank(recipe, current, options);
+    if (rank > bestRank) {
+      best = recipe;
+      bestRank = rank;
     }
   }
-
-  // Basename fallback ONLY when one side lacks directory context (e.g. the
-  // running process reports just a filename). Comparing basenames of two full
-  // paths with different parents would falsely match distinct models that
-  // happen to share a filename (/a/model.gguf vs /b/model.gguf), reporting a
-  // launch as already-running and silently serving the wrong model.
-  if (!recipePath.includes("/") || !currentPath.includes("/")) {
-    return basename(recipePath) === basename(currentPath);
-  }
-  return false;
+  return best;
 };

--- a/controller/src/modules/models/routes.ts
+++ b/controller/src/modules/models/routes.ts
@@ -39,7 +39,7 @@ const decodeResponse = <S extends Schema.Constraint>(
     Effect.flatMap(Schema.decodeUnknownEffect(schema)),
   );
 import { buildModelInfo, discoverModelDirectories } from "./model-browser";
-import { isRecipeRunning } from "./recipes/recipe-matching";
+import { selectRunningRecipe } from "./recipes/recipe-matching";
 import { notFound } from "../../core/errors";
 import { findObservedInferenceProcess } from "../../core/function-observability";
 import { fetchInference } from "../../http/local-fetch";
@@ -91,14 +91,17 @@ export const registerModelsRoutes = defineRoutes((app, context) => {
 
           const models: OpenAIModelInfo[] = [];
           const now = Math.floor(Date.now() / 1000);
+          // Several recipes can share one model path, and each would match the
+          // single running process — pick the best match once so exactly one
+          // entry is reported active (the rest stay listed, just inactive).
+          const activeRecipe = current
+            ? selectRunningRecipe(recipes, current, { allowEitherPathContains: true })
+            : null;
           for (const recipe of recipes) {
-            let isActive = false;
+            const isActive = recipe === activeRecipe;
             let maxModelLength = recipe.max_model_len;
-            if (current) {
-              isActive = isRecipeRunning(recipe, current, { allowEitherPathContains: true });
-              if (isActive && activeModelData?.data?.[0]?.max_model_len) {
-                maxModelLength = activeModelData.data[0].max_model_len;
-              }
+            if (isActive && activeModelData?.data?.[0]?.max_model_len) {
+              maxModelLength = activeModelData.data[0].max_model_len;
             }
             const modelId = recipe.served_model_name ?? recipe.id;
             models.push({
@@ -180,7 +183,10 @@ export const registerModelsRoutes = defineRoutes((app, context) => {
           const current = yield* findObservedInferenceProcess(context, "models.detail");
           let isActive = false;
           let maxModelLength = recipe.max_model_len;
-          if (current && isRecipeRunning(recipe, current, { allowEitherPathContains: true })) {
+          // Same exclusive selection as the list route: a recipe is active
+          // only when it is THE best match for the running process, so the
+          // detail view can never contradict the list.
+          if (current && selectRunningRecipe(recipes, current, { allowEitherPathContains: true }) === recipe) {
             isActive = true;
             const data = yield* fetchInference(context, "/v1/models", { timeoutMs: 5000 }).pipe(
               Effect.flatMap((response) =>

--- a/docs/ruthless-12h-mission.md
+++ b/docs/ruthless-12h-mission.md
@@ -1,0 +1,55 @@
+# Ruthless 12-hour mission — 2026-08-20/21
+
+Owner brief (verbatim intent): ruthlessly optimize and test every single
+feature; many bugs, slowness, lack of sync between browser and desktop; make
+the repo smaller and more functional; exo-spark-cli is the reference.
+
+## The reference shape (exo-spark-cli)
+
+The owner's private CLI does with ~1.4MB of TypeScript what this repo does
+with far more: models are **pure data** in one catalog file (entry pins repo,
+format, serve flags); **one `EngineSpec` lifecycle** (install, serve, health,
+stop) covers vLLM/llama.cpp/SGLang/MLX; agents are wired by **writing
+provider configs** (`~/.pi/agent`), not by wrapping them. Small, modular,
+compiles to one binary. That is the direction of every slimming decision here.
+
+## Phases
+
+- **M0 baseline** — ship the in-flight backlog release, install locally,
+  deploy pop-os. Test against what users run, not against dev.
+- **M1 sweep** — every feature, both surfaces (packaged desktop + pop-os
+  web), with timings. Output: a defect/slowness ledger in this file.
+- **M2 fix waves** — batched by subsystem, gates per batch, branch
+  `mission/ruthless-12h`, periodic merge+release.
+- **M3 slimming** — toward the reference shape. Known candidates with
+  verified plans already in hand: theme light-dark consolidation
+  (tokens.css 760→487), PR396 refactor stack, glm53 recents superset,
+  engines/compute consolidation (#171 direction), deeper knip/jscpd,
+  bundle size. Anything needing an owner deletion call gets flagged.
+- **M4 sync** — map browser↔desktop state divergence (separate runtimes and
+  data dirs vs shared controller), verify session-list-changed SSE
+  cross-surface, fix.
+
+## Ground rules
+
+- Never judge a fix by exit codes alone — read outputs, measure timings.
+- `npm run start` (standalone) for local web testing, never `next start`.
+- SSE must be proxied through Next, never locally built (buffering).
+- Controller on pop-os is never restarted (model stays up).
+- No deletions of user data/branches without an explicit owner OK.
+
+## Ledger
+
+(appended as the mission runs)
+
+### M4 findings (sync map, 2026-08-20)
+
+Why desktop and browser don't sync:
+1. Two independent agent-runtimes, two data roots (Electron userData vs ~/.local-studio); no replication anywhere.
+2. session-list-changed SSE is fully wired but process-local — it cannot see another host's writes.
+3. 25 of 65 /api/agent routes run in-process in Next (connectors, projects, terminals, fs, git, plugins, skills) — they never reach a remote runtime even if repointed.
+4. Browser tier is per-origin localStorage; desktop and pop-os are different origins.
+5. The desktop-ui-preferences sync is DEAD CODE: POSTs ui_preferences to /api/settings whose schema drops the field; reads a `persisted` key it never returns. The controller's ui_preferences store exists, implemented, written by nothing.
+6. Each runtime runs its own automation scheduler — divergent execution, not just divergent lists.
+
+Fix ladder (ranked): D repair pref-sync via controller studio settings (~20 lines, LWW) → A point desktop Next at a remote runtime (env exists: LOCAL_STUDIO_AGENT_RUNTIME_URL; needs bind+auth) → B proxy the in-process routes to the runtime (mechanical for 6 groups) → C serve the browser surface FROM the desktop (Tailscale Serve, documented).

--- a/docs/ruthless-12h-mission.md
+++ b/docs/ruthless-12h-mission.md
@@ -53,3 +53,18 @@ Why desktop and browser don't sync:
 6. Each runtime runs its own automation scheduler — divergent execution, not just divergent lists.
 
 Fix ladder (ranked): D repair pref-sync via controller studio settings (~20 lines, LWW) → A point desktop Next at a remote runtime (env exists: LOCAL_STUDIO_AGENT_RUNTIME_URL; needs bind+auth) → B proxy the in-process routes to the runtime (mechanical for 6 groups) → C serve the browser surface FROM the desktop (Tailscale Serve, documented).
+
+### M0 complete + first measurements
+
+- v2.14.0 released, installed locally (notarized), deployed to pop-os. NOTE:
+  #366's fail-closed posture 503'd the pop-os deploy until
+  LOCAL_STUDIO_FRONTEND_ALLOW_UNAUTHENTICATED=true was declared in a unit
+  drop-in — tailnet membership is the perimeter there. Remember for future
+  deploys.
+- M4-D landed: pref sync repointed at the controller store (verified live
+  round-trip through the deployed proxy), three-way merge on a per-surface
+  sync base. M4-B (route unification onto the runtime) delegated.
+- Bundle: initial JS on / is 1,134 KB / 26 chunks; mermaid (636K), xterm,
+  highlight chunks are lazy ✓. Initial-load diet is a bounded M3 target.
+- Repo caretaker automation (auto-36631e4a) active every 30 min, isolated
+  caretaker/* worktree branches.

--- a/frontend/desktop/electron-builder.yml
+++ b/frontend/desktop/electron-builder.yml
@@ -58,6 +58,30 @@ extraResources:
     filter:
       - "**/*"
       - "!**/*.{map,ts,mts,cts}"
+  # Pi's extension loader (jiti alias mode) eagerly require.resolve()s typebox
+  # and import.meta.resolve()s the pi packages from standalone.mjs's directory
+  # before loading ANY extension file. Without these four next to the bundle,
+  # every bundled pi extension fails with "Cannot find module 'typebox'".
+  - from: ../services/agent-runtime/dist/node_modules/typebox
+    to: app/agent-runtime/node_modules/typebox
+    filter:
+      - "**/*"
+      - "!**/*.{map,ts,mts,cts}"
+  - from: ../services/agent-runtime/dist/node_modules/@earendil-works/pi-agent-core
+    to: app/agent-runtime/node_modules/@earendil-works/pi-agent-core
+    filter:
+      - "**/*"
+      - "!**/*.{map,ts,mts,cts}"
+  - from: ../services/agent-runtime/dist/node_modules/@earendil-works/pi-tui
+    to: app/agent-runtime/node_modules/@earendil-works/pi-tui
+    filter:
+      - "**/*"
+      - "!**/*.{map,ts,mts,cts}"
+  - from: ../services/agent-runtime/dist/node_modules/@earendil-works/pi-ai
+    to: app/agent-runtime/node_modules/@earendil-works/pi-ai
+    filter:
+      - "**/*"
+      - "!**/*.{map,ts,mts,cts}"
   - from: node_modules/@lydell/node-pty
     to: desktop-runtime/node_modules/@lydell/node-pty
     filter:

--- a/frontend/desktop/project.mjs
+++ b/frontend/desktop/project.mjs
@@ -387,7 +387,16 @@ var init_bundle = __esm(() => {
     "devtools-protocol",
     "@silvia-odwyer/photon-node",
     "undici",
-    "@lydell/node-pty"
+    "@lydell/node-pty",
+    // Pi's extension loader (jiti alias mode) eagerly require.resolve()s
+    // typebox and import.meta.resolve()s the pi packages from the bundle's
+    // own directory BEFORE loading any extension file. Without these four on
+    // disk next to standalone.mjs, every bundled extension fails with
+    // "Cannot find module 'typebox'" in the packaged app.
+    "typebox",
+    "@earendil-works/pi-agent-core",
+    "@earendil-works/pi-tui",
+    "@earendil-works/pi-ai"
   ];
   rmSync2(distDir, { recursive: !0, force: !0 });
   mkdirSync(distDir, { recursive: !0 });

--- a/frontend/desktop/resources/pi-extensions/automations.ts
+++ b/frontend/desktop/resources/pi-extensions/automations.ts
@@ -56,7 +56,15 @@ type ScheduleArg = {
   weekdaysOnly?: unknown;
 };
 
-const WEEKDAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+const WEEKDAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
 
 const SCHEDULE_DOC =
   "Schedule format — one of: " +
@@ -111,7 +119,10 @@ export function normalizeScheduleArg(
     }
     return { ok: true, schedule: { kind: "weekly", day, time: (input.time as string).trim() } };
   }
-  return { ok: false, error: `schedule.kind must be 'interval', 'daily' or 'weekly'. ${SCHEDULE_DOC}` };
+  return {
+    ok: false,
+    error: `schedule.kind must be 'interval', 'daily' or 'weekly'. ${SCHEDULE_DOC}`,
+  };
 }
 
 /** One-line human description of a schedule, for list output. */
@@ -125,10 +136,9 @@ export function describeSchedule(schedule: NormalizedSchedule): string {
 
 const scheduleParameter = Type.Object(
   {
-    kind: Type.Union(
-      [Type.Literal("interval"), Type.Literal("daily"), Type.Literal("weekly")],
-      { description: "interval = every N minutes; daily/weekly = at a clock time" },
-    ),
+    kind: Type.Union([Type.Literal("interval"), Type.Literal("daily"), Type.Literal("weekly")], {
+      description: "interval = every N minutes; daily/weekly = at a clock time",
+    }),
     minutes: Type.Optional(Type.Number({ description: "interval only: minutes, >= 1" })),
     time: Type.Optional(Type.String({ description: "daily/weekly only: 'HH:MM' 24h local time" })),
     day: Type.Optional(Type.Number({ description: "weekly only: 0-6, 0 = Sunday" })),
@@ -354,9 +364,7 @@ function formatAutomationDetail(record: AutomationRecord, includeRuns: boolean):
 
 // ─── Store reads ────────────────────────────────────────────────────────────
 
-type ListResult =
-  | { ok: true; automations: AutomationRecord[] }
-  | { ok: false; error: string };
+type ListResult = { ok: true; automations: AutomationRecord[] } | { ok: false; error: string };
 
 /** The list endpoint is the only read path — there is no GET /automations/:id —
  *  and it already returns each automation in full, run history included. */
@@ -364,7 +372,10 @@ async function fetchAutomations(signal: AbortSignal | undefined): Promise<ListRe
   const { ok, status, body } = await httpJson("/api/agent/automations", { method: "GET" }, signal);
   if (!ok) return { ok: false, error: errorText(body, status) };
   const automations = (body as { automations?: unknown }).automations;
-  return { ok: true, automations: Array.isArray(automations) ? (automations as AutomationRecord[]) : [] };
+  return {
+    ok: true,
+    automations: Array.isArray(automations) ? (automations as AutomationRecord[]) : [],
+  };
 }
 
 async function fetchAutomation(
@@ -383,7 +394,10 @@ async function fetchAutomation(
   return { ok: true, automation: match };
 }
 
-function requireId(params: unknown, tool: string): { ok: true; id: string } | { ok: false; error: string } {
+function requireId(
+  params: unknown,
+  tool: string,
+): { ok: true; id: string } | { ok: false; error: string } {
   const raw = (params as { id?: unknown } | undefined)?.id;
   const id = typeof raw === "string" ? raw.trim() : "";
   if (!id) return { ok: false, error: `${tool} needs an automation id (see list_automations).` };
@@ -436,7 +450,9 @@ function registerReadTools(pi: ExtensionAPI): void {
       "job is actually doing its work (a run can succeed on schedule and still report a " +
       "failure), and to read the current prompt before editing it with update_automation.",
     parameters: Type.Object({
-      id: Type.String({ description: "The automation id from list_automations, e.g. 'auto-1a2b3c4d'." }),
+      id: Type.String({
+        description: "The automation id from list_automations, e.g. 'auto-1a2b3c4d'.",
+      }),
       includeRuns: Type.Optional(
         Type.Boolean({ description: "Include the run history. Default true." }),
       ),
@@ -473,7 +489,9 @@ function registerWriteTools(pi: ExtensionAPI): void {
       " The automation runs with the current session's model and project directory unless you " +
       "pass others. Returns the new automation's id.",
     parameters: Type.Object({
-      prompt: Type.String({ description: "The standalone instruction the automation runs each time." }),
+      prompt: Type.String({
+        description: "The standalone instruction the automation runs each time.",
+      }),
       schedule: scheduleParameter,
       name: Type.Optional(Type.String({ description: "Short display name shown in the app." })),
       model: Type.Optional(
@@ -649,7 +667,9 @@ function registerWriteTools(pi: ExtensionAPI): void {
           signal,
         );
         if (!reply.ok) {
-          return failure(`Failed to change automation status: ${errorText(reply.body, reply.status)}`);
+          return failure(
+            `Failed to change automation status: ${errorText(reply.body, reply.status)}`,
+          );
         }
         const automation = patchedAutomation(reply.body);
         const name = text(automation.name, parsed.id);
@@ -715,7 +735,9 @@ function registerWriteTools(pi: ExtensionAPI): void {
       "undone. If the user only wants it to stop firing, use set_automation_status with " +
       "'paused' instead.",
     parameters: Type.Object({
-      id: Type.String({ description: "The automation id from list_automations, e.g. 'auto-1a2b3c4d'." }),
+      id: Type.String({
+        description: "The automation id from list_automations, e.g. 'auto-1a2b3c4d'.",
+      }),
     }),
     async execute(_id, params, signal) {
       const parsed = requireId(params, "delete_automation");

--- a/frontend/desktop/resources/pi-extensions/automations.ts
+++ b/frontend/desktop/resources/pi-extensions/automations.ts
@@ -17,7 +17,7 @@
 // status, nextRunAt, lastRun and runs[].
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { Type } from "typebox";
+import { Type } from "./schema.ts";
 
 const FRONTEND_BASE = process.env.LOCAL_STUDIO_FRONTEND_BASE ?? "http://127.0.0.1:3000";
 const CALL_TIMEOUT_MS = 30_000;

--- a/frontend/desktop/resources/pi-extensions/chrome.ts
+++ b/frontend/desktop/resources/pi-extensions/chrome.ts
@@ -25,7 +25,7 @@
 // session id change between sessions.
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { Type, type Static, type TSchema } from "typebox";
+import { Type, type Static, type TSchema } from "./schema.ts";
 
 type ToolResult = {
   content: Array<{ type: "text"; text: string }>;

--- a/frontend/desktop/resources/pi-extensions/chrome.ts
+++ b/frontend/desktop/resources/pi-extensions/chrome.ts
@@ -310,11 +310,15 @@ export default async function registerChromeExtension(pi: ExtensionAPI) {
       async execute(_id, params, signal) {
         const args = (params ?? {}) as Record<string, unknown>;
         const detailBase: Record<string, unknown> = { browser: "chrome", tool: tool.name, params };
-        const detail = typeof args.url === "string" ? args.url : (args.selector as string | undefined);
+        const detail =
+          typeof args.url === "string" ? args.url : (args.selector as string | undefined);
         try {
           const data = await callRelay(env, tool.method, tool.params(params as never), signal);
           record(log, tool.name, detail, true);
-          return { content: [{ type: "text", text: asText(data) }], details: { ...detailBase, data } };
+          return {
+            content: [{ type: "text", text: asText(data) }],
+            details: { ...detailBase, data },
+          };
         } catch (error) {
           record(log, tool.name, detail, false);
           return failed(tool.name, detailBase, error);

--- a/frontend/desktop/resources/pi-extensions/connectors.ts
+++ b/frontend/desktop/resources/pi-extensions/connectors.ts
@@ -9,7 +9,7 @@
 // Loaded by pi-runtime only when at least one connector is enabled.
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { Type } from "typebox";
+import { Type } from "./schema.ts";
 
 type ToolResult = {
   content: Array<{ type: "text"; text: string }>;

--- a/frontend/desktop/resources/pi-extensions/cua.ts
+++ b/frontend/desktop/resources/pi-extensions/cua.ts
@@ -19,7 +19,7 @@
 // scope caching would pin the first session's answers onto every later one.
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { Type, type Static, type TSchema } from "typebox";
+import { Type, type Static, type TSchema } from "./schema.ts";
 
 type ToolResult = {
   content: Array<{ type: "text"; text: string }>;

--- a/frontend/desktop/resources/pi-extensions/github.ts
+++ b/frontend/desktop/resources/pi-extensions/github.ts
@@ -324,7 +324,10 @@ const TOOLS = [
     name: "github_pr_checks",
     label: "GitHub: Pull Request Checks",
     description: `Return the CI check runs for a pull request with their state and links. A non-zero exit here means checks are failing or pending — that is the answer, not an error. Follow a failure into github_run_view with \`failedLogs\` to see why. ${REPO_DEFAULT}`,
-    parameters: Type.Object({ number: Type.Number({ description: "Pull request number" }), repo: repoParam }),
+    parameters: Type.Object({
+      number: Type.Number({ description: "Pull request number" }),
+      repo: repoParam,
+    }),
     argv: (p) => ["pr", "checks", String(Math.trunc(p.number)), ...repoArgs(p.repo)],
   }),
   define({
@@ -419,7 +422,7 @@ const BLOCKED_COMMANDS = new Set([
 
 function blockedReason(args: string[]): string | null {
   const command = args[0] ?? "";
-  if (!command) return "github_cli needs at least one argument, e.g. [\"pr\", \"create\", \"--fill\"].";
+  if (!command) return 'github_cli needs at least one argument, e.g. ["pr", "create", "--fill"].';
   if (command.startsWith("-")) {
     return "github_cli takes a gh subcommand first, not a flag.";
   }
@@ -488,7 +491,7 @@ export default async function registerGithubExtension(pi: ExtensionAPI) {
     name: "github_cli",
     label: "GitHub: Run gh",
     description:
-      "Run any other `gh` subcommand as an argv array — `[\"pr\", \"create\", \"--fill\"]`, `[\"issue\", \"comment\", \"42\", \"--body\", \"...\"]`, `[\"release\", \"list\"]`. This is the write path: it acts on GitHub as the signed-in user and its effects are public and often permanent, so only run a mutating command the user actually asked for, and say what you ran. Prefer the named github_* tools where one exists — they return structured JSON, this returns whatever gh prints. There is no shell here, so pipes, redirects and globs do not work; pass each argument as its own array element. Credential and delete subcommands are refused.",
+      'Run any other `gh` subcommand as an argv array — `["pr", "create", "--fill"]`, `["issue", "comment", "42", "--body", "..."]`, `["release", "list"]`. This is the write path: it acts on GitHub as the signed-in user and its effects are public and often permanent, so only run a mutating command the user actually asked for, and say what you ran. Prefer the named github_* tools where one exists — they return structured JSON, this returns whatever gh prints. There is no shell here, so pipes, redirects and globs do not work; pass each argument as its own array element. Credential and delete subcommands are refused.',
     parameters: Type.Object({
       args: Type.Array(Type.String(), {
         description: "Arguments after `gh`, one per element",

--- a/frontend/desktop/resources/pi-extensions/github.ts
+++ b/frontend/desktop/resources/pi-extensions/github.ts
@@ -22,7 +22,7 @@
 
 import { execFile } from "node:child_process";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { Type, type Static, type TSchema } from "typebox";
+import { Type, type Static, type TSchema } from "./schema.ts";
 
 type ToolResult = {
   content: Array<{ type: "text"; text: string }>;

--- a/frontend/desktop/resources/pi-extensions/local-studio-timeouts.ts
+++ b/frontend/desktop/resources/pi-extensions/local-studio-timeouts.ts
@@ -1,4 +1,9 @@
-import { isToolCallEventType, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+// Type-only import: erased before module resolution, so this file stays
+// loadable from the packaged Resources directory, which has no node_modules.
+// A VALUE import from the pi package here is a bare runtime specifier that
+// cannot resolve there — which is why isToolCallEventType (a one-line
+// `event.toolName === name` check) is inlined below instead of imported.
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const DEFAULT_BASH_TIMEOUT_SECONDS = 120;
 const MAX_BASH_TIMEOUT_SECONDS = 900;
@@ -17,12 +22,13 @@ export default function localStudioTimeouts(pi: ExtensionAPI) {
   const maxTimeout = readSeconds("LOCAL_STUDIO_BASH_MAX_TIMEOUT_SECONDS", MAX_BASH_TIMEOUT_SECONDS);
 
   pi.on("tool_call", (event) => {
-    if (!isToolCallEventType("bash", event)) return;
-    const current = Number(event.input.timeout);
+    if (event.toolName !== "bash") return;
+    const input = event.input as { timeout?: unknown };
+    const current = Number(input.timeout);
     if (!Number.isFinite(current) || current <= 0) {
-      event.input.timeout = defaultTimeout;
+      input.timeout = defaultTimeout;
       return;
     }
-    event.input.timeout = Math.min(Math.trunc(current), maxTimeout);
+    input.timeout = Math.min(Math.trunc(current), maxTimeout);
   });
 }

--- a/frontend/desktop/resources/pi-extensions/obsidian.ts
+++ b/frontend/desktop/resources/pi-extensions/obsidian.ts
@@ -39,7 +39,7 @@ import { appendFile, mkdir, readFile, readdir, realpath, stat, writeFile } from 
 import { homedir } from "node:os";
 import path from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { Type, type Static, type TSchema } from "typebox";
+import { Type, type Static, type TSchema } from "./schema.ts";
 
 type ToolResult = {
   content: Array<{ type: "text"; text: string }>;

--- a/frontend/desktop/resources/pi-extensions/obsidian.ts
+++ b/frontend/desktop/resources/pi-extensions/obsidian.ts
@@ -138,7 +138,9 @@ function selectVault(vaults: Vault[], requested: string | undefined): Vault {
   if (byName.length === 1) return byName[0]!;
   const known = vaults.map((vault) => `${vault.name} (${vault.path})`).join(", ");
   if (byName.length > 1) {
-    throw new Refusal(`More than one vault is named "${wanted}". Pass its full path instead: ${known}.`);
+    throw new Refusal(
+      `More than one vault is named "${wanted}". Pass its full path instead: ${known}.`,
+    );
   }
   throw new Refusal(`No vault called "${wanted}". Known vaults: ${known}.`);
 }
@@ -184,7 +186,9 @@ async function notePath(root: string, input: string): Promise<string> {
   const withExt = raw.toLowerCase().endsWith(NOTE_EXT) ? raw : `${raw}${NOTE_EXT}`;
   const target = path.resolve(root, withExt);
   if (!isInside(root, target)) {
-    throw new Refusal(`"${raw}" resolves outside the vault. These tools only touch files inside it.`);
+    throw new Refusal(
+      `"${raw}" resolves outside the vault. These tools only touch files inside it.`,
+    );
   }
   const hidden = path
     .relative(root, target)
@@ -289,7 +293,10 @@ function splitFrontmatter(text: string): Frontmatter {
 }
 
 function unquote(value: string): string {
-  return value.trim().replace(/^["']|["']$/g, "").trim();
+  return value
+    .trim()
+    .replace(/^["']|["']$/g, "")
+    .trim();
 }
 
 /**
@@ -323,11 +330,7 @@ function parseFields(lines: string[]): Record<string, string | string[]> {
     }
     fields[key] =
       raw.startsWith("[") && raw.endsWith("]")
-        ? raw
-            .slice(1, -1)
-            .split(",")
-            .map(unquote)
-            .filter(Boolean)
+        ? raw.slice(1, -1).split(",").map(unquote).filter(Boolean)
         : unquote(raw);
   }
   return fields;
@@ -360,11 +363,18 @@ function isTag(value: string): boolean {
 /** A note's tags are the union of its frontmatter tags and its inline ones. */
 function tagsOf(fields: Record<string, string | string[]>, body: string): string[] {
   const tags = new Set(fieldList(fields, "tags", "tag").filter(isTag));
-  for (const match of body.matchAll(INLINE_TAG)) if (match[1] && isTag(match[1])) tags.add(match[1]);
+  for (const match of body.matchAll(INLINE_TAG))
+    if (match[1] && isTag(match[1])) tags.add(match[1]);
   return [...tags].sort((a, b) => a.localeCompare(b));
 }
 
-type Wikilink = { text: string; target: string; heading: string | null; alias: string | null; embed: boolean };
+type Wikilink = {
+  text: string;
+  target: string;
+  heading: string | null;
+  alias: string | null;
+  embed: boolean;
+};
 
 const WIKILINK = /(!?)\[\[([^\]\n]+)\]\]/g;
 
@@ -490,7 +500,7 @@ const vaultParam = Type.Optional(
 );
 const noteParam = Type.String({
   description:
-    "Vault-relative path (\"Projects/Roadmap.md\") or just the note name (\"Roadmap\"), resolved by name across the vault the way a [[wikilink]] is.",
+    'Vault-relative path ("Projects/Roadmap.md") or just the note name ("Roadmap"), resolved by name across the vault the way a [[wikilink]] is.',
 });
 
 const TOOLS = [
@@ -533,7 +543,7 @@ const TOOLS = [
         }),
       ),
       folder: Type.Optional(
-        Type.String({ description: "Restrict to a vault-relative folder, e.g. \"Daily Notes\"" }),
+        Type.String({ description: 'Restrict to a vault-relative folder, e.g. "Daily Notes"' }),
       ),
       limit: Type.Optional(Type.Number({ description: "Maximum notes to return (default 20)" })),
     }),
@@ -548,7 +558,9 @@ const TOOLS = [
       const needle = query.toLowerCase();
       const tagQuery = query.startsWith("#") ? query.slice(1).toLowerCase() : null;
       const scoped = folder
-        ? notes.filter((note) => note.rel.split(path.sep).join("/").toLowerCase().startsWith(`${folder.toLowerCase()}/`))
+        ? notes.filter((note) =>
+            note.rel.split(path.sep).join("/").toLowerCase().startsWith(`${folder.toLowerCase()}/`),
+          )
         : notes;
 
       const matches: Array<Record<string, unknown>> = [];
@@ -556,7 +568,13 @@ const TOOLS = [
         const titleHit = scope !== "content" && note.name.toLowerCase().includes(needle);
         const text = scope === "title" && !titleHit ? null : await readNote(note);
         if (text === null) {
-          if (titleHit) matches.push({ path: note.rel, title: note.name, modified: note.modified, matched: ["title"] });
+          if (titleHit)
+            matches.push({
+              path: note.rel,
+              title: note.name,
+              modified: note.modified,
+              matched: ["title"],
+            });
           continue;
         }
         const { fields, body } = splitFrontmatter(text);
@@ -564,9 +582,11 @@ const TOOLS = [
         const aliases = fieldList(fields, "aliases", "alias");
         const title = titleOf(note.name, fields);
         const matched: string[] = [];
-        if (scope !== "content" && (titleHit || title.toLowerCase().includes(needle))) matched.push("title");
+        if (scope !== "content" && (titleHit || title.toLowerCase().includes(needle)))
+          matched.push("title");
         if (aliases.some((alias) => alias.toLowerCase().includes(needle))) matched.push("alias");
-        if (tagQuery && tags.some((tag) => tag.toLowerCase().includes(tagQuery))) matched.push("tag");
+        if (tagQuery && tags.some((tag) => tag.toLowerCase().includes(tagQuery)))
+          matched.push("tag");
         const excerpts = scope === "title" ? [] : excerptsFor(body, query);
         if (excerpts.length > 0) matched.push("body");
         if (matched.length === 0) continue;
@@ -585,9 +605,12 @@ const TOOLS = [
       // then the notes with the most passages, then the most recent.
       matches.sort((a, b) => {
         const titleDelta =
-          Number((b.matched as string[]).includes("title")) - Number((a.matched as string[]).includes("title"));
+          Number((b.matched as string[]).includes("title")) -
+          Number((a.matched as string[]).includes("title"));
         if (titleDelta !== 0) return titleDelta;
-        const excerptDelta = ((b.excerpts as string[] | undefined)?.length ?? 0) - ((a.excerpts as string[] | undefined)?.length ?? 0);
+        const excerptDelta =
+          ((b.excerpts as string[] | undefined)?.length ?? 0) -
+          ((a.excerpts as string[] | undefined)?.length ?? 0);
         if (excerptDelta !== 0) return excerptDelta;
         return String(b.modified).localeCompare(String(a.modified));
       });
@@ -664,7 +687,7 @@ const TOOLS = [
     name: "obsidian_recent",
     label: "Obsidian: Recent Notes",
     description:
-      "List the notes modified most recently, newest first, with their paths, titles, tags and a first line of preview. The right first call when the user talks about their notes without naming one — it shows what they have actually been working on, which is usually what they mean by \"my notes\".",
+      'List the notes modified most recently, newest first, with their paths, titles, tags and a first line of preview. The right first call when the user talks about their notes without naming one — it shows what they have actually been working on, which is usually what they mean by "my notes".',
     parameters: Type.Object({
       vault: vaultParam,
       limit: Type.Optional(Type.Number({ description: "Maximum notes to return (default 20)" })),
@@ -676,15 +699,24 @@ const TOOLS = [
       const folder = params.folder?.trim().replace(/^\/+|\/+$/g, "");
       const { notes, truncated } = await listNotes(root);
       const scoped = folder
-        ? notes.filter((note) => note.rel.split(path.sep).join("/").toLowerCase().startsWith(`${folder.toLowerCase()}/`))
+        ? notes.filter((note) =>
+            note.rel.split(path.sep).join("/").toLowerCase().startsWith(`${folder.toLowerCase()}/`),
+          )
         : notes;
-      const recent = [...scoped].sort((a, b) => b.modified.localeCompare(a.modified)).slice(0, limit);
+      const recent = [...scoped]
+        .sort((a, b) => b.modified.localeCompare(a.modified))
+        .slice(0, limit);
       const detailed = await Promise.all(
         recent.map(async (note) => {
           const text = await readNote(note);
-          if (text === null) return { path: note.rel, title: note.name, modified: note.modified, bytes: note.bytes };
+          if (text === null)
+            return { path: note.rel, title: note.name, modified: note.modified, bytes: note.bytes };
           const { fields, body } = splitFrontmatter(text);
-          const preview = body.split(/\r?\n/).map((line) => line.trim()).find((line) => line.length > 0) ?? "";
+          const preview =
+            body
+              .split(/\r?\n/)
+              .map((line) => line.trim())
+              .find((line) => line.length > 0) ?? "";
           const tags = tagsOf(fields, body);
           return {
             path: note.rel,
@@ -728,7 +760,9 @@ const TOOLS = [
         const lines = body.split(/\r?\n/);
         const contexts: string[] = [];
         for (const line of lines) {
-          const hit = linksOf(line).some((link) => resolveLink(index, link.target).path === targetRel);
+          const hit = linksOf(line).some(
+            (link) => resolveLink(index, link.target).path === targetRel,
+          );
           if (hit) contexts.push(line.trim().slice(0, 240));
           if (contexts.length >= EXCERPTS_PER_NOTE) break;
         }
@@ -745,12 +779,18 @@ const TOOLS = [
     parameters: Type.Object({
       note: Type.String({
         description:
-          "Vault-relative path for the new note, e.g. \"Projects/Roadmap\" or \"Roadmap.md\". Folders are created as needed.",
+          'Vault-relative path for the new note, e.g. "Projects/Roadmap" or "Roadmap.md". Folders are created as needed.',
       }),
       content: Type.String({ description: "Markdown body of the note" }),
       vault: vaultParam,
-      tags: Type.Optional(Type.Array(Type.String(), { description: "Frontmatter tags, without the leading #" })),
-      aliases: Type.Optional(Type.Array(Type.String(), { description: "Frontmatter aliases — other names this note answers to" })),
+      tags: Type.Optional(
+        Type.Array(Type.String(), { description: "Frontmatter tags, without the leading #" }),
+      ),
+      aliases: Type.Optional(
+        Type.Array(Type.String(), {
+          description: "Frontmatter aliases — other names this note answers to",
+        }),
+      ),
     }),
     run: async (params, vaults) => {
       const { vault, root } = await openVault(vaults, params.vault);
@@ -832,7 +872,10 @@ export default async function registerObsidianExtension(pi: ExtensionAPI) {
         const detailBase = { tool: tool.name, params: (params ?? {}) as Record<string, unknown> };
         try {
           const data = await tool.run(params as never, vaults);
-          return { content: [{ type: "text", text: truncate(asText(data)) }], details: { ...detailBase, data } };
+          return {
+            content: [{ type: "text", text: truncate(asText(data)) }],
+            details: { ...detailBase, data },
+          };
         } catch (error) {
           if (error instanceof Refusal) {
             return {

--- a/frontend/desktop/resources/pi-extensions/schema.ts
+++ b/frontend/desktop/resources/pi-extensions/schema.ts
@@ -1,0 +1,115 @@
+// Dependency-free stand-in for the `typebox` Type builders the bundled
+// extensions use.
+//
+// These files are shipped as-is in the packaged app's Resources and loaded by
+// pi from disk at runtime. The packaged Resources directory has NO
+// node_modules anywhere above it, so a bare runtime import like
+// `import { Type } from "typebox"` can never resolve there — it loads fine in
+// dev (repo node_modules) and then fails in the packaged app with
+// "Cannot find module 'typebox'". Extensions must only use node builtins,
+// relative files in this directory, and type-only imports (which the TS
+// loader erases before resolution ever happens).
+//
+// The builders below produce objects byte-for-byte identical to what
+// typebox@1.3.7 emits for the subset these extensions use — same enumerable
+// JSON-Schema keys in the same order, same non-enumerable '~kind'/'~optional'
+// markers — so pi's schema handling (guards, validation, serialization to the
+// model API) sees real TypeBox-shaped schemas. The TYPES still come from
+// typebox via `import type`, so `Static<typeof Schema>` inference and pi's
+// own `registerTool` param typing keep working unchanged under
+// `npm run typecheck:extensions`; type-only imports cost nothing at runtime.
+
+import type {
+  Static,
+  TArray,
+  TBoolean,
+  TLiteral,
+  TLiteralValue,
+  TNumber,
+  TObject,
+  TOptional,
+  TProperties,
+  TSchema,
+  TString,
+  TUnion,
+  TUnsafe,
+} from "typebox";
+
+export type { Static, TSchema };
+
+type SchemaOptions = Record<string, unknown>;
+
+/** Attach TypeBox's non-enumerable marker keys ('~kind', '~optional',
+ *  '~unsafe') so guards dispatch correctly while JSON output stays clean. */
+function withMarkers<T>(schema: object, markers: Record<string, unknown>): T {
+  for (const [key, value] of Object.entries(markers)) {
+    Object.defineProperty(schema, key, {
+      value,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  }
+  return schema as T;
+}
+
+function isOptionalSchema(schema: unknown): boolean {
+  return (
+    typeof schema === "object" &&
+    schema !== null &&
+    (schema as Record<string, unknown>)["~optional"] === true
+  );
+}
+
+export const Type = {
+  String(options?: SchemaOptions): TString {
+    return withMarkers({ type: "string", ...options }, { "~kind": "String" });
+  },
+
+  Number(options?: SchemaOptions): TNumber {
+    return withMarkers({ type: "number", ...options }, { "~kind": "Number" });
+  },
+
+  Boolean(options?: SchemaOptions): TBoolean {
+    return withMarkers({ type: "boolean", ...options }, { "~kind": "Boolean" });
+  },
+
+  Literal<Value extends TLiteralValue>(value: Value, options?: SchemaOptions): TLiteral<Value> {
+    return withMarkers({ type: typeof value, const: value, ...options }, { "~kind": "Literal" });
+  },
+
+  Array<Items extends TSchema>(items: Items, options?: SchemaOptions): TArray<Items> {
+    return withMarkers({ type: "array", items, ...options }, { "~kind": "Array" });
+  },
+
+  Union<Types extends TSchema[]>(anyOf: [...Types], options?: SchemaOptions): TUnion<Types> {
+    return withMarkers({ anyOf, ...options }, { "~kind": "Union" });
+  },
+
+  Object<Properties extends TProperties>(
+    properties: Properties,
+    options?: SchemaOptions,
+  ): TObject<Properties> {
+    const required = Object.keys(properties).filter((key) => !isOptionalSchema(properties[key]));
+    return withMarkers(
+      {
+        type: "object",
+        ...(required.length > 0 ? { required } : {}),
+        properties,
+        ...options,
+      },
+      { "~kind": "Object" },
+    );
+  },
+
+  Optional<Schema extends TSchema>(schema: Schema): TOptional<Schema> {
+    // Copy with descriptors so the non-enumerable '~kind' marker survives.
+    const copy = Object.defineProperties({}, Object.getOwnPropertyDescriptors(schema));
+    return withMarkers(copy, { "~optional": true });
+  },
+
+  /** Pass a hand-written JSON Schema through with a chosen static type. */
+  Unsafe<Type>(schema: Record<string, unknown>): TUnsafe<Type> {
+    return withMarkers({ ...schema }, { "~unsafe": null });
+  },
+};

--- a/frontend/desktop/resources/pi-extensions/subagents.ts
+++ b/frontend/desktop/resources/pi-extensions/subagents.ts
@@ -16,7 +16,7 @@
 // stays a plain pi extension with no runtime imports.
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { Type } from "typebox";
+import { Type } from "./schema.ts";
 
 const FRONTEND_BASE = process.env.LOCAL_STUDIO_FRONTEND_BASE ?? "http://127.0.0.1:3000";
 const RUN_TIMEOUT_MS = 15 * 60_000;

--- a/frontend/desktop/resources/pi-extensions/tsconfig.json
+++ b/frontend/desktop/resources/pi-extensions/tsconfig.json
@@ -7,6 +7,10 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    // Extensions import their shared schema shim as "./schema.ts" — the
+    // literal on-disk name — because pi loads these files from the packaged
+    // Resources dir with no build step to rewrite specifiers.
+    "allowImportingTsExtensions": true,
     "lib": ["ES2022", "DOM"],
     "strict": true,
     "esModuleInterop": true,

--- a/frontend/src/app/api/agent/accounts/google/authorize/route.ts
+++ b/frontend/src/app/api/agent/accounts/google/authorize/route.ts
@@ -1,58 +1,18 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { Effect, Schema } from "effect";
-import { GoogleAccountError } from "@local-studio/agent-runtime/google-account";
-import {
-  beginGoogleLoopbackAuthorization,
-  cancelGoogleLoopbackAuthorization,
-} from "@local-studio/agent-runtime/google-oauth-loopback";
+import { type NextRequest } from "next/server";
 import { requireApiAccess } from "@/lib/auth/guard";
+import { proxyToAgentRuntime } from "@/app/api/agent/proxy-to-runtime";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const GoogleAccountInputSchema = Schema.Struct({
-  account: Schema.Union([Schema.Literal("gmail"), Schema.Literal("google-calendar")]),
-});
-
-export async function POST(request: NextRequest) {
+export async function POST(request: NextRequest): Promise<Response> {
   const denied = requireApiAccess(request);
   if (denied) return denied;
-  let input: typeof GoogleAccountInputSchema.Type;
-  try {
-    input = Schema.decodeUnknownSync(GoogleAccountInputSchema)(await request.json());
-  } catch {
-    return NextResponse.json({ error: "account is required" }, { status: 400 });
-  }
-  try {
-    return NextResponse.json(
-      await Effect.runPromise(beginGoogleLoopbackAuthorization(input.account)),
-    );
-  } catch (error) {
-    const status = error instanceof GoogleAccountError ? error.status : 500;
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Google sign-in failed" },
-      { status },
-    );
-  }
+  return proxyToAgentRuntime(request);
 }
 
-export async function DELETE(request: NextRequest) {
+export async function DELETE(request: NextRequest): Promise<Response> {
   const denied = requireApiAccess(request);
   if (denied) return denied;
-  let input: typeof GoogleAccountInputSchema.Type;
-  try {
-    input = Schema.decodeUnknownSync(GoogleAccountInputSchema)(await request.json());
-  } catch {
-    return NextResponse.json({ error: "account is required" }, { status: 400 });
-  }
-  try {
-    await Effect.runPromise(cancelGoogleLoopbackAuthorization(input.account));
-    return NextResponse.json({ cancelled: true });
-  } catch (error) {
-    const status = error instanceof GoogleAccountError ? error.status : 500;
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Google sign-in cancellation failed" },
-      { status },
-    );
-  }
+  return proxyToAgentRuntime(request);
 }

--- a/frontend/src/app/api/agent/accounts/google/route.ts
+++ b/frontend/src/app/api/agent/accounts/google/route.ts
@@ -1,108 +1,24 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { Effect, Schema } from "effect";
-import {
-  disconnectGoogleAccount,
-  getGoogleAccount,
-  GoogleAccountError,
-  saveGoogleClient,
-} from "@local-studio/agent-runtime/google-account";
-import { closePooledConnection } from "@local-studio/agent-runtime/connector-pool";
-import { listConnectors } from "@local-studio/agent-runtime/connectors-service";
-import { disableGoogleWorkspaceAdapter } from "@local-studio/agent-runtime/google-workspace-adapter";
-import {
-  GOOGLE_ACCOUNT_KEY_PATTERN,
-  googleWorkspaceConnectorIdentity,
-} from "@local-studio/agent-runtime/google-workspace-binding";
+import { type NextRequest } from "next/server";
 import { requireApiAccess } from "@/lib/auth/guard";
+import { proxyToAgentRuntime } from "@/app/api/agent/proxy-to-runtime";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const GoogleClientInputSchema = Schema.Struct({
-  clientId: Schema.String,
-  clientSecret: Schema.optional(Schema.String),
-});
-
-const GoogleDisconnectInputSchema = Schema.Struct({
-  account: Schema.Union([Schema.Literal("gmail"), Schema.Literal("google-calendar")]),
-  accountKey: Schema.String,
-});
-
-function failure(error: unknown) {
-  const status = error instanceof GoogleAccountError ? error.status : 500;
-  return NextResponse.json(
-    { error: error instanceof Error ? error.message : "Google account failed" },
-    { status },
-  );
-}
-
-/** Pooled sockets outlive a credential change, so every managed row is dropped. */
-async function closeGoogleConnections(): Promise<void> {
-  try {
-    for (const connector of await listConnectors()) {
-      if (googleWorkspaceConnectorIdentity(connector.id)) closePooledConnection(connector.id);
-    }
-  } catch {
-    // A connector file we cannot read has no live pooled connections to close.
-  }
-}
-
-export async function GET(request: NextRequest) {
+export async function GET(request: NextRequest): Promise<Response> {
   const denied = requireApiAccess(request);
   if (denied) return denied;
-  try {
-    return NextResponse.json({ account: await Effect.runPromise(getGoogleAccount()) });
-  } catch (error) {
-    return failure(error);
-  }
+  return proxyToAgentRuntime(request);
 }
 
-export async function PUT(request: NextRequest) {
+export async function PUT(request: NextRequest): Promise<Response> {
   const denied = requireApiAccess(request);
   if (denied) return denied;
-  let input: typeof GoogleClientInputSchema.Type;
-  try {
-    input = Schema.decodeUnknownSync(GoogleClientInputSchema)(await request.json());
-  } catch {
-    return NextResponse.json({ error: "clientId must be a string" }, { status: 400 });
-  }
-  try {
-    const account = await Effect.runPromise(saveGoogleClient(input));
-    return NextResponse.json({ account });
-  } catch (error) {
-    return failure(error);
-  } finally {
-    await closeGoogleConnections();
-  }
+  return proxyToAgentRuntime(request);
 }
 
-export async function DELETE(request: NextRequest) {
+export async function DELETE(request: NextRequest): Promise<Response> {
   const denied = requireApiAccess(request);
   if (denied) return denied;
-  let input: typeof GoogleDisconnectInputSchema.Type;
-  try {
-    input = Schema.decodeUnknownSync(GoogleDisconnectInputSchema)(await request.json());
-  } catch {
-    return NextResponse.json({ error: "account and accountKey are required" }, { status: 400 });
-  }
-  if (!GOOGLE_ACCOUNT_KEY_PATTERN.test(input.accountKey)) {
-    return NextResponse.json({ error: "accountKey is not a known account" }, { status: 400 });
-  }
-  const identity = { service: input.account, accountKey: input.accountKey };
-  try {
-    const account = await Effect.runPromise(
-      Effect.gen(function* () {
-        const disconnected = yield* disconnectGoogleAccount(identity);
-        yield* disableGoogleWorkspaceAdapter(identity).pipe(
-          Effect.mapError((error) => new GoogleAccountError(500, error.message)),
-        );
-        return disconnected;
-      }),
-    );
-    return NextResponse.json({ account });
-  } catch (error) {
-    return failure(error);
-  } finally {
-    await closeGoogleConnections();
-  }
+  return proxyToAgentRuntime(request);
 }

--- a/frontend/src/app/api/agent/connectors/call/route.ts
+++ b/frontend/src/app/api/agent/connectors/call/route.ts
@@ -1,98 +1,18 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { Schema } from "effect";
-import {
-  callConnectorTool,
-  ConnectorToolDeniedError,
-  listConnectorTools,
-} from "@local-studio/agent-runtime/connector-pool";
-import { enabledConnectors } from "@local-studio/agent-runtime/connectors-service";
-import {
-  isConnectorToolGranted,
-  listConnectorGrants,
-  resolveGrantedTools,
-} from "@local-studio/agent-runtime/connector-grants";
+import { type NextRequest } from "next/server";
 import { requireApiAccess } from "@/lib/auth/guard";
+import { proxyToAgentRuntime } from "@/app/api/agent/proxy-to-runtime";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const ConnectorToolCallSchema = Schema.Struct({
-  connector_id: Schema.String,
-  tool: Schema.String,
-  args: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
-  model_id: Schema.optional(Schema.String),
-});
-
-/**
- * The session's model, as claimed by the caller. It decides which connector
- * tools are offered and which calls are allowed. An unnamed model matches only
- * the `*` grants, so an older extension that does not send one keeps whatever
- * blanket access the user left in place and gains nothing else.
- */
-const callerModelId = (value: string | null | undefined): string => value?.trim() ?? "";
-
-export async function GET(request: NextRequest) {
+export async function GET(request: NextRequest): Promise<Response> {
   const denied = requireApiAccess(request);
   if (denied) return denied;
-  const modelId = callerModelId(request.nextUrl.searchParams.get("model_id"));
-  const grants = await listConnectorGrants();
-  const granted = (await enabledConnectors()).flatMap((connector) => {
-    const tools = resolveGrantedTools(grants, modelId, connector.id);
-    return tools === "all" || tools.length ? [{ connector, tools }] : [];
-  });
-  const inventory = await Promise.all(
-    granted.map(async ({ connector, tools }) => {
-      try {
-        const available = await listConnectorTools(connector.id);
-        return {
-          id: connector.id,
-          name: connector.name,
-          tools:
-            tools === "all" ? available : available.filter((tool) => tools.includes(tool.name)),
-        };
-      } catch (error) {
-        return {
-          id: connector.id,
-          name: connector.name,
-          tools: [],
-          error: error instanceof Error ? error.message : String(error),
-        };
-      }
-    }),
-  );
-  return NextResponse.json({ connectors: inventory });
+  return proxyToAgentRuntime(request);
 }
 
-export async function POST(request: NextRequest) {
+export async function POST(request: NextRequest): Promise<Response> {
   const denied = requireApiAccess(request);
   if (denied) return denied;
-  let body: typeof ConnectorToolCallSchema.Type;
-  try {
-    body = Schema.decodeUnknownSync(ConnectorToolCallSchema)(await request.json());
-  } catch {
-    return NextResponse.json({ error: "connector_id and tool are required" }, { status: 400 });
-  }
-  if (!body.connector_id.trim() || !body.tool.trim()) {
-    return NextResponse.json({ error: "connector_id and tool are required" }, { status: 400 });
-  }
-  try {
-    // Filtering the inventory only decides what the model is told about; the
-    // grant is re-checked here because this route is the actual boundary.
-    const grants = await listConnectorGrants();
-    if (
-      !isConnectorToolGranted(grants, callerModelId(body.model_id), body.connector_id, body.tool)
-    ) {
-      throw new ConnectorToolDeniedError(
-        `Model is not granted "${body.tool}" on connector "${body.connector_id}"`,
-      );
-    }
-    const result = await callConnectorTool(body.connector_id, body.tool, body.args ?? {});
-    return NextResponse.json({ ok: true, result });
-  } catch (error) {
-    const status = error instanceof ConnectorToolDeniedError ? 403 : 500;
-    return NextResponse.json(
-      { ok: false, error: error instanceof Error ? error.message : String(error) },
-      { status },
-    );
-  }
+  return proxyToAgentRuntime(request);
 }

--- a/frontend/src/app/api/agent/connectors/grants/route.ts
+++ b/frontend/src/app/api/agent/connectors/grants/route.ts
@@ -1,105 +1,24 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { Schema } from "effect";
-import { listConnectorTools } from "@local-studio/agent-runtime/connector-pool";
-import { enabledConnectors } from "@local-studio/agent-runtime/connectors-service";
-import {
-  listConnectorGrants,
-  removeConnectorGrant,
-  setConnectorGrant,
-} from "@local-studio/agent-runtime/connector-grants";
-import {
-  ConnectorGrantInputSchema,
-  ConnectorGrantRemovalSchema,
-  type ConnectorGrantTarget,
-} from "@local-studio/agent-runtime/connector-grants-contract";
+import { type NextRequest } from "next/server";
 import { requireApiAccess } from "@/lib/auth/guard";
+import { proxyToAgentRuntime } from "@/app/api/agent/proxy-to-runtime";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-function failure(error: unknown, fallback: string) {
-  return NextResponse.json(
-    { error: error instanceof Error ? error.message : fallback },
-    { status: 500 },
-  );
-}
-
-/**
- * The grant targets.
- *
- * Probing a connector for its tool names OPENS it, and opening a stdio MCP
- * connector spawns its child process. Doing that for every enabled connector
- * just to render a list meant merely viewing this page executed every MCP
- * server the user had configured — so the probe is scoped to the one connector
- * being edited, and the list itself launches nothing.
- *
- * A connector that cannot be reached still has to be listable, so a failed
- * probe degrades to an empty tool list rather than failing the request.
- */
-async function grantTargets(probeId: string | null): Promise<ConnectorGrantTarget[]> {
-  return Promise.all(
-    (await enabledConnectors()).map(async (connector) => {
-      const tools =
-        probeId === connector.id ? await listConnectorTools(connector.id).catch(() => []) : [];
-      return {
-        id: connector.id,
-        name: connector.name,
-        tools: tools.map((tool) => tool.name),
-      };
-    }),
-  );
-}
-
-export async function GET(request: NextRequest) {
+export async function GET(request: NextRequest): Promise<Response> {
   const denied = requireApiAccess(request);
   if (denied) return denied;
-  try {
-    // ?connector=<id> asks for that connector's tool names; without it the
-    // list is metadata only and nothing is executed.
-    const probeId = request.nextUrl.searchParams.get("connector")?.trim() || null;
-    const [grants, connectors] = await Promise.all([listConnectorGrants(), grantTargets(probeId)]);
-    return NextResponse.json({ grants, connectors });
-  } catch (error) {
-    return failure(error, "Connector grants failed");
-  }
+  return proxyToAgentRuntime(request);
 }
 
-export async function PUT(request: NextRequest) {
+export async function PUT(request: NextRequest): Promise<Response> {
   const denied = requireApiAccess(request);
   if (denied) return denied;
-  let input: typeof ConnectorGrantInputSchema.Type;
-  try {
-    input = Schema.decodeUnknownSync(ConnectorGrantInputSchema)(await request.json());
-  } catch {
-    return NextResponse.json(
-      { error: "modelId, connectorId and tools are required" },
-      { status: 400 },
-    );
-  }
-  if (!input.modelId.trim() || !input.connectorId.trim()) {
-    return NextResponse.json({ error: "modelId and connectorId are required" }, { status: 400 });
-  }
-  try {
-    return NextResponse.json({ grants: await setConnectorGrant(input) });
-  } catch (error) {
-    return failure(error, "Connector grant could not be saved");
-  }
+  return proxyToAgentRuntime(request);
 }
 
-export async function DELETE(request: NextRequest) {
+export async function DELETE(request: NextRequest): Promise<Response> {
   const denied = requireApiAccess(request);
   if (denied) return denied;
-  let input: typeof ConnectorGrantRemovalSchema.Type;
-  try {
-    input = Schema.decodeUnknownSync(ConnectorGrantRemovalSchema)(await request.json());
-  } catch {
-    return NextResponse.json({ error: "modelId and connectorId are required" }, { status: 400 });
-  }
-  try {
-    return NextResponse.json({
-      grants: await removeConnectorGrant(input.modelId, input.connectorId),
-    });
-  } catch (error) {
-    return failure(error, "Connector grant could not be removed");
-  }
+  return proxyToAgentRuntime(request);
 }

--- a/frontend/src/app/api/agent/connectors/route.ts
+++ b/frontend/src/app/api/agent/connectors/route.ts
@@ -1,125 +1,24 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { Schema } from "effect";
-import { ConnectorUpsertInputSchema } from "@local-studio/agent-runtime/connector-contract";
-import {
-  connectorToolPrefix,
-  isValidConnectorId,
-  listConnectors,
-  removeConnector,
-  toConnectorView,
-  upsertConnector,
-  type ConnectorConfig,
-} from "@local-studio/agent-runtime/connectors-service";
-import { closePooledConnection } from "@local-studio/agent-runtime/connector-pool";
+import { type NextRequest } from "next/server";
 import { requireApiAccess } from "@/lib/auth/guard";
+import { proxyToAgentRuntime } from "@/app/api/agent/proxy-to-runtime";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export async function GET(request: NextRequest) {
+export async function GET(request: NextRequest): Promise<Response> {
   const denied = requireApiAccess(request);
   if (denied) return denied;
-  const connectors = await listConnectors();
-  return NextResponse.json({ connectors: connectors.map(toConnectorView) });
+  return proxyToAgentRuntime(request);
 }
 
-/**
- * Everything a submitted connector can be refused for, in one place.
- *
- * A connector row names a command to execute or an endpoint to trust, so the
- * server checks it rather than relying on the form that happened to submit it —
- * this route is reachable by anything that can reach loopback, including the
- * agent's own tools.
- */
-async function rejectionFor(
-  body: typeof ConnectorUpsertInputSchema.Type,
-): Promise<NextResponse | null> {
-  const reject = (error: string, status: number) => NextResponse.json({ error }, { status });
-  if (!isValidConnectorId(body.id)) return reject("invalid connector id", 400);
-  if (body.transport === "stdio" && !body.command) {
-    return reject("command is required for stdio", 400);
-  }
-  if (body.transport === "http") {
-    if (!body.url) return reject("url is required for http", 400);
-    // An MCP endpoint is fetched by this process with whatever headers the row
-    // carries, so the scheme is worth pinning: `file:` would read local paths
-    // and the exotic schemes are not something a user meant to type.
-    if (!/^https?:\/\//i.test(body.url)) {
-      return reject("url must start with http:// or https://", 400);
-    }
-  }
-  // Tool names are namespaced `<id with - as _>_<tool>`, so `a-b` and `a_b`
-  // would offer the model two different servers under one name and the second
-  // registration would quietly win. Ids are compared on that derived prefix
-  // rather than literally, and only against *other* rows so a row can always be
-  // saved over itself.
-  const collision = (await listConnectors()).find(
-    (entry) =>
-      entry.id !== body.id && connectorToolPrefix(entry.id) === connectorToolPrefix(body.id),
-  );
-  return collision
-    ? reject(`Tool names would collide with connector "${collision.id}"`, 409)
-    : null;
-}
-
-export async function POST(request: NextRequest) {
+export async function POST(request: NextRequest): Promise<Response> {
   const denied = requireApiAccess(request);
   if (denied) return denied;
-  let body: typeof ConnectorUpsertInputSchema.Type;
-  try {
-    body = Schema.decodeUnknownSync(ConnectorUpsertInputSchema)(await request.json());
-  } catch {
-    return NextResponse.json({ error: "invalid connector payload" }, { status: 400 });
-  }
-  const rejection = await rejectionFor(body);
-  if (rejection) return rejection;
-  const connector: ConnectorConfig = {
-    id: body.id,
-    name: body.name?.trim() || body.id,
-    transport: body.transport,
-    ...(body.command ? { command: body.command } : {}),
-    ...(body.args ? { args: body.args } : {}),
-    ...(body.env ? { env: body.env } : {}),
-    ...(body.envSecret ? { envSecret: body.envSecret } : {}),
-    ...(body.cwd ? { cwd: body.cwd } : {}),
-    ...(body.url ? { url: body.url } : {}),
-    ...(body.headers ? { headers: body.headers } : {}),
-    ...(body.headerSecret ? { headerSecret: body.headerSecret } : {}),
-    // Three states, not two. Absent means "leave the allow list alone" — what
-    // every caller that only meant to flip `enabled` sends. An empty list means
-    // "clear it, allow every tool this server declares", which is the widening
-    // an authoring UI has to be able to express and could not before. A
-    // populated list is the restriction itself.
-    ...(body.allowTools === undefined
-      ? {}
-      : { allowTools: body.allowTools.length > 0 ? body.allowTools : undefined }),
-    enabled: body.enabled ?? true,
-  };
-  try {
-    const connectors = await upsertConnector(connector);
-    closePooledConnection(connector.id);
-    return NextResponse.json({ connectors: connectors.map(toConnectorView) });
-  } catch (error) {
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Connector could not be saved" },
-      { status: 409 },
-    );
-  }
+  return proxyToAgentRuntime(request);
 }
 
-export async function DELETE(request: NextRequest) {
+export async function DELETE(request: NextRequest): Promise<Response> {
   const denied = requireApiAccess(request);
   if (denied) return denied;
-  const id = request.nextUrl.searchParams.get("id") ?? "";
-  if (!id) return NextResponse.json({ error: "id is required" }, { status: 400 });
-  try {
-    const connectors = await removeConnector(id);
-    closePooledConnection(id);
-    return NextResponse.json({ connectors: connectors.map(toConnectorView) });
-  } catch (error) {
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Connector could not be removed" },
-      { status: 409 },
-    );
-  }
+  return proxyToAgentRuntime(request);
 }

--- a/frontend/src/app/api/agent/connectors/ssh-server-path/route.ts
+++ b/frontend/src/app/api/agent/connectors/ssh-server-path/route.ts
@@ -1,12 +1,12 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { resolveBundledMcpServerPath } from "@local-studio/agent-runtime/pi-runtime-helpers";
+import { type NextRequest } from "next/server";
 import { requireApiAccess } from "@/lib/auth/guard";
+import { proxyToAgentRuntime } from "@/app/api/agent/proxy-to-runtime";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export async function GET(request: NextRequest) {
+export async function GET(request: NextRequest): Promise<Response> {
   const denied = requireApiAccess(request);
   if (denied) return denied;
-  return NextResponse.json({ path: resolveBundledMcpServerPath("ssh-remote.mjs") });
+  return proxyToAgentRuntime(request);
 }

--- a/frontend/src/app/api/agent/connectors/test/route.ts
+++ b/frontend/src/app/api/agent/connectors/test/route.ts
@@ -1,29 +1,12 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { Schema } from "effect";
-import { ConnectorTestInputSchema } from "@local-studio/agent-runtime/connector-contract";
-import { listConnectors } from "@local-studio/agent-runtime/connectors-service";
-import { probeConnector } from "@local-studio/agent-runtime/connector-pool";
+import { type NextRequest } from "next/server";
 import { requireApiAccess } from "@/lib/auth/guard";
+import { proxyToAgentRuntime } from "@/app/api/agent/proxy-to-runtime";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export async function POST(request: NextRequest) {
+export async function POST(request: NextRequest): Promise<Response> {
   const denied = requireApiAccess(request);
   if (denied) return denied;
-  let body: typeof ConnectorTestInputSchema.Type;
-  try {
-    body = Schema.decodeUnknownSync(ConnectorTestInputSchema)(await request.json());
-  } catch {
-    return NextResponse.json({ error: "id is required" }, { status: 400 });
-  }
-  const connector = (await listConnectors()).find((entry) => entry.id === body.id);
-  if (!connector) return NextResponse.json({ error: "unknown connector" }, { status: 404 });
-  const result = await probeConnector(connector);
-  return NextResponse.json({
-    ok: result.ok,
-    tool_count: result.tools.length,
-    tool_names: result.tools.map((tool) => tool.name).slice(0, 40),
-    ...(result.error ? { error: result.error } : {}),
-  });
+  return proxyToAgentRuntime(request);
 }

--- a/frontend/src/app/api/agent/plugins/route.ts
+++ b/frontend/src/app/api/agent/plugins/route.ts
@@ -1,68 +1,24 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { Schema } from "effect";
-import { PluginUpsertInputSchema } from "@local-studio/agent-runtime/plugin-contract";
-import {
-  listUserPlugins,
-  removeUserPlugin,
-  resolveUserPluginsDir,
-  setUserPluginEnabled,
-  writeUserPlugin,
-} from "@local-studio/agent-runtime/user-plugins";
+import { type NextRequest } from "next/server";
 import { requireApiAccess } from "@/lib/auth/guard";
+import { proxyToAgentRuntime } from "@/app/api/agent/proxy-to-runtime";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const failure = (error: unknown, fallback: string, status: number) =>
-  NextResponse.json({ error: error instanceof Error ? error.message : fallback }, { status });
-
-async function listing() {
-  return NextResponse.json({
-    directory: resolveUserPluginsDir(),
-    plugins: await listUserPlugins(),
-  });
-}
-
-export async function GET(request: NextRequest) {
+export async function GET(request: NextRequest): Promise<Response> {
   const denied = requireApiAccess(request);
   if (denied) return denied;
-  return listing();
+  return proxyToAgentRuntime(request);
 }
 
-/**
- * Write a plugin's source, flip it on or off, or both.
- *
- * Writing is not running: the file lands in the extensions directory and is
- * picked up the next time a session is built, which is also the next time the
- * user sends a message. Nothing is spawned here.
- */
-export async function POST(request: NextRequest) {
+export async function POST(request: NextRequest): Promise<Response> {
   const denied = requireApiAccess(request);
   if (denied) return denied;
-  let body: typeof PluginUpsertInputSchema.Type;
-  try {
-    body = Schema.decodeUnknownSync(PluginUpsertInputSchema)(await request.json());
-  } catch {
-    return NextResponse.json({ error: "invalid plugin payload" }, { status: 400 });
-  }
-  try {
-    if (body.source !== undefined) await writeUserPlugin(body.id, body.source);
-    if (body.enabled !== undefined) await setUserPluginEnabled(body.id, body.enabled);
-    return listing();
-  } catch (error) {
-    return failure(error, "Plugin could not be saved", 409);
-  }
+  return proxyToAgentRuntime(request);
 }
 
-export async function DELETE(request: NextRequest) {
+export async function DELETE(request: NextRequest): Promise<Response> {
   const denied = requireApiAccess(request);
   if (denied) return denied;
-  const id = request.nextUrl.searchParams.get("id") ?? "";
-  if (!id) return NextResponse.json({ error: "id is required" }, { status: 400 });
-  try {
-    await removeUserPlugin(id);
-    return listing();
-  } catch (error) {
-    return failure(error, "Plugin could not be removed", 409);
-  }
+  return proxyToAgentRuntime(request);
 }

--- a/frontend/src/app/api/agent/plugins/source/route.ts
+++ b/frontend/src/app/api/agent/plugins/source/route.ts
@@ -1,27 +1,12 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { readUserPlugin } from "@local-studio/agent-runtime/user-plugins";
+import { type NextRequest } from "next/server";
 import { requireApiAccess } from "@/lib/auth/guard";
+import { proxyToAgentRuntime } from "@/app/api/agent/proxy-to-runtime";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-/**
- * One plugin's source. Split from the listing route because a list of plugins
- * is read on every visit to the tab while the code behind them is read only
- * when one is opened, and shipping every file's text to draw a table of names
- * would make the tab slower the more plugins a user writes.
- */
-export async function GET(request: NextRequest) {
+export async function GET(request: NextRequest): Promise<Response> {
   const denied = requireApiAccess(request);
   if (denied) return denied;
-  const id = request.nextUrl.searchParams.get("id") ?? "";
-  if (!id) return NextResponse.json({ error: "id is required" }, { status: 400 });
-  try {
-    return NextResponse.json(await readUserPlugin(id));
-  } catch (error) {
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Plugin could not be read" },
-      { status: 404 },
-    );
-  }
+  return proxyToAgentRuntime(request);
 }

--- a/frontend/src/app/api/agent/projects/route.ts
+++ b/frontend/src/app/api/agent/projects/route.ts
@@ -1,52 +1,17 @@
-import { NextRequest, NextResponse } from "next/server";
-import {
-  addProjectToStore,
-  listProjectsFromStore,
-  removeProjectFromStore,
-  type ProjectEntry,
-} from "@local-studio/agent-runtime/projects-store";
-import { errorMessage, jsonError } from "@/app/api/_lib/route-helpers";
+import { type NextRequest } from "next/server";
+import { proxyToAgentRuntime } from "@/app/api/agent/proxy-to-runtime";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export async function GET() {
-  try {
-    const projects = listProjectsFromStore();
-    return NextResponse.json({ projects });
-  } catch (error) {
-    return jsonError(errorMessage(error, "Failed to read projects"), 500);
-  }
+export async function GET(request: NextRequest): Promise<Response> {
+  return proxyToAgentRuntime(request);
 }
 
-export async function POST(request: NextRequest) {
-  let body: { path?: unknown };
-  try {
-    body = (await request.json()) as { path?: unknown };
-  } catch {
-    return jsonError("Invalid JSON body");
-  }
-  const directoryPath = typeof body.path === "string" ? body.path.trim() : "";
-  if (!directoryPath) {
-    return jsonError("path is required");
-  }
-  try {
-    const project: ProjectEntry = addProjectToStore(directoryPath);
-    return NextResponse.json({ project });
-  } catch (error) {
-    return jsonError(errorMessage(error, "Failed to add project"));
-  }
+export async function POST(request: NextRequest): Promise<Response> {
+  return proxyToAgentRuntime(request);
 }
 
-export async function DELETE(request: NextRequest) {
-  const id = new URL(request.url).searchParams.get("id");
-  if (!id) {
-    return jsonError("id is required");
-  }
-  try {
-    removeProjectFromStore(id);
-    return NextResponse.json({ ok: true });
-  } catch (error) {
-    return jsonError(errorMessage(error, "Failed to remove project"), 500);
-  }
+export async function DELETE(request: NextRequest): Promise<Response> {
+  return proxyToAgentRuntime(request);
 }

--- a/frontend/src/app/api/agent/prompt-templates/load/route.ts
+++ b/frontend/src/app/api/agent/prompt-templates/load/route.ts
@@ -1,12 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
-import { loadPromptTemplateInstructions } from "@/features/agent/prompt-templates-store";
+import { type NextRequest } from "next/server";
+import { proxyToAgentRuntime } from "@/app/api/agent/proxy-to-runtime";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export async function GET(request: NextRequest) {
-  const templatePath = request.nextUrl.searchParams.get("path") ?? "";
-  const template = templatePath ? loadPromptTemplateInstructions(templatePath) : null;
-  if (!template) return NextResponse.json({ error: "Template not found" }, { status: 404 });
-  return NextResponse.json({ template });
+export async function GET(request: NextRequest): Promise<Response> {
+  return proxyToAgentRuntime(request);
 }

--- a/frontend/src/app/api/agent/prompt-templates/route.ts
+++ b/frontend/src/app/api/agent/prompt-templates/route.ts
@@ -1,9 +1,9 @@
-import { NextResponse } from "next/server";
-import { discoverPromptTemplates } from "@/features/agent/prompt-templates-store";
+import { type NextRequest } from "next/server";
+import { proxyToAgentRuntime } from "@/app/api/agent/proxy-to-runtime";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export async function GET() {
-  return NextResponse.json({ templates: discoverPromptTemplates() });
+export async function GET(request: NextRequest): Promise<Response> {
+  return proxyToAgentRuntime(request);
 }

--- a/frontend/src/app/api/agent/skills/load/route.ts
+++ b/frontend/src/app/api/agent/skills/load/route.ts
@@ -1,12 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
-import { loadSkillInstructions } from "@local-studio/agent-runtime/skill-discovery";
+import { type NextRequest } from "next/server";
+import { proxyToAgentRuntime } from "@/app/api/agent/proxy-to-runtime";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export async function GET(request: NextRequest) {
-  const skillPath = request.nextUrl.searchParams.get("path") ?? "";
-  const skill = skillPath ? loadSkillInstructions(skillPath) : null;
-  if (!skill) return NextResponse.json({ error: "Skill not found" }, { status: 404 });
-  return NextResponse.json({ skill });
+export async function GET(request: NextRequest): Promise<Response> {
+  return proxyToAgentRuntime(request);
 }

--- a/frontend/src/app/api/agent/skills/route.ts
+++ b/frontend/src/app/api/agent/skills/route.ts
@@ -1,9 +1,9 @@
-import { NextResponse } from "next/server";
-import { discoverSkills } from "@local-studio/agent-runtime/skill-discovery";
+import { type NextRequest } from "next/server";
+import { proxyToAgentRuntime } from "@/app/api/agent/proxy-to-runtime";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export async function GET() {
-  return NextResponse.json({ skills: discoverSkills() });
+export async function GET(request: NextRequest): Promise<Response> {
+  return proxyToAgentRuntime(request);
 }

--- a/frontend/src/features/agent/ui/composer-project-drawer.tsx
+++ b/frontend/src/features/agent/ui/composer-project-drawer.tsx
@@ -152,13 +152,28 @@ export function ComposerProjectDrawer({
         data-testid="composer-drawer"
         className="relative z-0 mx-auto -mb-3 w-[calc(100%_-_26px)] max-w-[calc(var(--composer-w)*0.9_-_26px)] overflow-hidden rounded-[var(--composer-radius-inner)] border border-(--border) bg-(--fg)/[0.022] pb-2 text-[length:var(--fs-xs)] shadow-[var(--composer-elevation-inner)] md:pb-3 md:text-[length:var(--fs-sm)] backdrop-blur-sm [corner-shape:superellipse(1.5)] sm:w-[calc(90%_-_26px)]"
       >
-        <DrawerSummaryButton
-          open={open}
-          onToggle={() => setOpen((value) => !value)}
-          label={label}
-          queueCount={queueItems.length}
-          hasGoal={goal !== null}
-        />
+        <div className="px-1.5 pt-1">
+          <DrawerSummaryButton
+            open={open}
+            onToggle={() => setOpen((value) => !value)}
+            label={label}
+            queueCount={queueItems.length}
+            hasGoal={goal !== null}
+          />
+        </div>
+        {/* Collapsed is a summary, not a void: the branch and its diffstat
+            are the thing you check between prompts, so they stay visible
+            without opening the drawer. */}
+        {!open ? (
+          <div className="px-1.5 pt-0.5">
+            <GitRow
+              gitSummary={gitSummary}
+              gitBranch={gitBranch}
+              onInitGit={onInitGit}
+              onOpenDiff={onOpenDiff}
+            />
+          </div>
+        ) : null}
         {hasQueue ? (
           <div className="px-1.5 pb-0.5">
             <QueuedMessageStack
@@ -829,18 +844,15 @@ function DrawerSummaryButton({
       type="button"
       onClick={onToggle}
       aria-expanded={open}
-      className="flex h-7 w-full items-center gap-2 px-2.5 text-left text-(--fg)/78 transition-colors hover:bg-(--fg)/[0.03] md:h-8 md:gap-2.5 md:px-3"
+      // Same metrics as every list row below it — the collapsed summary and
+      // the expanded rows share one left edge and one height, so toggling
+      // the drawer doesn't make the text jump.
+      className={cx(listRowClass, "text-(--fg)/78 hover:bg-(--hover)")}
     >
       {hasQueue ? (
-        <ListChecks
-          className="h-3.5 w-3.5 shrink-0 text-(--fg)/56 md:h-4 md:w-4"
-          strokeWidth={1.7}
-        />
+        <ListChecks className="h-3.5 w-3.5 shrink-0 text-(--fg)/56" strokeWidth={1.7} />
       ) : (
-        <FolderOpen
-          className="h-3.5 w-3.5 shrink-0 text-(--fg)/56 md:h-4 md:w-4"
-          strokeWidth={1.7}
-        />
+        <FolderOpen className="h-3.5 w-3.5 shrink-0 text-(--fg)/56" strokeWidth={1.7} />
       )}
       <span className="min-w-0 flex-1 truncate">
         {hasQueue ? `${queueCount} queued message${queueCount === 1 ? "" : "s"}` : label}

--- a/frontend/src/features/agent/ui/projects-nav/recent-sessions-section.tsx
+++ b/frontend/src/features/agent/ui/projects-nav/recent-sessions-section.tsx
@@ -9,7 +9,7 @@ import {
   subscribeSessionActivity,
   type SessionActivity,
 } from "@/features/agent/session-index";
-import { useSessionActivity } from "@/features/agent/ui/use-open-sessions";
+import { useOpenSessions, useSessionActivity } from "@/features/agent/ui/use-open-sessions";
 import { Spinner } from "@/ui";
 import { orderByRecency, recentsTimestamp } from "@/features/agent/ui/session-recency";
 import { useProjectsNavSessionPrefs } from "@/features/agent/ui/projects-nav/use-projects-nav-effects";
@@ -164,17 +164,27 @@ function RowStatus({ activity }: { activity: SessionActivity }) {
 
 function RecentSessionRow({ session, prefs }: { session: AggregatedSession; prefs: SessionPrefs }) {
   const activitySnapshot = useSessionActivity();
+  const openSessions = useOpenSessions();
   const activity = sessionActivity([session.id], activitySnapshot);
+  // The open thread reads as selected here the same way it does in the
+  // project tree — this list is a navigation surface, so "where am I"
+  // must be answerable at a glance.
+  const isOpen = openSessions.some(
+    (open) => open.focused && (open.threadId === session.id || open.id === session.id),
+  );
   const title = rowTitle(session, prefs);
   const preview = rowPreview(session, title);
   return (
     <Link
       href={`/agent?project=${encodeURIComponent(session.projectId)}&session=${encodeURIComponent(session.id)}&replace=1`}
       title={[title, session.projectName, session.projectPath].filter(Boolean).join(" · ")}
+      aria-current={isOpen ? "page" : undefined}
       // Two lines, not the single-line row the other sections use: the prompt
       // preview is the point of this list, so it gets its own line under the
       // title rather than competing with it for width.
-      className="group flex flex-col gap-0.5 rounded-[var(--sidebar-row-radius)] px-2 py-1.5 transition-colors hover:bg-(--hover)"
+      className={`group flex flex-col gap-0.5 rounded-[var(--sidebar-row-radius)] px-2 py-1.5 transition-colors hover:bg-(--hover) ${
+        isOpen ? "bg-(--hover)" : ""
+      }`}
     >
       <span className="flex min-w-0 items-center gap-2">
         <span className="min-w-0 truncate text-[length:var(--fs-md)] text-(--fg)">{title}</span>

--- a/frontend/src/lib/desktop-ui-preferences.ts
+++ b/frontend/src/lib/desktop-ui-preferences.ts
@@ -20,6 +20,8 @@ const DURABLE_KEY_PREFIXES = ["local-studio.", "local-studio-", "localstudio_", 
 const EXCLUDED_DURABLE_KEYS = new Set([
   "local-studio.agent.transcripts.v1",
   "local-studio.agent.activeSessions.snapshot",
+  // The sync base itself — uploading it would nest the whole pref set.
+  "local-studio.ui-prefs-synced",
 ]);
 
 const EXCLUDED_DURABLE_PREFIXES = ["local-studio.agent.transcript."];
@@ -75,9 +77,14 @@ function withoutControllerCredentials(prefs: Record<string, string>): Record<str
   return rest;
 }
 
+// The controller's studio settings store is where preferences live — the
+// runtime's /api/settings only knows backendUrl+apiKey and silently dropped
+// everything this module sent it, which is why prefs never synced between
+// surfaces. The proxy route reaches whichever controller is active and
+// injects its stored key server-side.
 async function loadControllerUiPreferences(): Promise<Record<string, string>> {
   try {
-    const response = await fetch("/api/settings", {
+    const response = await fetch("/api/proxy/studio/settings", {
       cache: "no-store",
       signal: AbortSignal.timeout(UI_PREFERENCES_TIMEOUT_MS),
     });
@@ -89,14 +96,46 @@ async function loadControllerUiPreferences(): Promise<Record<string, string>> {
   }
 }
 
-async function saveControllerUiPreferences(prefs: Record<string, string>): Promise<void> {
+async function saveControllerUiPreferences(prefs: Record<string, string>): Promise<boolean> {
   try {
-    await fetch("/api/settings", {
+    const response = await fetch("/api/proxy/studio/settings", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ ui_preferences: withoutControllerCredentials(prefs) }),
       signal: AbortSignal.timeout(UI_PREFERENCES_TIMEOUT_MS),
     });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * What each key looked like the last time this surface synced with the
+ * controller. With that base, adoption is a three-way merge without clocks:
+ * a key the user never changed here follows the controller; a key they did
+ * change here wins locally and uploads on the next save.
+ */
+const SYNC_SNAPSHOT_KEY = "local-studio.ui-prefs-synced";
+
+function readSyncSnapshot(): Record<string, string> {
+  try {
+    const raw = window.localStorage.getItem(SYNC_SNAPSHOT_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : null;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return Object.fromEntries(
+      Object.entries(parsed as Record<string, unknown>).filter(
+        (entry): entry is [string, string] => typeof entry[1] === "string",
+      ),
+    );
+  } catch {
+    return {};
+  }
+}
+
+function writeSyncSnapshot(snapshot: Record<string, string>): void {
+  try {
+    window.localStorage.setItem(SYNC_SNAPSHOT_KEY, JSON.stringify(snapshot));
   } catch {}
 }
 
@@ -181,6 +220,8 @@ export function mergeControllersPreference(
 function applyMissingPreferences(prefs: Record<string, string>): Set<string> {
   const applied = new Set<string>();
   if (typeof window === "undefined") return applied;
+  const snapshot = readSyncSnapshot();
+  const nextSnapshot = { ...snapshot };
   for (const [key, value] of Object.entries(prefs ?? {})) {
     if (!isDurableUiPreferenceKey(key) || typeof value !== "string") continue;
     const currentValue = window.localStorage.getItem(key);
@@ -190,13 +231,21 @@ function applyMissingPreferences(prefs: Record<string, string>): Set<string> {
         window.localStorage.setItem(key, merged);
         applied.add(key);
       }
+      nextSnapshot[key] = value;
       continue;
     }
-    if (currentValue === null) {
-      window.localStorage.setItem(key, value);
-      applied.add(key);
+    // Adopt the controller's value when this surface never set the key, or
+    // set it and hasn't touched it since the last sync. A locally-changed
+    // key wins here and uploads on the next save.
+    if (currentValue === null || currentValue === snapshot[key]) {
+      if (currentValue !== value) {
+        window.localStorage.setItem(key, value);
+        applied.add(key);
+      }
+      nextSnapshot[key] = value;
     }
   }
+  writeSyncSnapshot(nextSnapshot);
   return applied;
 }
 
@@ -238,7 +287,11 @@ export function scheduleDurableUiPreferencesSave(): void {
   saveTimer = window.setTimeout(() => {
     saveTimer = null;
     const prefs = collectDurableUiPreferences();
-    void saveControllerUiPreferences(prefs);
+    void saveControllerUiPreferences(prefs).then((saved) => {
+      // The upload is now the shared truth; recording it as the sync base
+      // lets the next hydrate treat these values as "unchanged here".
+      if (saved) writeSyncSnapshot(withoutControllerCredentials(prefs));
+    });
     void desktop?.saveUiPreferences?.(prefs).catch(() => undefined);
   }, 200);
 }

--- a/services/agent-runtime/src/http/app.ts
+++ b/services/agent-runtime/src/http/app.ts
@@ -56,6 +56,42 @@ import {
 } from "./pty-handlers";
 import { handleAgentModels } from "./model-handlers";
 import {
+  handleConnectorCall,
+  handleConnectorDelete,
+  handleConnectorGrantDelete,
+  handleConnectorGrantPut,
+  handleConnectorGrantsGet,
+  handleConnectorInventory,
+  handleConnectorsList,
+  handleConnectorTest,
+  handleConnectorUpsert,
+  handleSshServerPath,
+} from "./connector-handlers";
+import {
+  handleGoogleAccountDisconnect,
+  handleGoogleAccountGet,
+  handleGoogleAuthorizeBegin,
+  handleGoogleAuthorizeCancel,
+  handleGoogleClientPut,
+} from "./google-account-handlers";
+import {
+  handleProjectAdd,
+  handleProjectRemove,
+  handleProjectsList,
+} from "./project-handlers";
+import {
+  handlePluginDelete,
+  handlePluginSource,
+  handlePluginsList,
+  handlePluginUpsert,
+} from "./plugin-handlers";
+import {
+  handlePromptTemplateLoad,
+  handlePromptTemplatesList,
+  handleSkillLoad,
+  handleSkillsList,
+} from "./discovery-handlers";
+import {
   handleAllSessions,
   handleSessionGet,
   handleSessionPatch,
@@ -115,6 +151,32 @@ export function createAgentRuntimeApp() {
     handleAutomationDelete(c.req.param("id")),
   );
   app.post("/api/agent/automations/:id/run", (c) => handleAutomationRun(c.req.param("id")));
+  app.get("/api/agent/connectors", () => handleConnectorsList());
+  app.post("/api/agent/connectors", (c) => handleConnectorUpsert(c.req.raw));
+  app.delete("/api/agent/connectors", (c) => handleConnectorDelete(c.req.raw));
+  app.get("/api/agent/connectors/call", (c) => handleConnectorInventory(c.req.raw));
+  app.post("/api/agent/connectors/call", (c) => handleConnectorCall(c.req.raw));
+  app.get("/api/agent/connectors/grants", (c) => handleConnectorGrantsGet(c.req.raw));
+  app.put("/api/agent/connectors/grants", (c) => handleConnectorGrantPut(c.req.raw));
+  app.delete("/api/agent/connectors/grants", (c) => handleConnectorGrantDelete(c.req.raw));
+  app.post("/api/agent/connectors/test", (c) => handleConnectorTest(c.req.raw));
+  app.get("/api/agent/connectors/ssh-server-path", () => handleSshServerPath());
+  app.get("/api/agent/accounts/google", () => handleGoogleAccountGet());
+  app.put("/api/agent/accounts/google", (c) => handleGoogleClientPut(c.req.raw));
+  app.delete("/api/agent/accounts/google", (c) => handleGoogleAccountDisconnect(c.req.raw));
+  app.post("/api/agent/accounts/google/authorize", (c) => handleGoogleAuthorizeBegin(c.req.raw));
+  app.delete("/api/agent/accounts/google/authorize", (c) => handleGoogleAuthorizeCancel(c.req.raw));
+  app.get("/api/agent/projects", () => handleProjectsList());
+  app.post("/api/agent/projects", (c) => handleProjectAdd(c.req.raw));
+  app.delete("/api/agent/projects", (c) => handleProjectRemove(c.req.raw));
+  app.get("/api/agent/plugins", () => handlePluginsList());
+  app.post("/api/agent/plugins", (c) => handlePluginUpsert(c.req.raw));
+  app.delete("/api/agent/plugins", (c) => handlePluginDelete(c.req.raw));
+  app.get("/api/agent/plugins/source", (c) => handlePluginSource(c.req.raw));
+  app.get("/api/agent/skills", () => handleSkillsList());
+  app.get("/api/agent/skills/load", (c) => handleSkillLoad(c.req.raw));
+  app.get("/api/agent/prompt-templates", () => handlePromptTemplatesList());
+  app.get("/api/agent/prompt-templates/load", (c) => handlePromptTemplateLoad(c.req.raw));
   app.get("/api/agent/pr", (c) => handlePrGet(c.req.raw));
   app.post("/api/agent/pr/merge", (c) => handlePrMerge(c.req.raw));
   app.get("/api/agent/subagents", (c) => handleSubagentsList(c.req.raw));

--- a/services/agent-runtime/src/http/connector-handlers.ts
+++ b/services/agent-runtime/src/http/connector-handlers.ts
@@ -1,0 +1,325 @@
+//
+// HTTP surface for MCP connectors: the CRUD listing, the granted-tool
+// inventory + tool calls, the per-model grants, the probe ("test") endpoint,
+// and the bundled ssh server path. Moved verbatim from the Next route
+// handlers so a remote runtime owns connector state instead of the frontend
+// process that happens to serve the UI.
+//
+
+import { Schema } from "effect";
+import {
+  ConnectorTestInputSchema,
+  ConnectorUpsertInputSchema,
+} from "../connector-contract";
+import {
+  connectorToolPrefix,
+  enabledConnectors,
+  isValidConnectorId,
+  listConnectors,
+  removeConnector,
+  toConnectorView,
+  upsertConnector,
+  type ConnectorConfig,
+} from "../connectors-service";
+import {
+  callConnectorTool,
+  closePooledConnection,
+  ConnectorToolDeniedError,
+  listConnectorTools,
+  probeConnector,
+} from "../connector-pool";
+import {
+  isConnectorToolGranted,
+  listConnectorGrants,
+  removeConnectorGrant,
+  resolveGrantedTools,
+  setConnectorGrant,
+} from "../connector-grants";
+import {
+  ConnectorGrantInputSchema,
+  ConnectorGrantRemovalSchema,
+  type ConnectorGrantTarget,
+} from "../connector-grants-contract";
+import { resolveBundledMcpServerPath } from "../pi-runtime-helpers";
+
+export async function handleConnectorsList(): Promise<Response> {
+  const connectors = await listConnectors();
+  return Response.json({ connectors: connectors.map(toConnectorView) });
+}
+
+/**
+ * Everything a submitted connector can be refused for, in one place.
+ *
+ * A connector row names a command to execute or an endpoint to trust, so the
+ * server checks it rather than relying on the form that happened to submit it —
+ * this route is reachable by anything that can reach loopback, including the
+ * agent's own tools.
+ */
+async function rejectionFor(
+  body: typeof ConnectorUpsertInputSchema.Type,
+): Promise<Response | null> {
+  const reject = (error: string, status: number) => Response.json({ error }, { status });
+  if (!isValidConnectorId(body.id)) return reject("invalid connector id", 400);
+  if (body.transport === "stdio" && !body.command) {
+    return reject("command is required for stdio", 400);
+  }
+  if (body.transport === "http") {
+    if (!body.url) return reject("url is required for http", 400);
+    // An MCP endpoint is fetched by this process with whatever headers the row
+    // carries, so the scheme is worth pinning: `file:` would read local paths
+    // and the exotic schemes are not something a user meant to type.
+    if (!/^https?:\/\//i.test(body.url)) {
+      return reject("url must start with http:// or https://", 400);
+    }
+  }
+  // Tool names are namespaced `<id with - as _>_<tool>`, so `a-b` and `a_b`
+  // would offer the model two different servers under one name and the second
+  // registration would quietly win. Ids are compared on that derived prefix
+  // rather than literally, and only against *other* rows so a row can always be
+  // saved over itself.
+  const collision = (await listConnectors()).find(
+    (entry) =>
+      entry.id !== body.id && connectorToolPrefix(entry.id) === connectorToolPrefix(body.id),
+  );
+  return collision
+    ? reject(`Tool names would collide with connector "${collision.id}"`, 409)
+    : null;
+}
+
+export async function handleConnectorUpsert(request: Request): Promise<Response> {
+  let body: typeof ConnectorUpsertInputSchema.Type;
+  try {
+    body = Schema.decodeUnknownSync(ConnectorUpsertInputSchema)(await request.json());
+  } catch {
+    return Response.json({ error: "invalid connector payload" }, { status: 400 });
+  }
+  const rejection = await rejectionFor(body);
+  if (rejection) return rejection;
+  const connector: ConnectorConfig = {
+    id: body.id,
+    name: body.name?.trim() || body.id,
+    transport: body.transport,
+    ...(body.command ? { command: body.command } : {}),
+    ...(body.args ? { args: body.args } : {}),
+    ...(body.env ? { env: body.env } : {}),
+    ...(body.envSecret ? { envSecret: body.envSecret } : {}),
+    ...(body.cwd ? { cwd: body.cwd } : {}),
+    ...(body.url ? { url: body.url } : {}),
+    ...(body.headers ? { headers: body.headers } : {}),
+    ...(body.headerSecret ? { headerSecret: body.headerSecret } : {}),
+    // Three states, not two. Absent means "leave the allow list alone" — what
+    // every caller that only meant to flip `enabled` sends. An empty list means
+    // "clear it, allow every tool this server declares", which is the widening
+    // an authoring UI has to be able to express and could not before. A
+    // populated list is the restriction itself.
+    ...(body.allowTools === undefined
+      ? {}
+      : { allowTools: body.allowTools.length > 0 ? body.allowTools : undefined }),
+    enabled: body.enabled ?? true,
+  };
+  try {
+    const connectors = await upsertConnector(connector);
+    closePooledConnection(connector.id);
+    return Response.json({ connectors: connectors.map(toConnectorView) });
+  } catch (error) {
+    return Response.json(
+      { error: error instanceof Error ? error.message : "Connector could not be saved" },
+      { status: 409 },
+    );
+  }
+}
+
+export async function handleConnectorDelete(request: Request): Promise<Response> {
+  const id = new URL(request.url).searchParams.get("id") ?? "";
+  if (!id) return Response.json({ error: "id is required" }, { status: 400 });
+  try {
+    const connectors = await removeConnector(id);
+    closePooledConnection(id);
+    return Response.json({ connectors: connectors.map(toConnectorView) });
+  } catch (error) {
+    return Response.json(
+      { error: error instanceof Error ? error.message : "Connector could not be removed" },
+      { status: 409 },
+    );
+  }
+}
+
+const ConnectorToolCallSchema = Schema.Struct({
+  connector_id: Schema.String,
+  tool: Schema.String,
+  args: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+  model_id: Schema.optional(Schema.String),
+});
+
+/**
+ * The session's model, as claimed by the caller. It decides which connector
+ * tools are offered and which calls are allowed. An unnamed model matches only
+ * the `*` grants, so an older extension that does not send one keeps whatever
+ * blanket access the user left in place and gains nothing else.
+ */
+const callerModelId = (value: string | null | undefined): string => value?.trim() ?? "";
+
+export async function handleConnectorInventory(request: Request): Promise<Response> {
+  const modelId = callerModelId(new URL(request.url).searchParams.get("model_id"));
+  const grants = await listConnectorGrants();
+  const granted = (await enabledConnectors()).flatMap((connector) => {
+    const tools = resolveGrantedTools(grants, modelId, connector.id);
+    return tools === "all" || tools.length ? [{ connector, tools }] : [];
+  });
+  const inventory = await Promise.all(
+    granted.map(async ({ connector, tools }) => {
+      try {
+        const available = await listConnectorTools(connector.id);
+        return {
+          id: connector.id,
+          name: connector.name,
+          tools:
+            tools === "all" ? available : available.filter((tool) => tools.includes(tool.name)),
+        };
+      } catch (error) {
+        return {
+          id: connector.id,
+          name: connector.name,
+          tools: [],
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }),
+  );
+  return Response.json({ connectors: inventory });
+}
+
+export async function handleConnectorCall(request: Request): Promise<Response> {
+  let body: typeof ConnectorToolCallSchema.Type;
+  try {
+    body = Schema.decodeUnknownSync(ConnectorToolCallSchema)(await request.json());
+  } catch {
+    return Response.json({ error: "connector_id and tool are required" }, { status: 400 });
+  }
+  if (!body.connector_id.trim() || !body.tool.trim()) {
+    return Response.json({ error: "connector_id and tool are required" }, { status: 400 });
+  }
+  try {
+    // Filtering the inventory only decides what the model is told about; the
+    // grant is re-checked here because this route is the actual boundary.
+    const grants = await listConnectorGrants();
+    if (
+      !isConnectorToolGranted(grants, callerModelId(body.model_id), body.connector_id, body.tool)
+    ) {
+      throw new ConnectorToolDeniedError(
+        `Model is not granted "${body.tool}" on connector "${body.connector_id}"`,
+      );
+    }
+    const result = await callConnectorTool(body.connector_id, body.tool, body.args ?? {});
+    return Response.json({ ok: true, result });
+  } catch (error) {
+    const status = error instanceof ConnectorToolDeniedError ? 403 : 500;
+    return Response.json(
+      { ok: false, error: error instanceof Error ? error.message : String(error) },
+      { status },
+    );
+  }
+}
+
+function grantsFailure(error: unknown, fallback: string): Response {
+  return Response.json(
+    { error: error instanceof Error ? error.message : fallback },
+    { status: 500 },
+  );
+}
+
+/**
+ * The grant targets.
+ *
+ * Probing a connector for its tool names OPENS it, and opening a stdio MCP
+ * connector spawns its child process. Doing that for every enabled connector
+ * just to render a list meant merely viewing this page executed every MCP
+ * server the user had configured — so the probe is scoped to the one connector
+ * being edited, and the list itself launches nothing.
+ *
+ * A connector that cannot be reached still has to be listable, so a failed
+ * probe degrades to an empty tool list rather than failing the request.
+ */
+async function grantTargets(probeId: string | null): Promise<ConnectorGrantTarget[]> {
+  return Promise.all(
+    (await enabledConnectors()).map(async (connector) => {
+      const tools =
+        probeId === connector.id ? await listConnectorTools(connector.id).catch(() => []) : [];
+      return {
+        id: connector.id,
+        name: connector.name,
+        tools: tools.map((tool) => tool.name),
+      };
+    }),
+  );
+}
+
+export async function handleConnectorGrantsGet(request: Request): Promise<Response> {
+  try {
+    // ?connector=<id> asks for that connector's tool names; without it the
+    // list is metadata only and nothing is executed.
+    const probeId = new URL(request.url).searchParams.get("connector")?.trim() || null;
+    const [grants, connectors] = await Promise.all([listConnectorGrants(), grantTargets(probeId)]);
+    return Response.json({ grants, connectors });
+  } catch (error) {
+    return grantsFailure(error, "Connector grants failed");
+  }
+}
+
+export async function handleConnectorGrantPut(request: Request): Promise<Response> {
+  let input: typeof ConnectorGrantInputSchema.Type;
+  try {
+    input = Schema.decodeUnknownSync(ConnectorGrantInputSchema)(await request.json());
+  } catch {
+    return Response.json(
+      { error: "modelId, connectorId and tools are required" },
+      { status: 400 },
+    );
+  }
+  if (!input.modelId.trim() || !input.connectorId.trim()) {
+    return Response.json({ error: "modelId and connectorId are required" }, { status: 400 });
+  }
+  try {
+    return Response.json({ grants: await setConnectorGrant(input) });
+  } catch (error) {
+    return grantsFailure(error, "Connector grant could not be saved");
+  }
+}
+
+export async function handleConnectorGrantDelete(request: Request): Promise<Response> {
+  let input: typeof ConnectorGrantRemovalSchema.Type;
+  try {
+    input = Schema.decodeUnknownSync(ConnectorGrantRemovalSchema)(await request.json());
+  } catch {
+    return Response.json({ error: "modelId and connectorId are required" }, { status: 400 });
+  }
+  try {
+    return Response.json({
+      grants: await removeConnectorGrant(input.modelId, input.connectorId),
+    });
+  } catch (error) {
+    return grantsFailure(error, "Connector grant could not be removed");
+  }
+}
+
+export async function handleConnectorTest(request: Request): Promise<Response> {
+  let body: typeof ConnectorTestInputSchema.Type;
+  try {
+    body = Schema.decodeUnknownSync(ConnectorTestInputSchema)(await request.json());
+  } catch {
+    return Response.json({ error: "id is required" }, { status: 400 });
+  }
+  const connector = (await listConnectors()).find((entry) => entry.id === body.id);
+  if (!connector) return Response.json({ error: "unknown connector" }, { status: 404 });
+  const result = await probeConnector(connector);
+  return Response.json({
+    ok: result.ok,
+    tool_count: result.tools.length,
+    tool_names: result.tools.map((tool) => tool.name).slice(0, 40),
+    ...(result.error ? { error: result.error } : {}),
+  });
+}
+
+export async function handleSshServerPath(): Promise<Response> {
+  return Response.json({ path: resolveBundledMcpServerPath("ssh-remote.mjs") });
+}

--- a/services/agent-runtime/src/http/discovery-handlers.ts
+++ b/services/agent-runtime/src/http/discovery-handlers.ts
@@ -1,0 +1,34 @@
+//
+// HTTP surface for the discovery listings the composer reads: skills and
+// prompt templates. Moved verbatim from the Next route handlers — both walk
+// directories on the machine the agent runs on, so a remote runtime must be
+// the one answering.
+//
+
+import { discoverSkills, loadSkillInstructions } from "../skill-discovery";
+import {
+  discoverPromptTemplates,
+  loadPromptTemplateInstructions,
+} from "../prompt-templates-store";
+
+export async function handleSkillsList(): Promise<Response> {
+  return Response.json({ skills: discoverSkills() });
+}
+
+export async function handleSkillLoad(request: Request): Promise<Response> {
+  const skillPath = new URL(request.url).searchParams.get("path") ?? "";
+  const skill = skillPath ? loadSkillInstructions(skillPath) : null;
+  if (!skill) return Response.json({ error: "Skill not found" }, { status: 404 });
+  return Response.json({ skill });
+}
+
+export async function handlePromptTemplatesList(): Promise<Response> {
+  return Response.json({ templates: discoverPromptTemplates() });
+}
+
+export async function handlePromptTemplateLoad(request: Request): Promise<Response> {
+  const templatePath = new URL(request.url).searchParams.get("path") ?? "";
+  const template = templatePath ? loadPromptTemplateInstructions(templatePath) : null;
+  if (!template) return Response.json({ error: "Template not found" }, { status: 404 });
+  return Response.json({ template });
+}

--- a/services/agent-runtime/src/http/google-account-handlers.ts
+++ b/services/agent-runtime/src/http/google-account-handlers.ts
@@ -1,0 +1,143 @@
+//
+// HTTP surface for the Google account: client credentials, connection status,
+// disconnects, and the loopback OAuth authorization flow. Moved verbatim from
+// the Next route handlers so a remote runtime owns the Google binding — the
+// loopback OAuth listener must run in the process the connectors run in.
+//
+
+import { Effect, Schema } from "effect";
+import {
+  disconnectGoogleAccount,
+  getGoogleAccount,
+  GoogleAccountError,
+  saveGoogleClient,
+} from "../google-account";
+import { closePooledConnection } from "../connector-pool";
+import { listConnectors } from "../connectors-service";
+import { disableGoogleWorkspaceAdapter } from "../google-workspace-adapter";
+import {
+  GOOGLE_ACCOUNT_KEY_PATTERN,
+  googleWorkspaceConnectorIdentity,
+} from "../google-workspace-binding";
+import {
+  beginGoogleLoopbackAuthorization,
+  cancelGoogleLoopbackAuthorization,
+} from "../google-oauth-loopback";
+
+const GoogleClientInputSchema = Schema.Struct({
+  clientId: Schema.String,
+  clientSecret: Schema.optional(Schema.String),
+});
+
+const GoogleDisconnectInputSchema = Schema.Struct({
+  account: Schema.Union([Schema.Literal("gmail"), Schema.Literal("google-calendar")]),
+  accountKey: Schema.String,
+});
+
+const GoogleAccountInputSchema = Schema.Struct({
+  account: Schema.Union([Schema.Literal("gmail"), Schema.Literal("google-calendar")]),
+});
+
+function failure(error: unknown, fallback = "Google account failed"): Response {
+  const status = error instanceof GoogleAccountError ? error.status : 500;
+  return Response.json(
+    { error: error instanceof Error ? error.message : fallback },
+    { status },
+  );
+}
+
+/** Pooled sockets outlive a credential change, so every managed row is dropped. */
+async function closeGoogleConnections(): Promise<void> {
+  try {
+    for (const connector of await listConnectors()) {
+      if (googleWorkspaceConnectorIdentity(connector.id)) closePooledConnection(connector.id);
+    }
+  } catch {
+    // A connector file we cannot read has no live pooled connections to close.
+  }
+}
+
+export async function handleGoogleAccountGet(): Promise<Response> {
+  try {
+    return Response.json({ account: await Effect.runPromise(getGoogleAccount()) });
+  } catch (error) {
+    return failure(error);
+  }
+}
+
+export async function handleGoogleClientPut(request: Request): Promise<Response> {
+  let input: typeof GoogleClientInputSchema.Type;
+  try {
+    input = Schema.decodeUnknownSync(GoogleClientInputSchema)(await request.json());
+  } catch {
+    return Response.json({ error: "clientId must be a string" }, { status: 400 });
+  }
+  try {
+    const account = await Effect.runPromise(saveGoogleClient(input));
+    return Response.json({ account });
+  } catch (error) {
+    return failure(error);
+  } finally {
+    await closeGoogleConnections();
+  }
+}
+
+export async function handleGoogleAccountDisconnect(request: Request): Promise<Response> {
+  let input: typeof GoogleDisconnectInputSchema.Type;
+  try {
+    input = Schema.decodeUnknownSync(GoogleDisconnectInputSchema)(await request.json());
+  } catch {
+    return Response.json({ error: "account and accountKey are required" }, { status: 400 });
+  }
+  if (!GOOGLE_ACCOUNT_KEY_PATTERN.test(input.accountKey)) {
+    return Response.json({ error: "accountKey is not a known account" }, { status: 400 });
+  }
+  const identity = { service: input.account, accountKey: input.accountKey };
+  try {
+    const account = await Effect.runPromise(
+      Effect.gen(function* () {
+        const disconnected = yield* disconnectGoogleAccount(identity);
+        yield* disableGoogleWorkspaceAdapter(identity).pipe(
+          Effect.mapError((error) => new GoogleAccountError(500, error.message)),
+        );
+        return disconnected;
+      }),
+    );
+    return Response.json({ account });
+  } catch (error) {
+    return failure(error);
+  } finally {
+    await closeGoogleConnections();
+  }
+}
+
+export async function handleGoogleAuthorizeBegin(request: Request): Promise<Response> {
+  let input: typeof GoogleAccountInputSchema.Type;
+  try {
+    input = Schema.decodeUnknownSync(GoogleAccountInputSchema)(await request.json());
+  } catch {
+    return Response.json({ error: "account is required" }, { status: 400 });
+  }
+  try {
+    return Response.json(
+      await Effect.runPromise(beginGoogleLoopbackAuthorization(input.account)),
+    );
+  } catch (error) {
+    return failure(error, "Google sign-in failed");
+  }
+}
+
+export async function handleGoogleAuthorizeCancel(request: Request): Promise<Response> {
+  let input: typeof GoogleAccountInputSchema.Type;
+  try {
+    input = Schema.decodeUnknownSync(GoogleAccountInputSchema)(await request.json());
+  } catch {
+    return Response.json({ error: "account is required" }, { status: 400 });
+  }
+  try {
+    await Effect.runPromise(cancelGoogleLoopbackAuthorization(input.account));
+    return Response.json({ cancelled: true });
+  } catch (error) {
+    return failure(error, "Google sign-in cancellation failed");
+  }
+}

--- a/services/agent-runtime/src/http/plugin-handlers.ts
+++ b/services/agent-runtime/src/http/plugin-handlers.ts
@@ -1,0 +1,84 @@
+//
+// HTTP surface for user plugins: the listing, source reads, writes, enable
+// flips, and removal. Moved verbatim from the Next route handlers so plugins
+// authored in the UI land in the runtime's extensions directory — the one the
+// agent actually loads from.
+//
+
+import { Schema } from "effect";
+import { PluginUpsertInputSchema } from "../plugin-contract";
+import {
+  listUserPlugins,
+  readUserPlugin,
+  removeUserPlugin,
+  resolveUserPluginsDir,
+  setUserPluginEnabled,
+  writeUserPlugin,
+} from "../user-plugins";
+
+const failure = (error: unknown, fallback: string, status: number) =>
+  Response.json({ error: error instanceof Error ? error.message : fallback }, { status });
+
+async function listing(): Promise<Response> {
+  return Response.json({
+    directory: resolveUserPluginsDir(),
+    plugins: await listUserPlugins(),
+  });
+}
+
+export async function handlePluginsList(): Promise<Response> {
+  return listing();
+}
+
+/**
+ * Write a plugin's source, flip it on or off, or both.
+ *
+ * Writing is not running: the file lands in the extensions directory and is
+ * picked up the next time a session is built, which is also the next time the
+ * user sends a message. Nothing is spawned here.
+ */
+export async function handlePluginUpsert(request: Request): Promise<Response> {
+  let body: typeof PluginUpsertInputSchema.Type;
+  try {
+    body = Schema.decodeUnknownSync(PluginUpsertInputSchema)(await request.json());
+  } catch {
+    return Response.json({ error: "invalid plugin payload" }, { status: 400 });
+  }
+  try {
+    if (body.source !== undefined) await writeUserPlugin(body.id, body.source);
+    if (body.enabled !== undefined) await setUserPluginEnabled(body.id, body.enabled);
+    return listing();
+  } catch (error) {
+    return failure(error, "Plugin could not be saved", 409);
+  }
+}
+
+export async function handlePluginDelete(request: Request): Promise<Response> {
+  const id = new URL(request.url).searchParams.get("id") ?? "";
+  if (!id) return Response.json({ error: "id is required" }, { status: 400 });
+  try {
+    await removeUserPlugin(id);
+    return listing();
+  } catch (error) {
+    return failure(error, "Plugin could not be removed", 409);
+  }
+}
+
+/**
+ * One plugin's source. Split from the listing route because a list of plugins
+ * is read on every visit to the tab while the code behind them is read only
+ * when one is opened, and shipping every file's text to draw a table of names
+ * would make the tab slower the more plugins a user writes.
+ */
+export async function handlePluginSource(request: Request): Promise<Response> {
+  const id = new URL(request.url).searchParams.get("id") ?? "";
+  if (!id) return Response.json({ error: "id is required" }, { status: 400 });
+  try {
+    return Response.json(await readUserPlugin(id));
+  } catch (error) {
+    return Response.json(
+      { error: error instanceof Error ? error.message : "Plugin could not be read" },
+      { status: 404 },
+    );
+  }
+}

--- a/services/agent-runtime/src/http/project-handlers.ts
+++ b/services/agent-runtime/src/http/project-handlers.ts
@@ -1,0 +1,54 @@
+//
+// HTTP surface for the projects list (the directories pinned in the sidebar).
+// Moved verbatim from the Next route handlers so a remote runtime's project
+// list is the one the UI shows.
+//
+
+import {
+  addProjectToStore,
+  listProjectsFromStore,
+  removeProjectFromStore,
+  type ProjectEntry,
+} from "../projects-store";
+import { errorMessage, jsonError } from "./helpers";
+
+export async function handleProjectsList(): Promise<Response> {
+  try {
+    const projects = listProjectsFromStore();
+    return Response.json({ projects });
+  } catch (error) {
+    return jsonError(errorMessage(error, "Failed to read projects"), 500);
+  }
+}
+
+export async function handleProjectAdd(request: Request): Promise<Response> {
+  let body: { path?: unknown };
+  try {
+    body = (await request.json()) as { path?: unknown };
+  } catch {
+    return jsonError("Invalid JSON body");
+  }
+  const directoryPath = typeof body.path === "string" ? body.path.trim() : "";
+  if (!directoryPath) {
+    return jsonError("path is required");
+  }
+  try {
+    const project: ProjectEntry = addProjectToStore(directoryPath);
+    return Response.json({ project });
+  } catch (error) {
+    return jsonError(errorMessage(error, "Failed to add project"));
+  }
+}
+
+export async function handleProjectRemove(request: Request): Promise<Response> {
+  const id = new URL(request.url).searchParams.get("id");
+  if (!id) {
+    return jsonError("id is required");
+  }
+  try {
+    removeProjectFromStore(id);
+    return Response.json({ ok: true });
+  } catch (error) {
+    return jsonError(errorMessage(error, "Failed to remove project"), 500);
+  }
+}

--- a/services/agent-runtime/src/pi-runtime-models.ts
+++ b/services/agent-runtime/src/pi-runtime-models.ts
@@ -288,8 +288,32 @@ async function savePersistedControllers(
 }
 
 /** How long a single controller gets to answer /v1/models before it is
- *  treated as down. */
-const CONTROLLER_MODELS_TIMEOUT_MS = 4_000;
+ *  treated as down. A healthy tailnet peer answers in well under 150ms
+ *  (measured 21-82ms), so 2.5s is already generous headroom for a slow LAN or
+ *  a controller busy loading a model. */
+const CONTROLLER_MODELS_TIMEOUT_MS = 2_500;
+
+/** How long a controller that timed out or refused a connection is skipped
+ *  before it is probed again. Within this window it is served as an empty
+ *  model list immediately, so one dead saved controller cannot make every
+ *  /api/agent/models call pay the full connect timeout (measured: a 4s flat
+ *  median on the desktop app while a saved peer was off). */
+const CONTROLLER_UNREACHABLE_BACKOFF_MS = 60_000;
+
+/** In-memory negative cache of unreachable controllers, keyed by normalized
+ *  controller URL identity. A successful fetch (or any HTTP response at all —
+ *  even an error status proves the host is reachable) clears the entry. */
+const unreachableControllers = new Map<string, { failedAt: number }>();
+
+function isControllerBackedOff(identity: string): boolean {
+  const entry = unreachableControllers.get(identity);
+  if (!entry) return false;
+  if (Date.now() - entry.failedAt >= CONTROLLER_UNREACHABLE_BACKOFF_MS) {
+    unreachableControllers.delete(identity);
+    return false;
+  }
+  return true;
+}
 
 async function fetchModelsFromController(
   controller: PiControllerConfig,
@@ -297,20 +321,38 @@ async function fetchModelsFromController(
   multipleControllers: boolean,
 ): Promise<ControllerModels> {
   const backendUrl = normalizeBackendUrl(controller.url);
+  const identity = controllerUrlIdentity(backendUrl);
+  if (isControllerBackedOff(identity)) {
+    // Recently unreachable: answer instantly with no models rather than
+    // paying the connect timeout again. The entry expires after the backoff
+    // window, so a controller that comes back is picked up within a minute.
+    return {
+      controller: { ...controller, url: backendUrl },
+      models: [],
+      providerId: providerIdForController(controller, index),
+    };
+  }
   const headers: HeadersInit = { Accept: "application/json" };
   if (controller.apiKey) headers.Authorization = `Bearer ${controller.apiKey}`;
-  const response = await fetch(`${backendUrl}/v1/models`, {
-    headers,
-    cache: "no-store",
-    // Every saved controller is listed before the composer can show a single
-    // model, and Promise.allSettled below waits for all of them. Without a
-    // deadline one unreachable host holds the whole model picker hostage for
-    // however long its network stack takes to give up — measured at 10.5s for
-    // a tailnet peer that is simply off. Healthy peers answer in 0.02-1.2s, so
-    // a few seconds is generous; a controller slower than this is reported as
-    // failed and the rest of the list still loads.
-    signal: AbortSignal.timeout(CONTROLLER_MODELS_TIMEOUT_MS),
-  });
+  let response: Response;
+  try {
+    response = await fetch(`${backendUrl}/v1/models`, {
+      headers,
+      cache: "no-store",
+      // Every saved controller is listed before the composer can show a single
+      // model, and Promise.allSettled below waits for all of them. Without a
+      // deadline one unreachable host holds the whole model picker hostage for
+      // however long its network stack takes to give up — measured at 10.5s for
+      // a tailnet peer that is simply off. A controller slower than the
+      // deadline is reported as failed and the rest of the list still loads.
+      signal: AbortSignal.timeout(CONTROLLER_MODELS_TIMEOUT_MS),
+    });
+  } catch (error) {
+    // Timed out or refused: remember it so the next calls skip this host.
+    unreachableControllers.set(identity, { failedAt: Date.now() });
+    throw error;
+  }
+  unreachableControllers.delete(identity);
   if (!response.ok) {
     throw new Error(`${backendUrl}/v1/models failed with HTTP ${response.status}`);
   }
@@ -333,7 +375,9 @@ async function fetchModelsFromController(
   return { controller: { ...controller, url: backendUrl }, models, providerId };
 }
 
-async function fetchModelsFromControllers(controllers: PiControllerConfig[]): Promise<{
+/** Exported for direct testing of the fan-out + unreachable-controller
+ *  backoff without going through settings/persistence. */
+export async function fetchModelsFromControllers(controllers: PiControllerConfig[]): Promise<{
   models: AgentModel[];
   controllerModels: ControllerModels[];
 }> {

--- a/services/agent-runtime/src/prompt-templates-store.ts
+++ b/services/agent-runtime/src/prompt-templates-store.ts
@@ -1,8 +1,8 @@
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
-import { resolveDataDir } from "@local-studio/agent-runtime/data-dir";
-import { matchSource, readCapped, sortedRows } from "@local-studio/agent-runtime/discovery-core";
+import { resolveDataDir } from "./data-dir";
+import { matchSource, readCapped, sortedRows } from "./discovery-core";
 
 export type PromptTemplateRow = {
   id: string;

--- a/services/agent-runtime/src/session-list-changed.ts
+++ b/services/agent-runtime/src/session-list-changed.ts
@@ -53,6 +53,11 @@ export function sessionListChangedStream(signal?: AbortSignal): ReadableStream<U
   return new ReadableStream<Uint8Array>({
     start(controller) {
       streamController = controller;
+      // First byte immediately: the Next standalone proxy withholds even the
+      // HTTP headers until the first body chunk, so without this an idle
+      // stream left EventSource stuck in "connecting" for up to a heartbeat
+      // interval (measured 45s on both surfaces).
+      controller.enqueue(encoder.encode(`: connected v${version}\n\n`));
       unsubscribe = subscribeSessionListChanged((event) => {
         if (closed) return;
         try {

--- a/services/agent-runtime/src/session-metadata-store.ts
+++ b/services/agent-runtime/src/session-metadata-store.ts
@@ -7,6 +7,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
+import { notifySessionListChanged } from "./session-list-changed";
 import lockfile from "proper-lockfile";
 import { resolveDataDir } from "./data-dir";
 import { isRecord } from "../../../shared/agent/guards";
@@ -120,6 +121,10 @@ function writeStore(store: SessionMetadataStore): void {
     chmodSync(tempPath, 0o600);
   } catch {}
   renameSync(tempPath, filepath);
+  // Archive/rename/pin live in this overlay, not in the session .jsonl the
+  // list watcher sees — without this, archiving a session never told any
+  // surface the list changed (verified empirically against the deployed app).
+  notifySessionListChanged();
 }
 
 async function withStoreLock<T>(callback: () => T): Promise<T> {

--- a/services/agent-runtime/src/sessions-store.ts
+++ b/services/agent-runtime/src/sessions-store.ts
@@ -254,7 +254,11 @@ async function readSessionSummary(
   if (header && firstUserMessage) {
     const lastTurn = await readLastUserTurn(filepath);
     if (lastTurn) {
-      lastUserPromptText = lastTurn.text;
+      // The raw turn text can open with injected context (<browser_context>…)
+      // that is not what the user typed; the title helper already knows how
+      // to peel it. An all-context turn yields no preview rather than noise.
+      const visible = sessionTitleFromUserPrompt(lastTurn.text);
+      if (visible) lastUserPromptText = visible;
       lastUserPromptAt = lastTurn.at;
     }
   }


### PR DESCRIPTION
First fix waves from the 12-hour optimization mission, every item measured or visually verified before and after.

**Browser↔desktop sync**: preference sync repointed at the controller's (working, previously orphaned) ui_preferences store with three-way merge; 14 in-process API routes moved onto the agent runtime so a shared runtime shares connectors/projects/plugins/skills/accounts; the session-list SSE delivers its first byte immediately (was 45s of header-withholding through the standalone proxy, both surfaces); archive/rename/pin now notify the list signal (was provably silent).

**Measured slowness**: /api/agent/models no longer pays a flat 4s for a dead saved controller (2500ms deadline + 60s negative cache; measured 2518ms → 0.1ms on backoff); controller /v1/models marks exactly one recipe active instead of three glm-5.2 rows all claiming the process.

**Packaged app repair**: the bundled pi extensions actually load — typebox replaced with a dependency-free schema shim (byte-identical output), and pi's loader dependencies staged into Resources (root cause: jiti resolves typebox + three pi packages before importing any extension). Needs this release's desktop rebuild to reach the app.

**Owner-reported UI**: open session highlights in the notifications view; composer drawer rows share one metric (no more text jump on toggle) and collapsed shows branch + diffstat; session previews stop rendering injected <browser_context>.

All gates green; agent-runtime 64/64; fixes verified live against the deployed app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)