### PR TITLE
feat(studio): add OrcaRouter as a first-run remote provider preset

### DIFF
--- a/controller/src/modules/studio/configs.ts
+++ b/controller/src/modules/studio/configs.ts
@@ -58,4 +58,18 @@ export const STUDIO_STARTER_PRESETS: StudioStarterPreset[] = [
       model: "deepseek-v4-flash",
     },
   },
+  {
+    id: "orcarouter",
+    name: "OrcaRouter",
+    description:
+      "Connect a hosted OpenAI-compatible gateway with one API key — one endpoint routes across many frontier models, with nothing to download.",
+    kind: "remote",
+    tags: ["remote", "instant"],
+    size_gb: null,
+    min_vram_gb: null,
+    remote: {
+      base_url: "https://api.orcarouter.ai/v1",
+      model: "orcarouter/auto",
+    },
+  },
 ];

--- a/frontend/src/ui/resource-logo.tsx
+++ b/frontend/src/ui/resource-logo.tsx
@@ -26,6 +26,7 @@ const PROVIDER_COLORS: Record<string, string> = {
   nvidia: "#76B900",
   openai: "#10A37F",
   openrouter: "#8B5CF6",
+  orcarouter: "#0160E6",
   xai: "#E5E7EB",
   zai: "#111827",
 };
@@ -49,6 +50,7 @@ const LOGO_OWNERS: ReadonlyArray<readonly [RegExp, string]> = [
   [/mistral/i, "mistralai"],
   [/nvidia/i, "nvidia"],
   [/openrouter/i, "OpenRouter"],
+  [/orcarouter/i, "OrcaRouter"],
   [/together/i, "togethercomputer"],
   [/xai/i, "xai-org"],
   [/xiaomi|mimo/i, "XiaomiMiMo"],


### PR DESCRIPTION
## Summary

Add [OrcaRouter](https://www.orcarouter.ai) as a first-run remote provider preset in Local Studio, alongside the existing DeepSeek hosted-endpoint preset. With one API key, a new user can route chat through OrcaRouter's OpenAI-compatible gateway without downloading any weights.

## Changes

- `controller/src/modules/studio/configs.ts`: register an `orcarouter` preset in `STUDIO_STARTER_PRESETS`, mirroring the existing `deepseek-v4-flash` remote preset. It points at `https://api.orcarouter.ai/v1` and defaults to the `orcarouter/auto` router, so the setup wizard's "remote" lane surfaces it as a named provider rather than an anonymous custom base URL.
- `frontend/src/ui/resource-logo.tsx`: add the `orcarouter` brand color and logo-owner mapping, matching the existing `openrouter` entry, so provider resources render with OrcaRouter branding in the UI.

Because this is the same generic OpenAI-compatible passthrough the controller already uses for configured remote providers, the proxy (`/v1/chat/completions`, `/v1/responses`, `/v1/messages`) handles OrcaRouter requests with no additional wiring; the preset just makes it discoverable in the first-run flow.

## Validation

- `tsc --noEmit` in `controller/`: passes
- `tsc --noEmit` in `frontend/`: passes
- `eslint` on both changed files: passes
- `knip` (controller), `validate-structure`, `validate-contracts`, `validate-ui`, `check:static`, `check:cleanup` (frontend): all pass
- Live test against OrcaRouter: `POST https://api.orcarouter.ai/v1/chat/completions` with `orcarouter/auto` returns `200` with a completion; `GET /v1/models` returns `200` and includes `orcarouter/auto`.

## Why OrcaRouter

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models, while also combining adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding it as a first-class provider means Local Studio users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint, screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Risks / rollout notes

None. This only adds a curated first-run preset and a logo mapping; existing providers, recipes, and the proxy are untouched. Users who already have a controller can still add `https://api.orcarouter.ai/v1` manually under any provider id.

I'm an engineer on the OrcaRouter team. Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
