### PR TITLE
fix(providers): expose configured remote models and report the full VRAM pool

### DIFF
--- a/controller/src/modules/models/routes.ts
+++ b/controller/src/modules/models/routes.ts
@@ -43,6 +43,7 @@ import { isRecipeRunning } from "./recipes/recipe-matching";
 import { notFound } from "../../core/errors";
 import { findObservedInferenceProcess } from "../../core/function-observability";
 import { fetchInference } from "../../http/local-fetch";
+import { fetchConfiguredProviderModels } from "../../services/provider-models";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -109,6 +110,24 @@ export const registerModelsRoutes = defineRoutes((app, context) => {
               max_model_len: maxModelLength,
               metadata: resolvedRecipeMetadata(recipe, modelId),
             });
+          }
+
+          const providerCatalogs = yield* fetchConfiguredProviderModels(context.config.providers);
+          const seenModelIds = new Set(models.map((model) => model.id));
+          for (const catalog of providerCatalogs) {
+            for (const providerModel of catalog.models) {
+              const modelId = `${catalog.provider}/${providerModel.id}`;
+              if (seenModelIds.has(modelId)) continue;
+              seenModelIds.add(modelId);
+              models.push({
+                id: modelId,
+                object: "model",
+                created: now,
+                owned_by: catalog.name,
+                active: true,
+                metadata: { remote: true, provider_id: catalog.provider },
+              });
+            }
           }
 
           if (models.length === 0 && current) {

--- a/controller/src/modules/proxy/openai-routes.ts
+++ b/controller/src/modules/proxy/openai-routes.ts
@@ -7,6 +7,7 @@ import { documentRoute, defineRoutes, mergeRoutes } from "../../http/route-regis
 import type { Recipe } from "../models/types";
 import { buildInferenceUrl } from "../../http/local-fetch";
 import {
+  buildProviderApiUrl,
   DEFAULT_CHAT_PROVIDER,
   parseProviderModel,
   resolveProviderConfig,
@@ -186,7 +187,7 @@ export const registerOpenAIRoutes = defineRoutes((app, context) => {
     }
     const upstreamUrl =
       providerRouting && requestedModel
-        ? `${providerRouting.baseUrl.replace(/\/+$/, "")}/v1/chat/completions`
+        ? buildProviderApiUrl(providerRouting.baseUrl, "/chat/completions")
         : buildInferenceUrl(context, "/v1/chat/completions");
     const inferenceKey = process.env["INFERENCE_API_KEY"] ?? "";
     const headers: Record<string, string> = {

--- a/controller/src/modules/studio/configs.ts
+++ b/controller/src/modules/studio/configs.ts
@@ -54,7 +54,7 @@ export const STUDIO_STARTER_PRESETS: StudioStarterPreset[] = [
     size_gb: null,
     min_vram_gb: null,
     remote: {
-      base_url: "http://pop-os-1.tailadb2c1.ts.net:8080/v1",
+      base_url: "https://api.deepseek.com",
       model: "deepseek-v4-flash",
     },
   },

--- a/controller/src/modules/studio/provider-routes.ts
+++ b/controller/src/modules/studio/provider-routes.ts
@@ -4,6 +4,7 @@ import { decodeJsonBody } from "../../core/validation";
 import { effectHandler } from "../../http/effect-handler";
 import { documentRoute, defineRoutes, mergeRoutes } from "../../http/route-registrar";
 import { savePersistedConfig, type ProviderConfig } from "../../config/persisted-config";
+import { fetchConfiguredProviderModels } from "../../services/provider-models";
 
 type ProviderView = {
   id: string;
@@ -26,10 +27,6 @@ const ProviderUpdateSchema = Schema.Struct({
   base_url: Schema.optional(Schema.String),
   api_key: Schema.optional(Schema.String),
   enabled: Schema.optional(Schema.Boolean),
-});
-
-const ProviderModelsSchema = Schema.Struct({
-  data: Schema.optional(Schema.Array(Schema.Struct({ id: Schema.optional(Schema.String) }))),
 });
 
 class ProviderPersistenceError extends Schema.TaggedErrorClass<ProviderPersistenceError>()(
@@ -65,32 +62,6 @@ const required = (
   const trimmed = value.trim();
   return trimmed ? Effect.succeed(trimmed) : Effect.fail(badRequest(`${label} is required`));
 };
-
-const providerModels = (
-  provider: ProviderConfig,
-): Effect.Effect<{ provider: string; models: Array<{ id: string }> }, unknown> =>
-  Effect.gen(function* () {
-    const url = `${provider.base_url.replace(/\/+$/, "")}/v1/models`;
-    const response = yield* Effect.tryPromise({
-      try: () =>
-        fetch(url, {
-          headers: { Authorization: `Bearer ${provider.api_key}` },
-          signal: AbortSignal.timeout(10_000),
-        }),
-      catch: (source) => source,
-    });
-    if (!response.ok) return yield* Effect.fail(response.status);
-    const payload = yield* Effect.tryPromise({
-      try: () => response.json(),
-      catch: (source) => source,
-    });
-    const decoded = yield* Schema.decodeUnknownEffect(ProviderModelsSchema)(payload);
-    const models = (decoded.data ?? []).flatMap((model) => {
-      const id = model.id?.trim();
-      return id ? [{ id }] : [];
-    });
-    return { provider: provider.id, models };
-  });
 
 export const registerStudioProviderRoutes = defineRoutes((app, context) => {
   return mergeRoutes(
@@ -181,16 +152,10 @@ export const registerStudioProviderRoutes = defineRoutes((app, context) => {
       "/studio/provider-models",
       documentRoute,
       effectHandler((ctx) =>
-        Effect.forEach(
-          context.config.providers.filter((provider) => provider.enabled && provider.api_key),
-          (provider) => providerModels(provider).pipe(Effect.option),
-          { concurrency: "unbounded" },
-        ).pipe(
-          Effect.map((results) =>
+        fetchConfiguredProviderModels(context.config.providers).pipe(
+          Effect.map((providers) =>
             ctx.json({
-              providers: results.flatMap((result) =>
-                result._tag === "Some" ? [result.value] : [],
-              ),
+              providers: providers.map(({ provider, models }) => ({ provider, models })),
             }),
           ),
         ),

--- a/controller/src/services/provider-models.ts
+++ b/controller/src/services/provider-models.ts
@@ -1,0 +1,51 @@
+import { Effect, Schema } from "effect";
+import type { ProviderConfig } from "../config/persisted-config";
+import { buildProviderApiUrl } from "./provider-routing";
+
+const ProviderModelsSchema = Schema.Struct({
+  data: Schema.optional(Schema.Array(Schema.Struct({ id: Schema.optional(Schema.String) }))),
+});
+
+export interface ProviderModelCatalog {
+  provider: string;
+  name: string;
+  models: Array<{ id: string }>;
+}
+
+const fetchProviderModels = (
+  provider: ProviderConfig,
+): Effect.Effect<ProviderModelCatalog, unknown> =>
+  Effect.gen(function* () {
+    const response = yield* Effect.tryPromise({
+      try: () =>
+        fetch(buildProviderApiUrl(provider.base_url, "/models"), {
+          headers: { Authorization: `Bearer ${provider.api_key}` },
+          signal: AbortSignal.timeout(10_000),
+        }),
+      catch: (source) => source,
+    });
+    if (!response.ok) return yield* Effect.fail(response.status);
+    const payload = yield* Effect.tryPromise({
+      try: () => response.json(),
+      catch: (source) => source,
+    });
+    const decoded = yield* Schema.decodeUnknownEffect(ProviderModelsSchema)(payload);
+    const models = (decoded.data ?? []).flatMap((model) => {
+      const id = model.id?.trim();
+      return id ? [{ id }] : [];
+    });
+    return { provider: provider.id, name: provider.name, models };
+  });
+
+export const fetchConfiguredProviderModels = (
+  providers: ProviderConfig[],
+): Effect.Effect<ProviderModelCatalog[]> =>
+  Effect.forEach(
+    providers.filter((provider) => provider.enabled && provider.api_key),
+    (provider) => fetchProviderModels(provider).pipe(Effect.option),
+    { concurrency: "unbounded" },
+  ).pipe(
+    Effect.map((results) =>
+      results.flatMap((result) => (result._tag === "Some" ? [result.value] : [])),
+    ),
+  );

--- a/controller/src/services/provider-routing.ts
+++ b/controller/src/services/provider-routing.ts
@@ -16,6 +16,14 @@ export interface ControllerProviderRoutingConfig {
   providers?: ProviderConfig[];
 }
 
+export const buildProviderApiUrl = (baseUrl: string, pathname: string): string => {
+  const normalizedBase = baseUrl.trim().replace(/\/+$/, "");
+  const normalizedPath = pathname.startsWith("/") ? pathname : `/${pathname}`;
+  return /\/v1$/i.test(normalizedBase)
+    ? `${normalizedBase}${normalizedPath}`
+    : `${normalizedBase}/v1${normalizedPath}`;
+};
+
 export const parseProviderModel = (rawModel: string): ParsedProviderModel => {
   const trimmed = rawModel.trim();
   if (!trimmed) {

--- a/frontend/src/features/agent/ui/model-visibility.ts
+++ b/frontend/src/features/agent/ui/model-visibility.ts
@@ -18,6 +18,9 @@ export function splitVisibleAgentModels(
   return {
     controllerModels,
     otherModels,
-    visibleModels: showOtherModels ? [...controllerModels, ...otherModels] : controllerModels,
+    visibleModels:
+      showOtherModels || controllerModels.length === 0
+        ? [...controllerModels, ...otherModels]
+        : controllerModels,
   };
 }

--- a/frontend/src/features/setup/setup-actions.ts
+++ b/frontend/src/features/setup/setup-actions.ts
@@ -152,7 +152,13 @@ export function connectRemotePresetEffect(
     );
     const alreadyThere = existing.providers.some((provider) => provider.id === preset.id);
     if (alreadyThere) {
-      yield* requestEffect(() => api.updateProvider(preset.id, { api_key: apiKey, enabled: true }));
+      yield* requestEffect(() =>
+        api.updateProvider(preset.id, {
+          base_url: remote.base_url,
+          api_key: apiKey,
+          enabled: true,
+        }),
+      );
     } else {
       yield* requestEffect(() =>
         api.createProvider({

--- a/frontend/src/features/setup/setup-view/step-hardware-model.ts
+++ b/frontend/src/features/setup/setup-view/step-hardware-model.ts
@@ -34,15 +34,17 @@ export function buildHardwareSummary(diagnostics: StudioDiagnostics | null): Har
   const gpuNames =
     diagnostics?.gpus.map((gpu) => gpu.name).join(", ") ||
     (appleSilicon ? "Apple Silicon GPU · Metal" : "No accelerator detected");
-  const firstGpuVramMb = diagnostics?.gpus[0]?.memory_total_mb ?? 0;
+  const totalGpuVramMb = appleSilicon
+    ? (diagnostics?.gpus[0]?.memory_total_mb ?? 0)
+    : (diagnostics?.gpus.reduce((sum, gpu) => sum + gpu.memory_total_mb, 0) ?? 0);
 
   return {
     cpu: `${diagnostics?.cpu_model ?? "Unknown"} · ${diagnostics?.cpu_cores ?? 0} cores`,
     gpu: gpuNames,
     memory: `${formatBytes(diagnostics?.memory_total ?? null)} total`,
     runtime: runtimeDescription(diagnostics, appleSilicon),
-    vram: firstGpuVramMb
-      ? `${Math.round(firstGpuVramMb / 1024)} GB${appleSilicon ? " unified" : ""}`
+    vram: totalGpuVramMb
+      ? `${Math.round(totalGpuVramMb / 1024)} GB${appleSilicon ? " unified" : ""}`
       : "Not reported",
   };
 }


### PR DESCRIPTION
Two commits that were sitting on the Windows port branch (#395) but were never Windows
work. Pulling them out rather than smuggling them through a platform PR. Nothing here is
platform-specific.

## `fix(providers): expose configured remote models`

`GET /v1/models` listed only local recipes, so a user whose providers are all remote saw
an empty catalogue and an empty model picker. This merges the configured providers' own
`/v1/models` into the listing as `provider/modelId`, marked remote, and lets the picker
fall back to those when the controller has none of its own.

The provider fetch moves out of the studio provider route into a shared service so the
two callers stop diverging, and both now route through one helper that appends the
OpenAI-compatible `/v1` prefix. That helper being the only place a provider `base_url`
gets a suffix is what makes the next part safe.

**Worth a look independently of the rest:** the shipped `deepseek-v4-flash` starter
preset in `controller/src/modules/studio/configs.ts` points at
`http://pop-os-1.tailadb2c1.ts.net:8080/v1` — a personal Tailscale hostname, over plain
HTTP, that nobody outside that tailnet can reach. That is live on `dev` right now. This
repoints it at `https://api.deepseek.com`. Installs that already stored the old value get
repointed when the preset is reconnected.

## `fix(setup): report the full multi-GPU VRAM pool`

The hardware summary read `memory_total_mb` off the first GPU only, so a two-card machine
advertised half its pool during setup and the model recommendation was sized against the
wrong number. This sums every reported GPU. Apple Silicon keeps reading the single
unified entry.

The controller already returned every GPU, so this is display arithmetic, not telemetry —
a dual-GPU Linux or Windows host is affected identically. It landed on the port branch
under a `fix(windows)` scope that was simply wrong.

## Notes

- Branched from `dev`, 9 files, no new dependencies.
- The test files that accompanied both commits on the port branch are **omitted** here,
  since `dev` has no test rail. They remain on the port branch if you ever want them.
- Verified against a pristine `origin/dev` baseline: `tsc --noEmit` output for the
  frontend is byte-identical to the baseline, and the controller typechecks at exit 0.
  The 12 pre-existing errors under `shared/` are unchanged and untouched by these files.
- Removing these two commits also shrinks the rebase surface of #395.
