### PR TITLE
fix(providers): salvage the four still-relevant pieces of #435

### DIFF
--- a/controller/src/modules/studio/configs.ts
+++ b/controller/src/modules/studio/configs.ts
@@ -54,7 +54,7 @@ export const STUDIO_STARTER_PRESETS: StudioStarterPreset[] = [
     size_gb: null,
     min_vram_gb: null,
     remote: {
-      base_url: "http://pop-os-1.tailadb2c1.ts.net:8080/v1",
+      base_url: "https://api.deepseek.com",
       model: "deepseek-v4-flash",
     },
   },

--- a/controller/src/services/provider-routing.ts
+++ b/controller/src/services/provider-routing.ts
@@ -31,13 +31,19 @@ export const parseProviderModel = (rawModel: string): ParsedProviderModel => {
   return { provider: DEFAULT_CHAT_PROVIDER, modelId: trimmed };
 };
 
+/** Providers get configured both with and without a trailing /v1, and every
+ *  consumer appends /v1/… itself — so strip a trailing /v1 at the chokepoints
+ *  instead of letting user-entered /v1 URLs produce /v1/v1 paths. */
+const stripTrailingV1 = (baseUrl: string): string =>
+  baseUrl.replace(/\/+$/, "").replace(/\/v1$/i, "");
+
 export const resolveConfiguredProviderConfig = (
   providerId: string,
   providers: ProviderConfig[] = [],
 ): ProviderRouteConfig | null => {
   const match = providers.find((p) => p.id.toLowerCase() === providerId.toLowerCase() && p.enabled);
   if (!match || !match.api_key) return null;
-  return { baseUrl: match.base_url, apiKey: match.api_key };
+  return { baseUrl: stripTrailingV1(match.base_url), apiKey: match.api_key };
 };
 
 interface ProviderModelCatalog {
@@ -57,7 +63,7 @@ export const discoverProviderModels = (
   timeoutMs = 10_000,
 ): Effect.Effect<ProviderModelCatalog, unknown> =>
   Effect.gen(function* () {
-    const url = `${provider.base_url.replace(/\/+$/, "")}/v1/models`;
+    const url = `${stripTrailingV1(provider.base_url)}/v1/models`;
     const response = yield* Effect.tryPromise({
       try: () =>
         fetch(url, {

--- a/frontend/src/features/agent/ui/model-visibility.ts
+++ b/frontend/src/features/agent/ui/model-visibility.ts
@@ -18,6 +18,11 @@ export function splitVisibleAgentModels(
   return {
     controllerModels,
     otherModels,
-    visibleModels: showOtherModels ? [...controllerModels, ...otherModels] : controllerModels,
+    // With no controller models at all, an empty picker helps nobody — fall
+    // back to the other models even when they are toggled off.
+    visibleModels:
+      showOtherModels || controllerModels.length === 0
+        ? [...controllerModels, ...otherModels]
+        : controllerModels,
   };
 }

--- a/frontend/src/features/setup/setup-view/step-hardware-model.ts
+++ b/frontend/src/features/setup/setup-view/step-hardware-model.ts
@@ -34,15 +34,20 @@ export function buildHardwareSummary(diagnostics: StudioDiagnostics | null): Har
   const gpuNames =
     diagnostics?.gpus.map((gpu) => gpu.name).join(", ") ||
     (appleSilicon ? "Apple Silicon GPU · Metal" : "No accelerator detected");
-  const firstGpuVramMb = diagnostics?.gpus[0]?.memory_total_mb ?? 0;
+  // The whole pool, not GPU 0: multi-GPU rigs report per-device totals and
+  // the fit rule sizes against the sum.
+  const totalGpuVramMb = (diagnostics?.gpus ?? []).reduce(
+    (sum, gpu) => sum + (gpu.memory_total_mb ?? 0),
+    0,
+  );
 
   return {
     cpu: `${diagnostics?.cpu_model ?? "Unknown"} · ${diagnostics?.cpu_cores ?? 0} cores`,
     gpu: gpuNames,
     memory: `${formatBytes(diagnostics?.memory_total ?? null)} total`,
     runtime: runtimeDescription(diagnostics, appleSilicon),
-    vram: firstGpuVramMb
-      ? `${Math.round(firstGpuVramMb / 1024)} GB${appleSilicon ? " unified" : ""}`
+    vram: totalGpuVramMb
+      ? `${Math.round(totalGpuVramMb / 1024)} GB${appleSilicon ? " unified" : ""}`
       : "Not reported",
   };
 }


### PR DESCRIPTION
Lands the surviving parts of #435 by @JoaoZaokk on current main (the PR's catalog-merge plumbing was superseded by the cached provider-catalog merge already on main):

- DeepSeek starter preset no longer ships the owner's personal tailnet hostname; it points at https://api.deepseek.com
- Provider base URLs entered with a trailing /v1 no longer produce /v1/v1 upstream paths (stripped at the routing chokepoints)
- Setup hardware summary reports the full VRAM pool across all GPUs instead of GPU 0
- The model picker falls back to non-controller models when no controller models exist, instead of rendering empty

Closes #435.

🤖 Generated with [Claude Code](https://claude.com/claude-code)