### PR TITLE
feat(controller): report multiple inference endpoints

### DIFF
--- a/controller/contracts/observability.ts
+++ b/controller/contracts/observability.ts
@@ -123,6 +123,15 @@ export interface ProcessInfo {
   served_model_name?: string | null;
 }
 
+export interface InferenceEndpointStatus {
+  id: string;
+  name: string;
+  ownership: "external";
+  port: number | null;
+  healthy: boolean;
+  models: string[];
+}
+
 export interface LogSession {
   id: string;
   recipe_id?: string;

--- a/controller/src/modules/models/routes.ts
+++ b/controller/src/modules/models/routes.ts
@@ -43,6 +43,7 @@ import { isRecipeRunning } from "./recipes/recipe-matching";
 import { notFound } from "../../core/errors";
 import { findObservedInferenceProcess } from "../../core/function-observability";
 import { fetchInference } from "../../http/local-fetch";
+import { listProviderModelsCached } from "../../services/provider-routing";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -127,6 +128,26 @@ export const registerModelsRoutes = defineRoutes((app, context) => {
                 vision: resolveModelVision({ identifiers: [inferredId] }),
               },
             });
+          }
+
+          const providerCatalogs = yield* listProviderModelsCached(context.config.providers);
+          for (const catalog of providerCatalogs) {
+            for (const model of catalog.models) {
+              const modelId = `${catalog.provider}/${model.id}`;
+              models.push({
+                id: modelId,
+                object: "model",
+                created: now,
+                owned_by: catalog.provider,
+                active: catalog.healthy,
+                max_model_len: null,
+                metadata: {
+                  external: true,
+                  provider: catalog.provider,
+                  vision: resolveModelVision({ identifiers: [model.id, modelId] }),
+                },
+              });
+            }
           }
 
           const payload: OpenAIModelList = { object: "list", data: models };

--- a/controller/src/modules/studio/provider-routes.ts
+++ b/controller/src/modules/studio/provider-routes.ts
@@ -4,6 +4,10 @@ import { decodeJsonBody } from "../../core/validation";
 import { effectHandler } from "../../http/effect-handler";
 import { documentRoute, defineRoutes, mergeRoutes } from "../../http/route-registrar";
 import { savePersistedConfig, type ProviderConfig } from "../../config/persisted-config";
+import {
+  discoverProviderModels,
+  enabledProvidersWithApiKey,
+} from "../../services/provider-routing";
 
 type ProviderView = {
   id: string;
@@ -26,10 +30,6 @@ const ProviderUpdateSchema = Schema.Struct({
   base_url: Schema.optional(Schema.String),
   api_key: Schema.optional(Schema.String),
   enabled: Schema.optional(Schema.Boolean),
-});
-
-const ProviderModelsSchema = Schema.Struct({
-  data: Schema.optional(Schema.Array(Schema.Struct({ id: Schema.optional(Schema.String) }))),
 });
 
 class ProviderPersistenceError extends Schema.TaggedErrorClass<ProviderPersistenceError>()(
@@ -65,32 +65,6 @@ const required = (
   const trimmed = value.trim();
   return trimmed ? Effect.succeed(trimmed) : Effect.fail(badRequest(`${label} is required`));
 };
-
-const providerModels = (
-  provider: ProviderConfig,
-): Effect.Effect<{ provider: string; models: Array<{ id: string }> }, unknown> =>
-  Effect.gen(function* () {
-    const url = `${provider.base_url.replace(/\/+$/, "")}/v1/models`;
-    const response = yield* Effect.tryPromise({
-      try: () =>
-        fetch(url, {
-          headers: { Authorization: `Bearer ${provider.api_key}` },
-          signal: AbortSignal.timeout(10_000),
-        }),
-      catch: (source) => source,
-    });
-    if (!response.ok) return yield* Effect.fail(response.status);
-    const payload = yield* Effect.tryPromise({
-      try: () => response.json(),
-      catch: (source) => source,
-    });
-    const decoded = yield* Schema.decodeUnknownEffect(ProviderModelsSchema)(payload);
-    const models = (decoded.data ?? []).flatMap((model) => {
-      const id = model.id?.trim();
-      return id ? [{ id }] : [];
-    });
-    return { provider: provider.id, models };
-  });
 
 export const registerStudioProviderRoutes = defineRoutes((app, context) => {
   return mergeRoutes(
@@ -182,8 +156,8 @@ export const registerStudioProviderRoutes = defineRoutes((app, context) => {
       documentRoute,
       effectHandler((ctx) =>
         Effect.forEach(
-          context.config.providers.filter((provider) => provider.enabled && provider.api_key),
-          (provider) => providerModels(provider).pipe(Effect.option),
+          enabledProvidersWithApiKey(context.config.providers),
+          (provider) => discoverProviderModels(provider).pipe(Effect.option),
           { concurrency: "unbounded" },
         ).pipe(
           Effect.map((results) =>

--- a/controller/src/modules/system/routes.ts
+++ b/controller/src/modules/system/routes.ts
@@ -9,6 +9,8 @@ import { badRequest, notFound } from "../../core/errors";
 import { decodeJsonBody } from "../../core/validation";
 import { effectHandler } from "../../http/effect-handler";
 import { findObservedInferenceProcess } from "../../core/function-observability";
+import type { InferenceEndpointStatus } from "@local-studio/contracts/observability";
+import { listProviderModelsCached, providerPort } from "../../services/provider-routing";
 import { estimateWeightsSizeBytes } from "../models/model-browser";
 import { getGpuInfo } from "./platform/gpu";
 import { getSystemRuntimeInfo } from "../engines/runtimes/runtime-info";
@@ -90,10 +92,26 @@ export const registerSystemRoutes = defineRoutes((app, context) => {
       effectHandler((ctx) =>
         Effect.gen(function* () {
           const current = yield* findObservedInferenceProcess(context, "status");
+          const catalogs = yield* listProviderModelsCached(context.config.providers);
+          const catalogsByProvider = new Map(catalogs.map((catalog) => [catalog.provider, catalog]));
+          const endpoints: InferenceEndpointStatus[] = context.config.providers
+            .filter((provider) => provider.enabled)
+            .map((provider) => {
+              const catalog = catalogsByProvider.get(provider.id);
+              return {
+                id: provider.id,
+                name: provider.name,
+                ownership: "external",
+                port: providerPort(provider.base_url),
+                healthy: catalog?.healthy ?? false,
+                models: catalog?.models.map((model) => model.id) ?? [],
+              };
+            });
           return ctx.json({
-            running: Boolean(current),
+            running: Boolean(current) || endpoints.some((endpoint) => endpoint.healthy),
             process: current,
             inference_port: context.config.inference_port,
+            endpoints,
             launching: context.bridge.launchingRecipeId(),
             launch_failures: context.launchFailureBudget.listActive(),
           });

--- a/controller/src/services/provider-routing.ts
+++ b/controller/src/services/provider-routing.ts
@@ -1,3 +1,4 @@
+import { Effect, Schema } from "effect";
 import type { ProviderConfig } from "../config/persisted-config";
 
 export const DEFAULT_CHAT_PROVIDER = "openai";
@@ -48,4 +49,91 @@ export const resolveProviderConfig = (
   config: ControllerProviderRoutingConfig = {},
 ): ProviderRouteConfig | null => {
   return resolveConfiguredProviderConfig(provider, config.providers);
+};
+
+export interface ProviderModelCatalog {
+  provider: string;
+  models: Array<{ id: string }>;
+  healthy: boolean;
+}
+
+const ProviderModelsSchema = Schema.Struct({
+  data: Schema.optional(Schema.Array(Schema.Struct({ id: Schema.optional(Schema.String) }))),
+});
+
+export const enabledProvidersWithApiKey = (providers: ProviderConfig[] = []): ProviderConfig[] =>
+  providers.filter((provider) => provider.enabled && provider.api_key);
+
+export const discoverProviderModels = (
+  provider: ProviderConfig,
+  timeoutMs = 10_000,
+): Effect.Effect<ProviderModelCatalog, unknown> =>
+  Effect.gen(function* () {
+    const url = `${provider.base_url.replace(/\/+$/, "")}/v1/models`;
+    const response = yield* Effect.tryPromise({
+      try: () =>
+        fetch(url, {
+          headers: { Authorization: `Bearer ${provider.api_key}` },
+          signal: AbortSignal.timeout(timeoutMs),
+        }),
+      catch: (source) => source,
+    });
+    if (!response.ok) return yield* Effect.fail(response.status);
+    const payload = yield* Effect.tryPromise({
+      try: () => response.json(),
+      catch: (source) => source,
+    });
+    const decoded = yield* Schema.decodeUnknownEffect(ProviderModelsSchema)(payload);
+    const models = (decoded.data ?? []).flatMap((model) => {
+      const id = model.id?.trim();
+      return id ? [{ id }] : [];
+    });
+    return { provider: provider.id, models, healthy: true };
+  });
+
+const DISCOVERY_TIMEOUT_MS = 3_000;
+const SUCCESS_TTL_MS = 60_000;
+const FAILURE_TTL_MS = 15_000;
+
+const catalogCache = new Map<string, { expiresAt: number; catalog: ProviderModelCatalog }>();
+
+export const listProviderModelsCached = (
+  providers: ProviderConfig[] = [],
+): Effect.Effect<ProviderModelCatalog[]> =>
+  Effect.forEach(
+    enabledProvidersWithApiKey(providers),
+    (provider) => {
+      const key = `${provider.id}\n${provider.base_url}\n${provider.api_key}`;
+      const cached = catalogCache.get(key);
+      if (cached && cached.expiresAt > Date.now()) return Effect.succeed(cached.catalog);
+      return discoverProviderModels(provider, DISCOVERY_TIMEOUT_MS).pipe(
+        Effect.tap((catalog) =>
+          Effect.sync(() =>
+            catalogCache.set(key, { expiresAt: Date.now() + SUCCESS_TTL_MS, catalog }),
+          ),
+        ),
+        Effect.catch(() =>
+          Effect.sync(() => {
+            const catalog: ProviderModelCatalog = {
+              provider: provider.id,
+              models: [],
+              healthy: false,
+            };
+            catalogCache.set(key, { expiresAt: Date.now() + FAILURE_TTL_MS, catalog });
+            return catalog;
+          }),
+        ),
+      );
+    },
+    { concurrency: "unbounded" },
+  );
+
+export const providerPort = (baseUrl: string): number | null => {
+  try {
+    const url = new URL(baseUrl);
+    const port = url.port ? Number(url.port) : url.protocol === "https:" ? 443 : 80;
+    return Number.isInteger(port) && port > 0 && port <= 65_535 ? port : null;
+  } catch {
+    return null;
+  }
 };

--- a/frontend/src/features/dashboard/control-panel/control-panel.tsx
+++ b/frontend/src/features/dashboard/control-panel/control-panel.tsx
@@ -35,6 +35,7 @@ export function ControlPanel(props: DashboardLayoutProps) {
         isStatusLoading={props.isStatusLoading}
         platformKind={props.platformKind}
         inferencePort={props.inferencePort}
+        endpoints={props.endpoints}
         onNavigateLogs={props.onNavigateLogs}
         onBenchmark={props.onBenchmark}
         benchmarking={props.benchmarking}

--- a/frontend/src/features/dashboard/control-panel/status-section-parts.tsx
+++ b/frontend/src/features/dashboard/control-panel/status-section-parts.tsx
@@ -4,7 +4,12 @@ import type { ReactNode } from "react";
 import { Square } from "@/ui/icon-registry";
 import { ModelStopConfirm } from "@/features/dashboard/model-stop-confirm";
 import { useModelLifecycle } from "@/features/dashboard/use-model-lifecycle";
-import type { ProcessInfo, RecipeWithStatus, RuntimePlatformKind } from "@/lib/types";
+import type {
+  InferenceEndpointStatus,
+  ProcessInfo,
+  RecipeWithStatus,
+  RuntimePlatformKind,
+} from "@/lib/types";
 import { cx } from "@/ui/utils";
 import { ModelsDropdown } from "./status-section-models-dropdown";
 import type { MetricColumnView } from "./status-section-view";
@@ -195,6 +200,38 @@ function StatusHeaderActions({
 export function benchmarkButtonLabel(benchmarking: boolean, result: number | null): string {
   if (benchmarking) return "Benchmarking…";
   return result === null ? "Bench" : `Bench · ${result.toFixed(1)} tok/s`;
+}
+
+export function EndpointStatusStrip({ endpoints }: { endpoints: InferenceEndpointStatus[] }) {
+  if (endpoints.length === 0) return null;
+  return (
+    <div className="mt-4 grid gap-2 sm:grid-cols-2">
+      {endpoints.map((endpoint) => (
+        <div
+          key={endpoint.id}
+          className="flex min-w-0 items-center gap-2 border border-(--border)/55 bg-(--surface)/40 px-3 py-2"
+        >
+          <span
+            className={`h-1.5 w-1.5 shrink-0 ${endpoint.healthy ? "bg-emerald-400" : "bg-(--err)"}`}
+          />
+          <span className="min-w-0 flex-1">
+            <span className="block truncate text-[length:var(--fs-sm)] font-medium text-(--fg)">
+              {endpoint.name}
+            </span>
+            <span className="block truncate font-mono text-[length:var(--fs-xs)] text-(--dim)">
+              {endpoint.models.length > 0 ? endpoint.models.join(", ") : "No models discovered"}
+            </span>
+          </span>
+          <span className="shrink-0 font-mono text-[length:var(--fs-xs)] text-(--dim)">
+            {endpoint.port ? `:${endpoint.port}` : "—"}
+          </span>
+          <span className="shrink-0 text-[length:var(--fs-xs)] text-(--dim)">
+            {endpoint.healthy ? "active" : "offline"}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
 }
 
 function HeaderStopButton({ running }: { running: boolean }) {

--- a/frontend/src/features/dashboard/control-panel/status-section.tsx
+++ b/frontend/src/features/dashboard/control-panel/status-section.tsx
@@ -1,7 +1,14 @@
 "use client";
 
-import type { GPU, Metrics, ProcessInfo, RecipeWithStatus, RuntimePlatformKind } from "@/lib/types";
-import { StatusHeader, StatusMetricStrip } from "./status-section-parts";
+import type {
+  GPU,
+  InferenceEndpointStatus,
+  Metrics,
+  ProcessInfo,
+  RecipeWithStatus,
+  RuntimePlatformKind,
+} from "@/lib/types";
+import { EndpointStatusStrip, StatusHeader, StatusMetricStrip } from "./status-section-parts";
 import { MetricTrends, useMetricSamples } from "./status-section-trends";
 import { resolveStatusSectionView } from "./status-section-view";
 
@@ -15,6 +22,7 @@ interface StatusSectionProps {
   isStatusLoading: boolean;
   platformKind?: RuntimePlatformKind | null;
   inferencePort?: number;
+  endpoints: InferenceEndpointStatus[];
   onNavigateLogs: () => void;
   onBenchmark: () => void;
   benchmarking: boolean;
@@ -37,6 +45,7 @@ export function StatusSection({
   isStatusLoading,
   platformKind,
   inferencePort,
+  endpoints,
   onNavigateLogs,
   onBenchmark,
   benchmarking,
@@ -82,6 +91,7 @@ export function StatusSection({
         onViewAll={onViewAll}
         recipes={recipes}
       />
+      <EndpointStatusStrip endpoints={endpoints} />
       <StatusMetricStrip
         live={view.liveMetrics}
         steady={view.steadyMetrics}

--- a/frontend/src/features/dashboard/layout/dashboard-types.ts
+++ b/frontend/src/features/dashboard/layout/dashboard-types.ts
@@ -1,5 +1,6 @@
 import type {
   GPU,
+  InferenceEndpointStatus,
   LaunchProgress,
   Metrics,
   ProcessInfo,
@@ -30,6 +31,7 @@ export interface DashboardLayoutProps {
   isConnected: boolean;
   isStatusLoading: boolean;
   inferencePort?: number;
+  endpoints: InferenceEndpointStatus[];
   onNavigateLogs: () => void;
   onBenchmark: () => void;
   onLaunch: (recipeId: string) => Promise<void>;

--- a/frontend/src/features/dashboard/use-dashboard-data.ts
+++ b/frontend/src/features/dashboard/use-dashboard-data.ts
@@ -40,6 +40,7 @@ export function useDashboardData() {
     isConnected: realtime.connected,
     isStatusLoading: realtime.statusLoading,
     inferencePort: realtime.status?.inference_port,
+    endpoints: realtime.status?.endpoints ?? [],
     benchmarking: actions.benchmarking,
     benchmarkResult: actions.benchmarkResult,
     launching: lifecycle.status === "starting",

--- a/frontend/src/hooks/realtime-status-equality.ts
+++ b/frontend/src/hooks/realtime-status-equality.ts
@@ -1,5 +1,6 @@
 import type {
   GPU,
+  InferenceEndpointStatus,
   LaunchProgressData,
   Metrics,
   ProcessInfo,
@@ -24,12 +25,33 @@ function areProcessInfosEqual(a: ProcessInfo | null, b: ProcessInfo | null) {
   );
 }
 
+function areEndpointStatusesEqual(a: InferenceEndpointStatus[], b: InferenceEndpointStatus[]) {
+  if (a === b) return true;
+  return (
+    a.length === b.length &&
+    a.every((left, index) => {
+      const right = b[index];
+      return (
+        right !== undefined &&
+        left.id === right.id &&
+        left.name === right.name &&
+        left.ownership === right.ownership &&
+        left.port === right.port &&
+        left.healthy === right.healthy &&
+        left.models.length === right.models.length &&
+        left.models.every((model, modelIndex) => model === right.models[modelIndex])
+      );
+    })
+  );
+}
+
 export function areStatusEqual(a: StatusData | null, b: StatusData | null) {
   if (a === b) return true;
   if (!a || !b) return false;
   return (
     a.running === b.running &&
     a.inference_port === b.inference_port &&
+    areEndpointStatusesEqual(a.endpoints, b.endpoints) &&
     areProcessInfosEqual(a.process, b.process)
   );
 }

--- a/frontend/src/hooks/realtime-status-store.ts
+++ b/frontend/src/hooks/realtime-status-store.ts
@@ -262,10 +262,10 @@ function emitNoPolledStatus() {
 
 function emitPolledStatus({ compatibility, gpus, metrics, status }: PollResults) {
   if (!status) return emitNoPolledStatus();
-  const { running, process, inference_port } = status;
+  const { running, process, inference_port, endpoints } = status;
   const launching = status.launching ?? null;
   emitIfChanged({
-    status: { running, process, inference_port, launching },
+    status: { running, process, inference_port, endpoints, launching },
     statusLoading: false,
     connected: true,
     gpus,
@@ -290,6 +290,9 @@ function statusFromEventData(
     running: Boolean(data["running"] ?? process),
     process,
     inference_port: Number(data["inference_port"] ?? 8000),
+    endpoints: Array.isArray(data["endpoints"])
+      ? (data["endpoints"] as NonNullable<RealtimeStatusSnapshot["status"]>["endpoints"])
+      : (snapshot.status?.endpoints ?? []),
     launching:
       typeof data["launching"] === "string" && data["launching"] ? data["launching"] : null,
   };

--- a/frontend/src/hooks/realtime-status-types.ts
+++ b/frontend/src/hooks/realtime-status-types.ts
@@ -1,5 +1,6 @@
 import type {
   GPU,
+  InferenceEndpointStatus,
   LaunchProgressData,
   Metrics,
   ProcessInfo,
@@ -12,6 +13,7 @@ export interface StatusData {
   running: boolean;
   process: ProcessInfo | null;
   inference_port: number;
+  endpoints: InferenceEndpointStatus[];
   launching: string | null;
 }
 

--- a/frontend/src/lib/api/system.ts
+++ b/frontend/src/lib/api/system.ts
@@ -2,6 +2,7 @@ import type {
   CompatibilityReport,
   ConfigData,
   GPU,
+  InferenceEndpointStatus,
   Metrics,
   ProcessInfo,
   UsageStats,
@@ -161,12 +162,14 @@ export function createSystemApi(core: ApiCore) {
       running: boolean;
       process: ProcessInfo | null;
       inference_port: number;
+      endpoints: InferenceEndpointStatus[];
       launching: string | null;
     }> => {
       const data = await core.request<{
         running: boolean;
         process: ProcessInfo | null;
         inference_port: number;
+        endpoints?: InferenceEndpointStatus[];
         launching?: string | null;
       }>("/status", options);
 
@@ -174,6 +177,7 @@ export function createSystemApi(core: ApiCore) {
         running: data.running ?? !!data.process,
         process: data.process ?? null,
         inference_port: data.inference_port || 8000,
+        endpoints: Array.isArray(data.endpoints) ? data.endpoints : [],
         launching: typeof data.launching === "string" && data.launching ? data.launching : null,
       };
     },

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -62,6 +62,7 @@ export type {
 
 export type {
   GPU,
+  InferenceEndpointStatus,
   LogSession,
   Metrics,
   PeakMetrics,


### PR DESCRIPTION
## Summary
- discover every enabled provider endpoint independently
- expose endpoint health, port, and model inventory through `/status` and `/v1/models`
- render read-only endpoint cards in the dashboard without taking lifecycle ownership of external runtimes
- preserve endpoint inventory when legacy realtime events omit it

## Validation
- `npm run check`
- dev desktop production build
- live controller acceptance with DeepSeek on `:8888` and Qwen on `:8892`
- routed completions through both provider/model IDs