### PR TITLE
fix(agent-runtime): make the suite pass on Windows

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,1 +1,5 @@
-../scripts/project.mjs
+#!/usr/bin/env node
+import("../scripts/project.mjs").catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,1 +1,5 @@
-../scripts/project.mjs
+#!/usr/bin/env node
+import("../scripts/project.mjs").catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,1 +1,5 @@
-../scripts/project.mjs
+#!/usr/bin/env node
+import("../scripts/project.mjs").catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,26 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+
+  windows-automation:
+    name: Repository automation (Windows)
+    if: github.event_name != 'schedule'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.19.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+      - name: Toolchain check
+        run: npm run doctor
+      - name: Git hook registration
+        run: node scripts/project.mjs setup-hooks
+      - name: Automation layout gate
+        run: node scripts/project.mjs audit-layout
+
   trufflehog:
     name: Secret Scanning (TruffleHog)
     runs-on: ubuntu-latest

--- a/frontend/desktop/automation/agent-runtime.mjs
+++ b/frontend/desktop/automation/agent-runtime.mjs
@@ -14,7 +14,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
-import { repoRoot } from "./lib.mjs";
+import { platformInvocation, repoRoot } from "./lib.mjs";
 
 const packageDir = path.join(repoRoot, "services", "agent-runtime");
 const distDir = path.join(packageDir, "dist");
@@ -52,25 +52,22 @@ export function bundleAgentRuntime() {
   rmSync(distDir, { recursive: true, force: true });
   mkdirSync(distDir, { recursive: true });
 
-  const build = spawnSync(
-    "bun",
-    [
-      "build",
-      "src/server.ts",
-      "--target=node",
-      "--external",
-      "fsevents",
-      "--external",
-      "playwright-core",
-      "--external",
-      "@silvia-odwyer/photon-node",
-      "--external",
-      "undici",
-      "--minify",
-      "--outfile=dist/standalone.mjs",
-    ],
-    { cwd: packageDir, stdio: "inherit" },
-  );
+  const [bun, bunArgs] = platformInvocation("bun", [
+    "build",
+    "src/server.ts",
+    "--target=node",
+    "--external",
+    "fsevents",
+    "--external",
+    "playwright-core",
+    "--external",
+    "@silvia-odwyer/photon-node",
+    "--external",
+    "undici",
+    "--minify",
+    "--outfile=dist/standalone.mjs",
+  ]);
+  const build = spawnSync(bun, bunArgs, { cwd: packageDir, stdio: "inherit" });
   if (build.status !== 0) {
     throw Error(`Agent runtime bundle failed with status ${build.status ?? "unknown"}`);
   }

--- a/frontend/desktop/automation/lib.mjs
+++ b/frontend/desktop/automation/lib.mjs
@@ -4,6 +4,7 @@
 // side effects — each exports functions the project.mjs entry dispatches to.
 
 import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import path from "node:path";
 
 /** Repo root: this file lives at frontend/desktop/automation/lib.mjs. */
@@ -16,9 +17,42 @@ export function valueAfter(args, name) {
   return index === -1 ? undefined : args[index + 1];
 }
 
+/**
+ * Windows has no `npm`, `npx`, or `bun` on PATH — it has `npm.cmd`, `npx.cmd`, and a
+ * `bun.exe` that a Node-managed install leaves outside PATH entirely. spawnSync does
+ * not consult PATHEXT, so the bare name fails with ENOENT. Resolve npm and npx to the
+ * JavaScript CLI the running Node already ships and invoke it directly, which also
+ * avoids handing an argv to cmd.exe for re-parsing. POSIX is returned untouched.
+ */
+export function platformInvocation(command, args) {
+  if (process.platform !== "win32") return [command, args];
+  if (command === "bun") {
+    const candidates = [
+      path.join(path.dirname(process.execPath), "node_modules", "bun", "bin", "bun.exe"),
+      process.env["BUN_INSTALL"] ? path.join(process.env["BUN_INSTALL"], "bin", "bun.exe") : null,
+    ];
+    const executable = candidates.find((candidate) => candidate && existsSync(candidate));
+    return executable ? [executable, args] : [command, args];
+  }
+  if (command !== "npm" && command !== "npx") return [command, args];
+  const npmCli = process.env["npm_execpath"]?.trim();
+  const cli =
+    command === "npm" ? npmCli : npmCli ? path.join(path.dirname(npmCli), "npx-cli.js") : null;
+  const fallback = path.join(
+    path.dirname(process.execPath),
+    "node_modules",
+    "npm",
+    "bin",
+    `${command}-cli.js`,
+  );
+  const script = cli && existsSync(cli) ? cli : fallback;
+  return [process.execPath, [script, ...args]];
+}
+
 /** Run a command inheriting stdio; exit the process with its status on failure. */
 export function run(command, args, cwd = repoRoot) {
-  const result = spawnSync(command, args, { cwd, stdio: "inherit" });
+  const [resolvedCommand, resolvedArgs] = platformInvocation(command, args);
+  const result = spawnSync(resolvedCommand, resolvedArgs, { cwd, stdio: "inherit" });
   if (result.error) throw result.error;
   if (result.status !== 0) process.exit(result.status ?? 1);
 }

--- a/frontend/desktop/automation/toolchain.mjs
+++ b/frontend/desktop/automation/toolchain.mjs
@@ -4,7 +4,7 @@
 import { spawnSync } from "node:child_process";
 import { chmodSync, lstatSync, mkdirSync, readdirSync, rmSync, symlinkSync } from "node:fs";
 import path from "node:path";
-import { frontendDir, git, repoRoot, run } from "./lib.mjs";
+import { frontendDir, git, platformInvocation, repoRoot, run } from "./lib.mjs";
 
 function parsedVersion(value) {
   const match = value.match(/(\d+)\.(\d+)(?:\.(\d+))?/);
@@ -19,10 +19,16 @@ function versionMeetsMinimum(actual, minimum) {
   return true;
 }
 
+function probeTool(command, args) {
+  const [resolvedCommand, resolvedArgs] = platformInvocation(command, args);
+  const result = spawnSync(resolvedCommand, resolvedArgs, { cwd: repoRoot, encoding: "utf8" });
+  if (result.error || result.status !== 0) return null;
+  return `${result.stdout ?? ""}${result.stderr ?? ""}`.trim();
+}
+
 function requireTool(label, command, args, minimum) {
-  const result = spawnSync(command, args, { cwd: repoRoot, encoding: "utf8" });
-  if (result.error || result.status !== 0) throw Error(`${label} is required but unavailable`);
-  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`.trim();
+  const output = probeTool(command, args);
+  if (output === null) throw Error(`${label} is required but unavailable`);
   const actual = parsedVersion(output);
   if (!actual || !versionMeetsMinimum(actual, minimum)) {
     throw Error(`${label} ${minimum.join(".")} or newer is required; found ${output || "unknown"}`);
@@ -30,11 +36,47 @@ function requireTool(label, command, args, minimum) {
   console.log(`${label}: ${actual.join(".")}`);
 }
 
+/**
+ * Python is the one tool whose name is not settled on Windows: the python.org installer
+ * ships `python` and the `py` launcher, and the `python3` that is on PATH is usually the
+ * Microsoft Store stub, which exits non-zero without a version. Try the spellings in
+ * turn and require one of them to satisfy the minimum, reporting what was actually
+ * found when none does. Only Windows takes this path.
+ */
+function requireToolCandidate(label, candidates, minimum) {
+  const found = [];
+  for (const [command, args] of candidates) {
+    const output = probeTool(command, args);
+    if (output === null) continue;
+    const actual = parsedVersion(output);
+    if (actual && versionMeetsMinimum(actual, minimum)) {
+      console.log(`${label}: ${actual.join(".")}`);
+      return;
+    }
+    if (output) found.push(output);
+  }
+  throw Error(
+    `${label} ${minimum.join(".")} or newer is required${found.length > 0 ? `; found ${found.join(", ")}` : " but unavailable"}`,
+  );
+}
+
 export function doctor() {
   requireTool("Node.js", process.execPath, ["--version"], [22, 19, 0]);
   requireTool("npm", "npm", ["--version"], [10, 0, 0]);
   requireTool("Bun", "bun", ["--version"], [1, 3, 14]);
-  requireTool("Python", "python3", ["--version"], [3, 10, 0]);
+  if (process.platform === "win32") {
+    requireToolCandidate(
+      "Python",
+      [
+        ["python", ["--version"]],
+        ["py", ["-3", "--version"]],
+        ["python3", ["--version"]],
+      ],
+      [3, 10, 0],
+    );
+  } else {
+    requireTool("Python", "python3", ["--version"], [3, 10, 0]);
+  }
   requireTool("Git", "git", ["--version"], [2, 0, 0]);
   console.log("Toolchain check passed");
 }
@@ -89,6 +131,9 @@ export function setupHooks() {
   }
   git(["rev-parse", "--git-dir"]);
   git(["config", "core.hooksPath", ".githooks"]);
+  // NTFS has no executable bit and chmod is a no-op there at best; git records the
+  // committed 100755 mode either way, which is what the hooks actually need.
+  if (process.platform === "win32") return;
   for (const name of readdirSync(path.join(repoRoot, ".githooks"))) {
     chmodSync(path.join(repoRoot, ".githooks", name), 0o755);
   }

--- a/frontend/desktop/automation/validate.mjs
+++ b/frontend/desktop/automation/validate.mjs
@@ -584,16 +584,26 @@ export function controllerStandards() {
 }
 
 /**
- * The automation layout gate: exactly two shell scripts plus the project.mjs
- * symlink in scripts/, exactly three tracked executables, no per-package
- * scripts/ directories. The automation modules themselves live in
- * frontend/desktop/automation/ as ordinary non-executable source.
+ * The automation layout gate: exactly three files in scripts/, exactly seven tracked
+ * executables, no per-package scripts/ directories. The automation modules themselves
+ * live in frontend/desktop/automation/ as ordinary non-executable source.
+ *
+ * The hooks and scripts/project.mjs are executable shims rather than symlinks, because
+ * a Windows checkout materialises a symlink as a text file holding its target path.
+ * Both lists are therefore stated rather than derived from one another.
  */
 export function auditLayout() {
-  const expected = [
-    "frontend/desktop/project.mjs",
+  const expectedScripts = [
     "scripts/install-controller.sh",
     "scripts/install-desktop-app.sh",
+    "scripts/project.mjs",
+  ];
+  const expectedExecutable = [
+    ".githooks/commit-msg",
+    ".githooks/pre-commit",
+    ".githooks/pre-push",
+    "frontend/desktop/project.mjs",
+    ...expectedScripts,
   ];
   const actual = readdirSync(path.join(repoRoot, "scripts"), { withFileTypes: true })
     .filter((entry) => entry.isFile())
@@ -608,8 +618,8 @@ export function auditLayout() {
     (directory) => existsSync(path.join(repoRoot, directory)),
   );
   if (
-    JSON.stringify(actual) !== JSON.stringify(expected.slice(1)) ||
-    JSON.stringify(executable) !== JSON.stringify(expected) ||
+    JSON.stringify(actual) !== JSON.stringify(expectedScripts) ||
+    JSON.stringify(executable) !== JSON.stringify(expectedExecutable) ||
     stale.length > 0
   ) {
     throw Error(

--- a/frontend/desktop/project.mjs
+++ b/frontend/desktop/project.mjs
@@ -3,10 +3,11 @@
 // lives in ./automation/ as ordinary readable ESM — this file only dispatches.
 //
 // Four ways in:
-//   * `node scripts/project.mjs <command>` (scripts/project.mjs is a symlink
-//     here) — the subcommand registry below.
-//   * The .githooks/{commit-msg,pre-commit,pre-push} symlinks — dispatched on
-//     the invoked basename, with no logic in the hook files themselves.
+//   * `node scripts/project.mjs <command>` (scripts/project.mjs is a one-line
+//     shim that imports this file) — the subcommand registry below.
+//   * The .githooks/{commit-msg,pre-commit,pre-push} shims — dispatched on the
+//     invoked basename, with no logic in the hook files themselves. Shims, not
+//     symlinks: a Windows checkout writes a symlink out as its target path.
 //   * `setup-hooks`, special-cased so a fresh clone can register the hooks
 //     before anything else works.
 //   * As a module: electron-builder imports the default export as its

--- a/frontend/desktop/start-dev.mjs
+++ b/frontend/desktop/start-dev.mjs
@@ -1,0 +1,17 @@
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const electron = require("electron");
+const child = spawn(electron, ["desktop/dist/main.js"], {
+  stdio: "inherit",
+  env: {
+    ...process.env,
+    LOCAL_STUDIO_DESKTOP_DEV_SERVER_URL: "http://127.0.0.1:3000",
+  },
+});
+
+child.once("exit", (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  process.exit(code ?? 1);
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "check:cleanup": "knip && jscpd src && depcheck",
     "check:ui-structure": "node ../scripts/project.mjs validate-ui",
     "desktop:build:main": "tsc -p desktop/tsconfig.json --noEmit && bun build desktop/main.ts desktop/preload.ts --outdir desktop/dist --target=node --format=cjs --minify --external electron --external @lydell/node-pty",
-    "desktop:start:dev": "LOCAL_STUDIO_DESKTOP_DEV_SERVER_URL=http://127.0.0.1:3000 electron desktop/dist/main.js",
+    "desktop:start:dev": "node desktop/start-dev.mjs",
     "desktop:build": "npm run build && npm run desktop:build:main",
     "desktop:dev": "npm run desktop:build:main && concurrently -k -n NEXT,ELECTRON -c cyan,magenta \"npm run dev\" \"node -e \\\"setTimeout(() => process.exit(0), 3000)\\\" && npm run desktop:start:dev\"",
     "desktop:dist": "npm run desktop:build && electron-builder --config desktop/electron-builder.yml",

--- a/frontend/src/app/api/_lib/home-root.ts
+++ b/frontend/src/app/api/_lib/home-root.ts
@@ -1,0 +1,12 @@
+import os from "node:os";
+
+// Next traces these routes with @vercel/nft, which constant-folds os.homedir() and
+// then, unable to resolve what readdir or statSync is finally given, widens the call
+// to "<home>/**/*". Globbing a Windows user profile walks the pre-Vista junctions
+// (Application Data, Cookies) that the OS denies, and the build dies on EPERM.
+// Reading the same variable Node itself reads leaves the value opaque to the tracer
+// while the runtime result is unchanged.
+export function homeRoot(): string {
+  const fromEnv = process.platform === "win32" ? process.env["USERPROFILE"] : process.env["HOME"];
+  return fromEnv && fromEnv.trim() ? fromEnv : os.homedir();
+}

--- a/frontend/src/app/api/agent/directories/route.ts
+++ b/frontend/src/app/api/agent/directories/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
-import os from "node:os";
 import path from "node:path";
 import { readdir, stat } from "node:fs/promises";
+import { homeRoot } from "@/app/api/_lib/home-root";
 import { errorMessage, jsonError } from "@/app/api/_lib/route-helpers";
 
 export const runtime = "nodejs";
@@ -30,7 +30,7 @@ function isLoopbackHost(host: string | null): boolean {
 
 function configuredRoots(): string[] {
   const raw = process.env.LOCAL_STUDIO_DIRECTORY_BROWSER_ROOTS;
-  if (!raw) return [path.resolve(os.homedir())];
+  if (!raw) return [path.resolve(homeRoot())];
   return raw
     .split(path.delimiter)
     .map((entry) => entry.trim())
@@ -46,7 +46,7 @@ function isWithinRoot(candidate: string, root: string): boolean {
 }
 
 function resolveAllowedPath(input: string | null, roots: string[]): string | null {
-  const fallbackRoot = roots[0] ?? path.resolve(os.homedir());
+  const fallbackRoot = roots[0] ?? path.resolve(homeRoot());
   const candidate = path.resolve(input?.trim() || fallbackRoot);
   return roots.some((root) => isWithinRoot(candidate, root)) ? candidate : null;
 }
@@ -88,7 +88,7 @@ export async function GET(request: NextRequest) {
     return Response.json({
       path: directoryPath,
       parent: parent === directoryPath ? null : parent,
-      home: os.homedir(),
+      home: homeRoot(),
       entries,
     });
   } catch (error) {

--- a/frontend/src/app/api/agent/terminal/resolve-cwd/route.ts
+++ b/frontend/src/app/api/agent/terminal/resolve-cwd/route.ts
@@ -1,15 +1,15 @@
 import { statSync } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { NextRequest } from "next/server";
+import { homeRoot } from "@/app/api/_lib/home-root";
 import { requireApiAccess } from "@/lib/auth/guard";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 function expandTilde(target: string): string {
-  if (target === "~") return os.homedir();
-  if (target.startsWith("~/")) return path.join(os.homedir(), target.slice(2));
+  if (target === "~") return homeRoot();
+  if (target.startsWith("~/")) return path.join(homeRoot(), target.slice(2));
   return target;
 }
 
@@ -29,7 +29,7 @@ export async function POST(request: NextRequest) {
 
   let next: string;
   if (!target || target === "~") {
-    next = os.homedir();
+    next = homeRoot();
   } else if (target === "-") {
     if (!previous) return Response.json({ ok: false, error: "OLDPWD not set" }, { status: 400 });
     next = previous;

--- a/scripts/project.mjs
+++ b/scripts/project.mjs
@@ -1,1 +1,2 @@
-../frontend/desktop/project.mjs
+#!/usr/bin/env node
+await import("../frontend/desktop/project.mjs");

--- a/services/agent-runtime/src/sessions-store.ts
+++ b/services/agent-runtime/src/sessions-store.ts
@@ -66,7 +66,12 @@ function summaryStartTime(session: Pick<SessionSummary, "startedAt" | "updatedAt
 export function encodeCwdForPi(cwd: string): string {
   const normalized = path.resolve(cwd).replace(/\\+/g, "/");
   const collapsed = normalized.replace(/^\//, "").replace(/\/+/g, "-");
-  return `--${collapsed}--`;
+  // A drive letter keeps its colon through the collapse, and on Windows a colon
+  // inside a path component names an alternate data stream rather than a directory:
+  // creating or reading one fails with ENOTDIR. POSIX keeps the historic spelling so
+  // session directories written before this still match.
+  const legal = process.platform === "win32" ? collapsed.replace(/:/g, "-") : collapsed;
+  return `--${legal}--`;
 }
 
 export function configuredPiSessionDir(cwd: string): string | undefined {

--- a/services/agent-runtime/test/oauth-connectors.test.ts
+++ b/services/agent-runtime/test/oauth-connectors.test.ts
@@ -182,7 +182,10 @@ describe("oauth connector engine", () => {
   test("token store is 0600 and holds the refresh token, which status never returns", async () => {
     const file = resolveOAuthTokensFilePath();
     expect(existsSync(file)).toBe(true);
-    expect(statSync(file).mode & 0o777).toBe(0o600);
+    // Windows carries no POSIX mode bits: node reports a fixed mode there whatever
+    // chmod was asked for, so the check would assert nothing. The secret the file
+    // holds is guarded by the assertions below on every platform.
+    if (process.platform !== "win32") expect(statSync(file).mode & 0o777).toBe(0o600);
     const raw = readFileSync(file, "utf8");
     expect(raw).toContain("gho_device_access_1");
     expect(raw).toContain("ghr_refresh_1");

--- a/services/agent-runtime/test/session-usage.test.ts
+++ b/services/agent-runtime/test/session-usage.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { appendFileSync, mkdtempSync, rmSync, writeFileSync, truncateSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { readSessionUsageTotals, type SessionUsageTotals } from "../src/session-usage";
@@ -147,19 +148,26 @@ describe("incremental usage scan", () => {
 async function scanInFreshProcess(file: string, dataDir: string): Promise<SessionUsageTotals> {
   const script = `
     const { readSessionUsageTotals } = await import(${JSON.stringify(
-      path.resolve(import.meta.dir, "../src/session-usage.ts"),
+      pathToFileURL(path.resolve(import.meta.dir, "../src/session-usage.ts")).href,
     )});
     const started = performance.now();
     const totals = await readSessionUsageTotals(${JSON.stringify(file)});
     console.log(JSON.stringify({ ...totals, ms: performance.now() - started }));
   `;
-  const proc = Bun.spawn(["bun", "-e", script], {
+  // Windows drops a multi-line argument on its way to "bun -e": the runtime
+  // prints its help and exits, and the last line of that help is what the parse
+  // below would then choke on. A file carries the same script to every platform.
+  const scriptDir = mkdtempSync(path.join(tmpdir(), "session-usage-spawn-"));
+  const scriptFile = path.join(scriptDir, "scan.ts");
+  writeFileSync(scriptFile, script);
+  const proc = Bun.spawn(["bun", scriptFile], {
     env: { ...process.env, LOCAL_STUDIO_DATA_DIR: dataDir },
     stdout: "pipe",
     stderr: "pipe",
   });
   const out = await new Response(proc.stdout).text();
   const code = await proc.exited;
+  rmSync(scriptDir, { recursive: true, force: true });
   if (code !== 0) throw new Error(await new Response(proc.stderr).text());
   // The runtime may print its own notices before ours; the result is the last
   // line we wrote.


### PR DESCRIPTION
Fifteen of the agent-runtime tests fail on Windows on `main` today. CI only runs this job on ubuntu, so nothing catches them. Three distinct causes, one of them in shipped code.

Stacks on #450 and #453: a Windows build needs #450 (the `scripts/project.mjs` symlink checks out as text, its relative imports then resolve from the wrong directory, and the agent-runtime bundle dies on `spawnSync("bun", …)`) and #453 (`next build` dies globbing the user profile). The three commits here are the only ones of mine.

## 1. `encodeCwdForPi` produces a name Windows cannot hold — shipped code

The encoder collapses a path into one directory name, and a drive letter carries its colon through:

```
--C:-Users-<user>-...-project--
```

A colon inside a Windows path component names an alternate data stream, not a directory, so creating or reading one fails with `ENOTDIR`. The legacy session lookup in `sessionsDirsForCwd` can therefore never resolve on Windows — it degrades quietly in production and fails loudly in the tests, which create the directory. POSIX keeps the historic spelling, because directories written before this still have to match.

## 2. `bun -e` drops a multi-line script on Windows

`session-usage.test.ts` spawns a fresh process to prove the on-disk memo survives one. On Windows the runtime prints its help and exits, and `JSON.parse` chokes on the last line of that help. Measured directly:

| script | exit | stdout |
| --- | --- | --- |
| one line | 0 | the JSON |
| leading newline | 1 | help |
| multi-line | 0 | empty |
| multi-line, indented | 0 | help |

The script goes to a file instead. The dynamic import also takes a file URL, since a bare Windows path reaches the ESM resolver as a package specifier.

## 3. A POSIX mode assertion on a platform with no modes

`statSync(file).mode & 0o777` can never be `0o600` on Windows: node reports a fixed mode whatever `chmod` was asked for, so the comparison asserts nothing there. POSIX still requires `0600`, and the assertions that the file holds the refresh token and that `status` never returns it still run everywhere.

## Verified

Windows 11: `bun test` in `services/agent-runtime` goes from 62 pass / 15 fail to **77 pass / 0 fail**.

Not run on macOS — that machine currently has no node or bun installed. Every change is either inside a `process.platform === "win32"` branch or portable by construction (a file-backed spawn, `pathToFileURL`), so the POSIX path is unchanged; the ubuntu job here is the check that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
