### PR TITLE
chore: add reproducible devenv workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,9 @@ frontend/dist-desktop-dev/
 frontend/dist-installers/
 .vercel
 .env*
+
+# Devenv
+.devenv*
+devenv.local.nix
+devenv.local.yaml
+.direnv

--- a/README.md
+++ b/README.md
@@ -126,6 +126,35 @@ directory, installing an engine, downloading a model, launching it, and
 benchmarking. Engine installs (vLLM/SGLang/MLX) land below the data directory at
 `runtime/venvs/<backend>-latest`.
 
+### Devenv
+
+The repository includes a locked [devenv](https://devenv.sh/) environment with
+Node.js, npm, Bun, Python, uv, Git, and curl. Enter the development shell with:
+
+```bash
+devenv shell
+```
+
+Workspace dependencies are installed from their native lockfiles on first use
+and again whenever a package manifest or lockfile changes. On macOS, start the
+controller head node and Electron desktop app together with:
+
+```bash
+devenv up
+```
+
+The head node is available independently on every supported platform, and the
+desktop process includes its head-node dependency:
+
+```bash
+devenv up head-node
+devenv up desktop
+```
+
+Each process checks its fixed port before launch so an existing process fails
+visibly instead of silently moving either half of the stack to an incompatible
+port.
+
 ## Agent runtime
 
 The agent surface lives at `/agent` in the frontend. It uses

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,65 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1787350801,
+        "narHash": "sha256-gEOKc1EhkbrUj7JTjxwlNyh42vu89lpiyP33ubx/NCw=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "5844e78c960ab73bb92e131bc2902b39b9ee52dd",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
+      "locked": {
+        "lastModified": 1787002832,
+        "narHash": "sha256-DGkHh88/7YLVGZ7HzSVN4YmUmR+wGKudIp6H9UsUNT0=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "ee3d58d53cfcddfc0ae6fc7f04f4fe2a0c7cf0ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1786858016,
+        "narHash": "sha256-Vczr2zxD0orq6N2QQe5uqOGF7TRDcQJRRuAcsdHr4kg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "54ba4bcec4043e72a4006d825e0d7aff5562008f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,111 @@
+{ lib, pkgs, ... }:
+
+let
+  bunVersion = "1.3.14";
+  bunSources = {
+    aarch64-darwin = pkgs.fetchurl {
+      url = "https://github.com/oven-sh/bun/releases/download/bun-v${bunVersion}/bun-darwin-aarch64.zip";
+      hash = "sha256-2LliIYKK1vl6x6wKt+lYcjQa92MAHogD6CZ2UsJlJiA=";
+    };
+    aarch64-linux = pkgs.fetchurl {
+      url = "https://github.com/oven-sh/bun/releases/download/bun-v${bunVersion}/bun-linux-aarch64.zip";
+      hash = "sha256-on/7Y6gxA3WDbg1vZorhf6jY0YuIw3yCHGUzGXOhmjs=";
+    };
+    x86_64-linux = pkgs.fetchurl {
+      url = "https://github.com/oven-sh/bun/releases/download/bun-v${bunVersion}/bun-linux-x64.zip";
+      hash = "sha256-lR7iruhV8IWVruxiJSJqKY0/6oOj3NZGXAnLzN9+hI8=";
+    };
+  };
+  system = pkgs.stdenv.hostPlatform.system;
+  bun = pkgs.bun.overrideAttrs (previous: {
+    version = bunVersion;
+    src = bunSources.${system} or (throw "Bun ${bunVersion} is unavailable for ${system}");
+    passthru = previous.passthru // {
+      sources = bunSources;
+    };
+  });
+in
+{
+  packages = [
+    pkgs.curl
+    pkgs.git
+  ];
+
+  languages.javascript = {
+    enable = true;
+    package = pkgs.nodejs_22;
+    lsp.enable = false;
+    npm.enable = true;
+    bun = {
+      enable = true;
+      package = bun;
+    };
+  };
+
+  languages.python = {
+    enable = true;
+    package = pkgs.python311;
+    lsp.enable = false;
+    uv.enable = true;
+  };
+
+  tasks."local-studio:setup" = {
+    exec = "npm run setup";
+    execIfModified = [
+      "package.json"
+      "controller/package.json"
+      "controller/bun.lock"
+      "controller/contracts/package.json"
+      "frontend/package.json"
+      "frontend/package-lock.json"
+      "services/agent-runtime/package.json"
+      "services/agent-runtime/bun.lock"
+      "shared/package.json"
+      "shared/bun.lock"
+    ];
+    before = [
+      "devenv:enterShell"
+      "devenv:processes:head-node"
+    ]
+    ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+      "devenv:processes:desktop"
+    ];
+  };
+
+  processes.head-node = {
+    cwd = "./controller";
+    exec = ''
+      if ! ${lib.getExe pkgs.python311} -c 'import socket; connection = socket.socket(); connection.bind(("127.0.0.1", 8080)); connection.close()' 2>/dev/null; then
+        echo "Port 8080 is already in use" >&2
+        exit 1
+      fi
+      exec bun run dev
+    '';
+    env.LOCAL_STUDIO_PORT = "8080";
+    restart.on = "never";
+    ready = {
+      exec = "${lib.getExe pkgs.curl} --fail --silent --output /dev/null http://127.0.0.1:8080/health";
+      period = 1;
+      timeout = 120;
+    };
+  };
+
+  processes.desktop = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
+    exec = ''
+      if ! ${lib.getExe pkgs.python311} -c 'import socket; connection = socket.socket(); connection.bind(("127.0.0.1", 3000)); connection.close()' 2>/dev/null; then
+        echo "Port 3000 is already in use" >&2
+        exit 1
+      fi
+      exec npm --prefix frontend run desktop:dev
+    '';
+    after = [ "devenv:processes:head-node@ready" ];
+    env.PORT = "3000";
+    restart.on = "never";
+    ready = {
+      exec = "${lib.getExe pkgs.curl} --fail --silent --output /dev/null http://127.0.0.1:3000/";
+      initial_delay = 2;
+      period = 1;
+      timeout = 120;
+    };
+  };
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,4 @@
+require_version: ">=2.1.2"
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling


### PR DESCRIPTION
## Summary

- pin the devenv input and project dependencies
- add a development shell with the repository toolchain
- add `devenv up` processes for the desktop app and head node
- document the shell, process, and validation workflows

## Validation

- `devenv shell -- npm run check`
- `devenv shell doctor`
- head-node readiness validation
- Linux devenv evaluation
- `nixfmt` validation