### PR TITLE
fix(agent-runtime): wait for the goal driver to settle instead of sleeping

### DIFF
--- a/services/agent-runtime/test/goal-driver.test.ts
+++ b/services/agent-runtime/test/goal-driver.test.ts
@@ -68,8 +68,25 @@ const assistantSays = (text: string) => ({
   message: { role: "assistant", content: [{ type: "text", text }] },
 });
 
-/** The driver settles asynchronously off the event stream. */
-const flush = () => new Promise((resolve) => setTimeout(resolve, 30));
+/**
+ * The driver settles asynchronously off the event stream, so wait for the goal
+ * record to stop changing rather than for a fixed delay. A single 30ms sleep
+ * raced the driver on loaded CI runners: the assertions ran while the turn was
+ * still being processed, so the suite failed intermittently on CI while
+ * passing on every developer machine.
+ */
+const flush = async (): Promise<void> => {
+  const deadline = Date.now() + 2_000;
+  let previous = JSON.stringify(await readGoal(PI_SESSION_ID));
+  let stableReads = 0;
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const current = JSON.stringify(await readGoal(PI_SESSION_ID));
+    stableReads = current === previous ? stableReads + 1 : 0;
+    previous = current;
+    if (stableReads >= 3) return;
+  }
+};
 
 async function setGoal(patch: Parameters<typeof writeGoal>[1] = {}) {
   await writeGoal(PI_SESSION_ID, {


### PR DESCRIPTION
**main is currently red** — the `agent-runtime` job fails on `6a6ece0e0`, and it is a flaky test rather than a code regression.

`goal-driver.test.ts` flushed with a fixed 30ms sleep, which races the driver on loaded CI runners: the assertions run while the turn is still being processed, so `turnsUsed`/`status` read their pre-turn values. It passes on every developer machine, which is why it slipped through.

`flush()` now polls the goal record until it stops changing (three stable reads, 2s cap), so it returns as fast as the driver settles and tolerates a slow runner.

Verified:
- full agent-runtime suite: 77 pass / 0 fail, three consecutive runs
- `goal-driver.test.ts` passes under 8-way CPU saturation
- the same file fails on the old fixed-sleep code when the delay is shortened, confirming timing (not semantics) was the cause

This unblocks main plus #436 and #440, which are both inheriting the red job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)