### PR TITLE
fix(automation): make the repository automation runnable on Windows

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,1 +1,5 @@
-../scripts/project.mjs
+#!/usr/bin/env node
+import("../scripts/project.mjs").catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,1 +1,5 @@
-../scripts/project.mjs
+#!/usr/bin/env node
+import("../scripts/project.mjs").catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,1 +1,5 @@
-../scripts/project.mjs
+#!/usr/bin/env node
+import("../scripts/project.mjs").catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,26 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+
+  windows-automation:
+    name: Repository automation (Windows)
+    if: github.event_name != 'schedule'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.19.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+      - name: Toolchain check
+        run: npm run doctor
+      - name: Git hook registration
+        run: node scripts/project.mjs setup-hooks
+      - name: Automation layout gate
+        run: node scripts/project.mjs audit-layout
+
   trufflehog:
     name: Secret Scanning (TruffleHog)
     runs-on: ubuntu-latest

--- a/frontend/desktop/automation/agent-runtime.mjs
+++ b/frontend/desktop/automation/agent-runtime.mjs
@@ -14,7 +14,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
-import { repoRoot } from "./lib.mjs";
+import { platformInvocation, repoRoot } from "./lib.mjs";
 
 const packageDir = path.join(repoRoot, "services", "agent-runtime");
 const distDir = path.join(packageDir, "dist");
@@ -52,25 +52,22 @@ export function bundleAgentRuntime() {
   rmSync(distDir, { recursive: true, force: true });
   mkdirSync(distDir, { recursive: true });
 
-  const build = spawnSync(
-    "bun",
-    [
-      "build",
-      "src/server.ts",
-      "--target=node",
-      "--external",
-      "fsevents",
-      "--external",
-      "playwright-core",
-      "--external",
-      "@silvia-odwyer/photon-node",
-      "--external",
-      "undici",
-      "--minify",
-      "--outfile=dist/standalone.mjs",
-    ],
-    { cwd: packageDir, stdio: "inherit" },
-  );
+  const [bun, bunArgs] = platformInvocation("bun", [
+    "build",
+    "src/server.ts",
+    "--target=node",
+    "--external",
+    "fsevents",
+    "--external",
+    "playwright-core",
+    "--external",
+    "@silvia-odwyer/photon-node",
+    "--external",
+    "undici",
+    "--minify",
+    "--outfile=dist/standalone.mjs",
+  ]);
+  const build = spawnSync(bun, bunArgs, { cwd: packageDir, stdio: "inherit" });
   if (build.status !== 0) {
     throw Error(`Agent runtime bundle failed with status ${build.status ?? "unknown"}`);
   }

--- a/frontend/desktop/automation/lib.mjs
+++ b/frontend/desktop/automation/lib.mjs
@@ -4,6 +4,7 @@
 // side effects — each exports functions the project.mjs entry dispatches to.
 
 import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import path from "node:path";
 
 /** Repo root: this file lives at frontend/desktop/automation/lib.mjs. */
@@ -16,9 +17,42 @@ export function valueAfter(args, name) {
   return index === -1 ? undefined : args[index + 1];
 }
 
+/**
+ * Windows has no `npm`, `npx`, or `bun` on PATH — it has `npm.cmd`, `npx.cmd`, and a
+ * `bun.exe` that a Node-managed install leaves outside PATH entirely. spawnSync does
+ * not consult PATHEXT, so the bare name fails with ENOENT. Resolve npm and npx to the
+ * JavaScript CLI the running Node already ships and invoke it directly, which also
+ * avoids handing an argv to cmd.exe for re-parsing. POSIX is returned untouched.
+ */
+export function platformInvocation(command, args) {
+  if (process.platform !== "win32") return [command, args];
+  if (command === "bun") {
+    const candidates = [
+      path.join(path.dirname(process.execPath), "node_modules", "bun", "bin", "bun.exe"),
+      process.env["BUN_INSTALL"] ? path.join(process.env["BUN_INSTALL"], "bin", "bun.exe") : null,
+    ];
+    const executable = candidates.find((candidate) => candidate && existsSync(candidate));
+    return executable ? [executable, args] : [command, args];
+  }
+  if (command !== "npm" && command !== "npx") return [command, args];
+  const npmCli = process.env["npm_execpath"]?.trim();
+  const cli =
+    command === "npm" ? npmCli : npmCli ? path.join(path.dirname(npmCli), "npx-cli.js") : null;
+  const fallback = path.join(
+    path.dirname(process.execPath),
+    "node_modules",
+    "npm",
+    "bin",
+    `${command}-cli.js`,
+  );
+  const script = cli && existsSync(cli) ? cli : fallback;
+  return [process.execPath, [script, ...args]];
+}
+
 /** Run a command inheriting stdio; exit the process with its status on failure. */
 export function run(command, args, cwd = repoRoot) {
-  const result = spawnSync(command, args, { cwd, stdio: "inherit" });
+  const [resolvedCommand, resolvedArgs] = platformInvocation(command, args);
+  const result = spawnSync(resolvedCommand, resolvedArgs, { cwd, stdio: "inherit" });
   if (result.error) throw result.error;
   if (result.status !== 0) process.exit(result.status ?? 1);
 }

--- a/frontend/desktop/automation/toolchain.mjs
+++ b/frontend/desktop/automation/toolchain.mjs
@@ -4,7 +4,7 @@
 import { spawnSync } from "node:child_process";
 import { chmodSync, lstatSync, mkdirSync, readdirSync, rmSync, symlinkSync } from "node:fs";
 import path from "node:path";
-import { frontendDir, git, repoRoot, run } from "./lib.mjs";
+import { frontendDir, git, platformInvocation, repoRoot, run } from "./lib.mjs";
 
 function parsedVersion(value) {
   const match = value.match(/(\d+)\.(\d+)(?:\.(\d+))?/);
@@ -19,10 +19,16 @@ function versionMeetsMinimum(actual, minimum) {
   return true;
 }
 
+function probeTool(command, args) {
+  const [resolvedCommand, resolvedArgs] = platformInvocation(command, args);
+  const result = spawnSync(resolvedCommand, resolvedArgs, { cwd: repoRoot, encoding: "utf8" });
+  if (result.error || result.status !== 0) return null;
+  return `${result.stdout ?? ""}${result.stderr ?? ""}`.trim();
+}
+
 function requireTool(label, command, args, minimum) {
-  const result = spawnSync(command, args, { cwd: repoRoot, encoding: "utf8" });
-  if (result.error || result.status !== 0) throw Error(`${label} is required but unavailable`);
-  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`.trim();
+  const output = probeTool(command, args);
+  if (output === null) throw Error(`${label} is required but unavailable`);
   const actual = parsedVersion(output);
   if (!actual || !versionMeetsMinimum(actual, minimum)) {
     throw Error(`${label} ${minimum.join(".")} or newer is required; found ${output || "unknown"}`);
@@ -30,11 +36,47 @@ function requireTool(label, command, args, minimum) {
   console.log(`${label}: ${actual.join(".")}`);
 }
 
+/**
+ * Python is the one tool whose name is not settled on Windows: the python.org installer
+ * ships `python` and the `py` launcher, and the `python3` that is on PATH is usually the
+ * Microsoft Store stub, which exits non-zero without a version. Try the spellings in
+ * turn and require one of them to satisfy the minimum, reporting what was actually
+ * found when none does. Only Windows takes this path.
+ */
+function requireToolCandidate(label, candidates, minimum) {
+  const found = [];
+  for (const [command, args] of candidates) {
+    const output = probeTool(command, args);
+    if (output === null) continue;
+    const actual = parsedVersion(output);
+    if (actual && versionMeetsMinimum(actual, minimum)) {
+      console.log(`${label}: ${actual.join(".")}`);
+      return;
+    }
+    if (output) found.push(output);
+  }
+  throw Error(
+    `${label} ${minimum.join(".")} or newer is required${found.length > 0 ? `; found ${found.join(", ")}` : " but unavailable"}`,
+  );
+}
+
 export function doctor() {
   requireTool("Node.js", process.execPath, ["--version"], [22, 19, 0]);
   requireTool("npm", "npm", ["--version"], [10, 0, 0]);
   requireTool("Bun", "bun", ["--version"], [1, 3, 14]);
-  requireTool("Python", "python3", ["--version"], [3, 10, 0]);
+  if (process.platform === "win32") {
+    requireToolCandidate(
+      "Python",
+      [
+        ["python", ["--version"]],
+        ["py", ["-3", "--version"]],
+        ["python3", ["--version"]],
+      ],
+      [3, 10, 0],
+    );
+  } else {
+    requireTool("Python", "python3", ["--version"], [3, 10, 0]);
+  }
   requireTool("Git", "git", ["--version"], [2, 0, 0]);
   console.log("Toolchain check passed");
 }
@@ -89,6 +131,9 @@ export function setupHooks() {
   }
   git(["rev-parse", "--git-dir"]);
   git(["config", "core.hooksPath", ".githooks"]);
+  // NTFS has no executable bit and chmod is a no-op there at best; git records the
+  // committed 100755 mode either way, which is what the hooks actually need.
+  if (process.platform === "win32") return;
   for (const name of readdirSync(path.join(repoRoot, ".githooks"))) {
     chmodSync(path.join(repoRoot, ".githooks", name), 0o755);
   }

--- a/frontend/desktop/automation/validate.mjs
+++ b/frontend/desktop/automation/validate.mjs
@@ -584,16 +584,26 @@ export function controllerStandards() {
 }
 
 /**
- * The automation layout gate: exactly two shell scripts plus the project.mjs
- * symlink in scripts/, exactly three tracked executables, no per-package
- * scripts/ directories. The automation modules themselves live in
- * frontend/desktop/automation/ as ordinary non-executable source.
+ * The automation layout gate: exactly three files in scripts/, exactly seven tracked
+ * executables, no per-package scripts/ directories. The automation modules themselves
+ * live in frontend/desktop/automation/ as ordinary non-executable source.
+ *
+ * The hooks and scripts/project.mjs are executable shims rather than symlinks, because
+ * a Windows checkout materialises a symlink as a text file holding its target path.
+ * Both lists are therefore stated rather than derived from one another.
  */
 export function auditLayout() {
-  const expected = [
-    "frontend/desktop/project.mjs",
+  const expectedScripts = [
     "scripts/install-controller.sh",
     "scripts/install-desktop-app.sh",
+    "scripts/project.mjs",
+  ];
+  const expectedExecutable = [
+    ".githooks/commit-msg",
+    ".githooks/pre-commit",
+    ".githooks/pre-push",
+    "frontend/desktop/project.mjs",
+    ...expectedScripts,
   ];
   const actual = readdirSync(path.join(repoRoot, "scripts"), { withFileTypes: true })
     .filter((entry) => entry.isFile())
@@ -608,8 +618,8 @@ export function auditLayout() {
     (directory) => existsSync(path.join(repoRoot, directory)),
   );
   if (
-    JSON.stringify(actual) !== JSON.stringify(expected.slice(1)) ||
-    JSON.stringify(executable) !== JSON.stringify(expected) ||
+    JSON.stringify(actual) !== JSON.stringify(expectedScripts) ||
+    JSON.stringify(executable) !== JSON.stringify(expectedExecutable) ||
     stale.length > 0
   ) {
     throw Error(

--- a/frontend/desktop/project.mjs
+++ b/frontend/desktop/project.mjs
@@ -3,10 +3,11 @@
 // lives in ./automation/ as ordinary readable ESM — this file only dispatches.
 //
 // Four ways in:
-//   * `node scripts/project.mjs <command>` (scripts/project.mjs is a symlink
-//     here) — the subcommand registry below.
-//   * The .githooks/{commit-msg,pre-commit,pre-push} symlinks — dispatched on
-//     the invoked basename, with no logic in the hook files themselves.
+//   * `node scripts/project.mjs <command>` (scripts/project.mjs is a one-line
+//     shim that imports this file) — the subcommand registry below.
+//   * The .githooks/{commit-msg,pre-commit,pre-push} shims — dispatched on the
+//     invoked basename, with no logic in the hook files themselves. Shims, not
+//     symlinks: a Windows checkout writes a symlink out as its target path.
 //   * `setup-hooks`, special-cased so a fresh clone can register the hooks
 //     before anything else works.
 //   * As a module: electron-builder imports the default export as its

--- a/frontend/desktop/start-dev.mjs
+++ b/frontend/desktop/start-dev.mjs
@@ -1,0 +1,17 @@
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const electron = require("electron");
+const child = spawn(electron, ["desktop/dist/main.js"], {
+  stdio: "inherit",
+  env: {
+    ...process.env,
+    LOCAL_STUDIO_DESKTOP_DEV_SERVER_URL: "http://127.0.0.1:3000",
+  },
+});
+
+child.once("exit", (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  process.exit(code ?? 1);
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "check:cleanup": "knip && jscpd src && depcheck",
     "check:ui-structure": "node ../scripts/project.mjs validate-ui",
     "desktop:build:main": "tsc -p desktop/tsconfig.json --noEmit && bun build desktop/main.ts desktop/preload.ts --outdir desktop/dist --target=node --format=cjs --minify --external electron --external @lydell/node-pty",
-    "desktop:start:dev": "LOCAL_STUDIO_DESKTOP_DEV_SERVER_URL=http://127.0.0.1:3000 electron desktop/dist/main.js",
+    "desktop:start:dev": "node desktop/start-dev.mjs",
     "desktop:build": "npm run build && npm run desktop:build:main",
     "desktop:dev": "npm run desktop:build:main && concurrently -k -n NEXT,ELECTRON -c cyan,magenta \"npm run dev\" \"node -e \\\"setTimeout(() => process.exit(0), 3000)\\\" && npm run desktop:start:dev\"",
     "desktop:dist": "npm run desktop:build && electron-builder --config desktop/electron-builder.yml",

--- a/scripts/project.mjs
+++ b/scripts/project.mjs
@@ -1,1 +1,2 @@
-../frontend/desktop/project.mjs
+#!/usr/bin/env node
+await import("../frontend/desktop/project.mjs");


### PR DESCRIPTION
## The problem

Git on Windows defaults to `core.symlinks=false`, and under that setting a checkout writes
a symlink out as an ordinary text file whose contents are the target path. Every entry
point into this repository's automation is a symlink:

```
120000  .githooks/commit-msg  -> ../scripts/project.mjs
120000  .githooks/pre-commit  -> ../scripts/project.mjs
120000  .githooks/pre-push    -> ../scripts/project.mjs
120000  scripts/project.mjs   -> ../frontend/desktop/project.mjs
```

So on a Windows clone of `main`, `scripts/project.mjs` is a one-line text file and:

```
$ node scripts/project.mjs doctor
file:///C:/.../scripts/project.mjs:1
../frontend/desktop/project.mjs
^
SyntaxError
```

Nothing downstream of that works: the hooks never fire, `npm run setup`, `npm run check`,
`npm run build` and every `node scripts/project.mjs <command>` in package.json and in CI
fail the same way. Verified directly against `main`.

## The change

Each symlink becomes a five-line executable shim that imports the same target. The
dispatch design is untouched — `project.mjs` still routes on
`path.basename(process.argv[1])`, which is the hook's own name however it was invoked, so
the hook files still carry no logic. `auditLayout` and the two comments that described the
old symlinks are updated to match.

Three further things break once the entry point runs at all, and each is fixed only on
`win32`:

- **`npm`, `npx` and `bun` are not executables on Windows.** npm and npx are `.cmd` batch
  files, which Node has refused to spawn without `shell: true` since the fix for
  CVE-2024-27980; a Node-managed bun install puts `bun.exe` outside PATH and leaves a bare
  `bun` shim `spawnSync` cannot run. `lib.mjs` gains `platformInvocation`, which resolves
  npm and npx to the JavaScript CLI the running Node already ships and bun to the
  executable the local install actually placed, then invokes those directly rather than
  handing an argv to `cmd.exe` to re-parse. It returns POSIX invocations unchanged.
  `run()`, the toolchain probes and the agent-runtime bundle go through it — that last one
  is what `npm run build` currently dies on, with `Agent runtime bundle failed with status
  unknown`. The status is `null` because the spawn never happened.
- **`python3` on Windows is usually the Microsoft Store stub**, which exits non-zero
  without printing a version, while the real interpreter is `python` or the `py` launcher.
  `doctor()` tries the three spellings on `win32` only; the POSIX branch still calls
  `requireTool` with `python3` exactly as before.
- **`setupHooks` chmods `.githooks/*`**, which NTFS has no bit for. Skipped on `win32`;
  the committed `100755` mode is what the hooks need and git records it either way.

`desktop:start:dev` set an environment variable with a `VAR=value command` prefix, which
is shell syntax `cmd.exe` does not have, so the script ran electron with no dev-server
URL. It now calls `desktop/start-dev.mjs`, which spawns the same electron with the same
variable through the environment it inherits.

## CI

A `windows-latest` job runs `doctor`, `setup-hooks` and `audit-layout` — exactly the
surface this repairs, and exactly what would fail again if the shims were reverted to
symlinks. It deliberately does not install dependencies or build anything: packaging and
tests on Windows are a separate concern and do not belong in a change about whether the
automation runs at all.

## Verification

Windows 11, Node 22.22.2, npm 10.9.7, Bun 1.3.14, Git 2.54.0, against this branch:

- `doctor`, `setup-hooks`, `audit-layout`, `validate-contracts`, `validate-structure` pass
  through the shims
- `npm ci`, the three `bun install`s and `link-services` complete
- `npm run build` produces the standalone server
- the pre-push gate's own checks pass: conventional commits, `check:static`,
  `check:cleanup` (0 jscpd clones, no depcheck findings), `assert-standalone`
- the pre-commit hook's lint-staged and typecheck pass

macOS and Linux are untouched: every branch added is guarded on `process.platform ===
"win32"`, and no file outside the automation surface is modified.

## Relationship to #395

This is the first of two small, `main`-based replacements for #395, which targets the
abandoned `dev` branch, carries 38 commits across 110 files, and is unmergeable. Nothing
here depends on the native-process, WSL2 or llama.cpp work in that PR — those have no home
in the repository after #443 and stay out. #395 will be closed once the second replacement
is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
