### PR TITLE
fix(agent): require strict goal outcome sentinels

### DIFF
--- a/services/agent-runtime/bun.lock
+++ b/services/agent-runtime/bun.lock
@@ -19,6 +19,7 @@
       "devDependencies": {
         "@types/node": "24.6.0",
         "@types/proper-lockfile": "4.1.4",
+        "typescript": "5.9.3",
       },
     },
   },
@@ -78,19 +79,19 @@
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.84.2", "", { "dependencies": { "@earendil-works/pi-ai": "^0.84.2", "@earendil-works/pi-telemetry": "^0.84.2", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, "sha512-8Pn3wSCxj0cfo5I6jxQYVB/3uuQRmHhAlEclyjqpOuMEdQMIODHizRogv56FLdbU+dTiGnybeHQ2N+sV1/L2YA=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.84.3", "", { "dependencies": { "@earendil-works/pi-ai": "^0.84.3", "@earendil-works/pi-telemetry": "^0.84.3", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, "sha512-VURr+xBRl3RxYcw3kT9Pn3yfi6LbRoCJgHF7h1mAblMjtLNV/MfG/RyF0uJizBAM886AEakSiw3j9c/aSngppg=="],
 
     "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.84.2", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@earendil-works/pi-telemetry": "^0.84.2", "@google/genai": "1.52.0", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.40.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-6MzsrYIYNVlE7SfpbL2yYb67Qo58p/7Q+xWG1RZvoX1P80aRCHSod2/13aFpxkow1lPO2LEh3c495J0Gwmyjig=="],
 
-    "@earendil-works/pi-client": ["@earendil-works/pi-client@0.84.2", "", { "dependencies": { "@earendil-works/pi-protocol": "^0.84.2" } }, "sha512-/RFSPhD/bZbpOp1oJj+UneSUFSgZhWxzcSENUY+8+8xhoBrWXMYI2t77XNx4Yf+c8YK2qTHquForhNcelYpXvg=="],
+    "@earendil-works/pi-client": ["@earendil-works/pi-client@0.84.3", "", { "dependencies": { "@earendil-works/pi-protocol": "^0.84.3" } }, "sha512-zfErYane+390W0xpBJ/FWCp6aktPpkpcIcXUeZiAziWLoxE80ZNQALRyOSa/gGS5V+1OkNnMYxRxbzN0zUvnOA=="],
 
     "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.84.2", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.84.2", "@earendil-works/pi-ai": "^0.84.2", "@earendil-works/pi-client": "^0.84.2", "@earendil-works/pi-protocol": "^0.84.2", "@earendil-works/pi-tui": "^0.84.2", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "grok-mermaid": "0.2.2", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.3.7", "undici": "8.9.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-l4E+B7hgXKWddRo8bC/eSue2aWZjEgJ9xIpf5p0Og+lq8a2TArCwJ0HCoCPCgaBP/tN4zbYH/wOwvx9pJpeLCA=="],
 
-    "@earendil-works/pi-protocol": ["@earendil-works/pi-protocol@0.84.2", "", { "dependencies": { "typebox": "1.3.7" } }, "sha512-jbBh03fkeckWEroHpcZBr4w5/Ibat8WwdXFlXHivYQImrQNFtLpDeL0t1cku4hmK0q3pceIRQHkw4fwbM4YILQ=="],
+    "@earendil-works/pi-protocol": ["@earendil-works/pi-protocol@0.84.3", "", { "dependencies": { "typebox": "1.3.7" } }, "sha512-9a4g6WhLOvRqvsIOFaWxg/2gdrbY4Thclwj5ipLUPAWChfsDJ/8XdPc2sRhSOkD6EsxpEFJz3xppcfwI6EcZDg=="],
 
-    "@earendil-works/pi-telemetry": ["@earendil-works/pi-telemetry@0.84.2", "", {}, "sha512-wg5caea7uIv1BHRBm2Y116RvFG4oSAiP5qk9tA2463PDGIr4K8M1Ceyyg5DOpF/shUUl0gk826yQJAeAcHYB9g=="],
+    "@earendil-works/pi-telemetry": ["@earendil-works/pi-telemetry@0.84.3", "", {}, "sha512-sgEkWoKrvSGaKn+YfLLFZmn+/A7B/w62eLwTD57nI+C9to8ITlFFVbgC2OtwvPnT3NFGHdCd53qhBEMIlptD1g=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.84.2", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-ds2TLihOnM5sLJB3VpXV6y0uR5efVuHf4MN7yDpsty6hA2DUO/EDVzjp/0od0G2JslzVLMjT8T8zavtxVb+qbg=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.84.3", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-fS6OEQKEEALnKa6Uw8LcgZZ+9CWck7f3MQSCETQp6leUgIFwMEDtKmOUnL9nsYm+RIPmy7OmplVxYRbV6hiaFg=="],
 
     "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
@@ -496,6 +497,8 @@
 
     "typebox": ["typebox@1.3.7", "", {}, "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg=="],
 
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
     "undici": ["undici@8.9.0", "", {}, "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA=="],
 
     "undici-types": ["undici-types@7.13.0", "", {}, "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ=="],
@@ -525,6 +528,8 @@
     "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1092.0", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/nested-clients": "^3.997.34", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-hBYUAr6iBLNFcsiWTgtBb0stdSw39VOUq4Sp4A5caCNf66BAZplWN4FleKrVpJx5li2YgdnK2DqoFSMWC642FQ=="],
 
     "@aws-sdk/nested-clients/@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.9", "", { "dependencies": { "@smithy/core": "^3.29.7", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-xVBZ3hptB99iNO9XyWqEhC7KD9bP9UPXhuy3h5Y2ItCfBv160D9IIC/Fmmp3EbnWwit4C+KVqlSE+E29Nk/pPg=="],
+
+    "@earendil-works/pi-agent-core/@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.84.3", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@earendil-works/pi-telemetry": "^0.84.3", "@google/genai": "1.52.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.40.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-M0YUV8vNO3y2WwWSyY8ijKJV5W4gkSUixuvk+Z00ZBjsyMfsdXfITsHEwP1UIf09YRWXT6oGn0GlCamt+P32XQ=="],
 
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 

--- a/services/agent-runtime/package.json
+++ b/services/agent-runtime/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "bundle": "node ../../scripts/project.mjs bundle-agent-runtime",
     "build": "node ../../scripts/project.mjs prepare-agent-runtime && tsc -p tsconfig.build.json && node ../../scripts/project.mjs postbuild-agent-runtime",
-    "check": "bun run build",
+    "check": "bun run build && bun test",
     "dev": "bun --watch src/server.ts",
     "start": "node dist/server.js"
   },
@@ -29,7 +29,8 @@
   },
   "devDependencies": {
     "@types/node": "24.6.0",
-    "@types/proper-lockfile": "4.1.4"
+    "@types/proper-lockfile": "4.1.4",
+    "typescript": "5.9.3"
   },
   "overrides": {
     "brace-expansion": "5.0.9"

--- a/shared/agent/goal-protocol.ts
+++ b/shared/agent/goal-protocol.ts
@@ -42,18 +42,17 @@ export function isGoalContinuationPrompt(text: string): boolean {
 
 export type GoalOutcome = { kind: "complete" } | { kind: "blocked"; reason: string };
 
-// A sentinel owns the rest of its line: GOAL_BLOCKED carries its reason there,
-// and a GOAL_COMPLETE is normally alone on the last line anyway.
-const SENTINEL_RE = /[ \t]*\b(?:GOAL_COMPLETE|GOAL_BLOCKED)\b[ \t]*[:\-–—]?[ \t]*[^\n]*/g;
-const COMPLETE_RE = /\bGOAL_COMPLETE\b/;
-const BLOCKED_RE = /\bGOAL_BLOCKED\b[ \t]*[:\-–—]?[ \t]*([^\n]*)/;
+const COMPLETE_SENTINEL_LINE_RE = /(?:^|\n)[ \t]*GOAL_COMPLETE[ \t]*$/;
+const BLOCKED_SENTINEL_LINE_RE =
+  /(?:^|\n)[ \t]*GOAL_BLOCKED(?:[ \t]*[:\-–—]?[ \t]*([^\n]*))?[ \t]*$/;
+const SENTINEL_LINE_RE =
+  /(?:^|\n)[ \t]*(?:GOAL_COMPLETE|GOAL_BLOCKED(?:[ \t]*[:\-–—]?[ \t]*[^\n]*)?)[ \t]*$/;
 
-/** The outcome a settled turn declared, or null when it declared none.
- *  Completion wins over a blocked marker in the pathological both-present case:
- *  a turn that reached the objective has nothing left to be blocked on. */
+/** The outcome a settled turn declared, or null when it declared none. */
 export function goalOutcomeFromText(text: string): GoalOutcome | null {
-  if (COMPLETE_RE.test(text)) return { kind: "complete" };
-  const blocked = BLOCKED_RE.exec(text);
+  const finalText = text.trimEnd();
+  if (COMPLETE_SENTINEL_LINE_RE.test(finalText)) return { kind: "complete" };
+  const blocked = BLOCKED_SENTINEL_LINE_RE.exec(finalText);
   return blocked ? { kind: "blocked", reason: (blocked[1] ?? "").trim() } : null;
 }
 
@@ -63,7 +62,7 @@ export function goalOutcomeFromText(text: string): GoalOutcome | null {
 // at a time. Six characters is the shortest prefix that commits to a sentinel
 // ("GOAL_C" / "GOAL_B"), which leaves the ordinary words "goal" and "GOAL_"
 // alone.
-const PARTIAL_TAIL_RE = /(?:^|\s)(GOAL_[A-Z]*)$/;
+const PARTIAL_TAIL_RE = /(?:^|\n)[ \t]*(GOAL_[A-Z]*)$/;
 
 function stripPartialSentinelTail(text: string): string {
   const match = PARTIAL_TAIL_RE.exec(text);
@@ -82,6 +81,6 @@ function stripPartialSentinelTail(text: string): string {
  *  Returns the input unchanged (same value) when there was nothing to strip, so
  *  callers can use the result to decide whether anything moved. */
 export function stripGoalSentinels(text: string): string {
-  const stripped = stripPartialSentinelTail(text.replace(SENTINEL_RE, ""));
+  const stripped = stripPartialSentinelTail(text.replace(SENTINEL_LINE_RE, ""));
   return stripped === text ? text : stripped.trimEnd();
 }

--- a/shared/agent/goal-protocol.ts
+++ b/shared/agent/goal-protocol.ts
@@ -44,9 +44,9 @@ export type GoalOutcome = { kind: "complete" } | { kind: "blocked"; reason: stri
 
 const COMPLETE_SENTINEL_LINE_RE = /(?:^|\n)[ \t]*GOAL_COMPLETE[ \t]*$/;
 const BLOCKED_SENTINEL_LINE_RE =
-  /(?:^|\n)[ \t]*GOAL_BLOCKED(?:[ \t]*[:\-–—]?[ \t]*([^\n]*))?[ \t]*$/;
+  /(?:^|\n)[ \t]*GOAL_BLOCKED(?![A-Za-z0-9_])(?:[ \t]*[:\-–—]?[ \t]*([^\n]*))?[ \t]*$/;
 const SENTINEL_LINE_RE =
-  /(?:^|\n)[ \t]*(?:GOAL_COMPLETE|GOAL_BLOCKED(?:[ \t]*[:\-–—]?[ \t]*[^\n]*)?)[ \t]*$/;
+  /(?:^|\n)[ \t]*(?:GOAL_COMPLETE|GOAL_BLOCKED(?![A-Za-z0-9_])(?:[ \t]*[:\-–—]?[ \t]*[^\n]*)?)[ \t]*$/;
 
 /** The outcome a settled turn declared, or null when it declared none. */
 export function goalOutcomeFromText(text: string): GoalOutcome | null {


### PR DESCRIPTION
Lands #430 by @moortekweb-art with a regenerated agent-runtime lockfile and one hardening tweak on top: the blocked sentinel now requires a non-identifier boundary, so a final line like GOAL_BLOCKED_BY_X no longer parses as blocked with a garbled reason.

Sentinels must now sit alone on the reply's final line, which shrinks the surface where quoted tool output or page text could falsely settle a goal. All 19 goal tests pass; the pinned typescript 5.9.3 lockfile entry was verified against the npm registry's published integrity hash.

Closes #430.

🤖 Generated with [Claude Code](https://claude.com/claude-code)