### PR TITLE
fix(agent-runtime): report cancelled subagents without the abort error

### DIFF
--- a/services/agent-runtime/src/subagents.ts
+++ b/services/agent-runtime/src/subagents.ts
@@ -126,7 +126,9 @@ function clampReport(text: string): string {
 export function subagentReport(run: SubagentRun): LastAssistantResult {
   if (!run.piSessionId) return { text: "", error: null };
   const result = lastAssistantResult(run.cwd, run.piSessionId);
-  return { text: clampReport(result.text), error: result.error };
+  // Aborting the child writes "Request was aborted" into its transcript as an
+  // assistant error; adopting it would paint a deliberate stop as a failure.
+  return { text: clampReport(result.text), error: run.status === "cancelled" ? null : result.error };
 }
 
 /** True while this runtime still has the child streaming. */

--- a/services/agent-runtime/test/subagents.test.ts
+++ b/services/agent-runtime/test/subagents.test.ts
@@ -1,0 +1,71 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { encodeCwdForPi } from "../src/sessions-store";
+import { subagentReport, type SubagentRun } from "../src/subagents";
+
+const temporaryRoots: string[] = [];
+
+afterAll(() => {
+  for (const root of temporaryRoots) rmSync(root, { recursive: true, force: true });
+});
+
+/** A child transcript whose last assistant entry is the abort marker pi
+ *  writes when a run is stopped mid-flight. */
+function writeAbortedTranscript(piSessionId: string): string {
+  const root = mkdtempSync(path.join(tmpdir(), "subagents-"));
+  temporaryRoots.push(root);
+  const agentDir = path.join(root, "pi-agent");
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  const cwd = path.join(root, "project");
+  mkdirSync(cwd, { recursive: true });
+  const sessionDir = path.join(agentDir, "sessions", encodeCwdForPi(cwd));
+  mkdirSync(sessionDir, { recursive: true });
+  const lines = [
+    JSON.stringify({ type: "session", id: piSessionId, cwd }),
+    JSON.stringify({
+      type: "message",
+      message: { role: "assistant", content: [{ type: "text", text: "partial work" }] },
+    }),
+    JSON.stringify({
+      type: "message",
+      message: { role: "assistant", content: [], errorMessage: "Request was aborted" },
+    }),
+  ];
+  writeFileSync(path.join(sessionDir, `rollout_${piSessionId}.jsonl`), `${lines.join("\n")}\n`);
+  return cwd;
+}
+
+function runWith(status: SubagentRun["status"], piSessionId: string, cwd: string): SubagentRun {
+  return {
+    id: "run-1",
+    parentPiSessionId: "parent-1",
+    name: "smoke",
+    task: "test task",
+    piSessionId,
+    runtimeSessionId: "subagent:parent-1:run-1",
+    cwd,
+    status,
+    startedAt: new Date().toISOString(),
+    finishedAt: null,
+  };
+}
+
+describe("subagentReport", () => {
+  test("a cancelled run does not adopt the transcript's abort marker as an error", () => {
+    const piSessionId = "01a02222-0000-7000-8000-000000000001";
+    const cwd = writeAbortedTranscript(piSessionId);
+    const report = subagentReport(runWith("cancelled", piSessionId, cwd));
+    expect(report.error).toBeNull();
+    expect(report.text).toBe("partial work");
+  });
+
+  test("a failed run still surfaces the transcript error", () => {
+    const piSessionId = "01a02222-0000-7000-8000-000000000002";
+    const cwd = writeAbortedTranscript(piSessionId);
+    const report = subagentReport(runWith("error", piSessionId, cwd));
+    expect(report.error).toBe("Request was aborted");
+    expect(report.text).toBe("partial work");
+  });
+});


### PR DESCRIPTION
A user-initiated stop leaves the child transcript with pi's abort marker ("Request was aborted") as its last assistant error, and subagentReport adopted it — so a deliberately cancelled run reported status "cancelled" WITH an error, and the chips UI can paint an intentional stop as a failure (verified live on v2.15.1: the stop response carried both).

Fix: subagentReport returns error null for cancelled runs; real failures (status "error") still surface the transcript error. New test fabricates an aborted child transcript and asserts both policies. Gate: build clean, 77/77 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)